### PR TITLE
[WIP] RHS GREF compatibility

### DIFF
--- a/addons/main/static/include/rhs_gref_compat.hpp
+++ b/addons/main/static/include/rhs_gref_compat.hpp
@@ -1,4 +1,6 @@
-// rhsgref_faction_cdf_b_ground
+//==========================================//
+// rhsgref_faction_cdf_b_ground             //
+//==========================================//
 
 rhsgref_faction_cdf_b_ground_mappings = [] call ALIVE_fnc_hashCreate;
 
@@ -13,11 +15,13 @@ rhsgref_faction_cdf_b_ground_typeMappings = [] call ALIVE_fnc_hashCreate;
 
 [rhsgref_faction_cdf_b_ground_mappings, "GroupFactionTypes", rhsgref_faction_cdf_b_ground_typeMappings] call ALIVE_fnc_hashSet;
 
-[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+// Remark: as for now, CfgGroups entries for: rhs_group_cdf_b_gaz66, rhs_group_cdf_b_gaz66_para and rhs_group_cdf_b_ural share the same group names.
+// Is there a way to distinguish them?
+[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Infantry", ["rhsgref_group_cdf_b_reg_infantry_squad", "rhsgref_group_cdf_b_reg_infantry_squad_weap","rhsgref_group_cdf_b_para_infantry_squad", "rhsgref_group_cdf_b_para_infantry_squad_weap"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Motorized", ["rhs_group_cdf_b_btr60_chq", "rhs_group_cdf_b_btr60_squad", "rhs_group_cdf_b_btr60_squad_2mg", "rhs_group_cdf_b_btr60_squad_aa", "rhs_group_cdf_b_btr60_squad_mg_sniper", "rhs_group_cdf_b_btr60_squad_sniper", "rhs_group_cdf_b_btr70_chq", "rhs_group_cdf_b_btr70_squad", "rhs_group_cdf_b_btr70_squad_2mg", "rhs_group_cdf_b_btr70_squad_aa", "rhs_group_cdf_b_btr70_squad_mg_sniper", "rhs_group_cdf_b_btr70_squad_sniper", "rhs_group_cdf_b_ural_chq", "rhs_group_cdf_b_ural_squad", "rhs_group_cdf_b_ural_squad_2mg", "rhs_group_cdf_b_ural_squad_aa", "rhs_group_cdf_b_ural_squad_mg_sniper", "rhs_group_cdf_b_ural_squad_sniper", "BUS_MotInf_AA", "BUS_MotInf_AT", "BUS_MotInf_Team_GMG", "BUS_MotInf_Team_HMG"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Mechanized", ["rhs_group_cdf_b_bmd1_chq", "rhs_group_cdf_b_bmd1_squad", "rhs_group_cdf_b_bmd1_squad_2mg", "rhs_group_cdf_b_bmd1_squad_aa", "rhs_group_cdf_b_bmd1_squad_mg_sniper", "rhs_group_cdf_b_bmd1_squad_sniper", "rhs_group_cdf_b_bmd2_chq", "rhs_group_cdf_b_bmd2_squad", "rhs_group_cdf_b_bmd2_squad_2mg", "rhs_group_cdf_b_bmd2_squad_aa", "rhs_group_cdf_b_bmd2_squad_mg_sniper", "rhs_group_cdf_b_bmd2_squad_sniper", "rhs_group_cdf_b_bmp1_chq", "rhs_group_cdf_b_bmp1_squad", "rhs_group_cdf_b_bmp1_squad_2mg", "rhs_group_cdf_b_bmp1_squad_aa", "rhs_group_cdf_b_bmp1_squad_mg_sniper", "rhs_group_cdf_b_bmp1_squad_sniper", "rhs_group_cdf_b_bmp2_chq", "rhs_group_cdf_b_bmp2_squad", "rhs_group_cdf_b_bmp2_squad_2mg", "rhs_group_cdf_b_bmp2_squad_aa", "rhs_group_cdf_b_bmp2_squad_mg_sniper", "rhs_group_cdf_b_bmp2_squad_sniper"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Armored", ["RHS_T72baPlatoon", "RHS_T72baPlatoon_AA", "RHS_T72baSection"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Artillery", ["RHS_SPGPlatoon_ins_g_bm21", "RHS_SPGSection_ins_g_bm21"]] call ALIVE_fnc_hashSet;
 
 [rhsgref_faction_cdf_b_ground_mappings, "Groups", rhsgref_faction_cdf_b_ground_factionCustomGroups] call ALIVE_fnc_hashSet;
 
@@ -27,7 +31,9 @@ rhsgref_faction_cdf_b_ground_typeMappings = [] call ALIVE_fnc_hashCreate;
 [ALIVE_factionDefaultTransport, "rhsgref_faction_cdf_b_ground", []] call ALIVE_fnc_hashSet;
 [ALIVE_factionDefaultAirTransport, "rhsgref_faction_cdf_b_ground", []] call ALIVE_fnc_hashSet;
 
-// rhsgref_faction_chdkz
+//==========================================//
+// rhsgref_faction_chdkz                    //
+//==========================================//
 
 rhsgref_faction_chdkz_mappings = [] call ALIVE_fnc_hashCreate;
 
@@ -42,11 +48,13 @@ rhsgref_faction_chdkz_typeMappings = [] call ALIVE_fnc_hashCreate;
 
 [rhsgref_faction_chdkz_mappings, "GroupFactionTypes", rhsgref_faction_chdkz_typeMappings] call ALIVE_fnc_hashSet;
 
-[rhsgref_faction_chdkz_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_chdkz_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_chdkz_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_chdkz_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_chdkz_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+// Remark: as for now, CfgGroups entries for: rhs_group_indp_ins_gaz66 and rhs_group_indp_ins_ural share the same group names.
+// Is there a way to distinguish them?
+[rhsgref_faction_chdkz_factionCustomGroups, "Infantry", "rhsgref_group_chdkz_infantry_aa", "rhsgref_group_chdkz_infantry_at", "rhsgref_group_chdkz_infantry_mg", "rhsgref_group_chdkz_infantry_patrol", "rhsgref_group_chdkz_insurgents_squad"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_factionCustomGroups, "Motorized", ["rhs_group_chdkz_btr60_chq", "rhs_group_chdkz_btr60_squad", "rhs_group_chdkz_btr60_squad_2mg", "rhs_group_chdkz_btr60_squad_aa", "rhs_group_chdkz_btr60_squad_mg_sniper", "rhs_group_chdkz_btr60_squad_sniper", "rhs_group_chdkz_btr70_chq", "rhs_group_chdkz_btr70_squad", "rhs_group_chdkz_btr70_squad_2mg", "rhs_group_chdkz_btr70_squad_aa", "rhs_group_chdkz_btr70_squad_mg_sniper", "rhs_group_chdkz_btr70_squad_sniper", "rhs_group_chdkz_ural_chq", "rhs_group_chdkz_ural_squad", "rhs_group_chdkz_ural_squad_2mg", "rhs_group_chdkz_ural_squad_aa", "rhs_group_chdkz_ural_squad_mg_sniper", "rhs_group_chdkz_ural_squad_sniper", "BUS_MotInf_AA", "BUS_MotInf_AT", "BUS_MotInf_Team_GMG", "BUS_MotInf_Team_HMG"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_factionCustomGroups, "Mechanized", ["rhs_group_rus_ins_bmd1_chq", "rhs_group_rus_ins_bmd1_squad", "rhs_group_rus_ins_bmd1_squad_2mg", "rhs_group_rus_ins_bmd1_squad_aa", "rhs_group_rus_ins_bmd1_squad_mg_sniper", "rhs_group_rus_ins_bmd1_squad_sniper", "rhs_group_rus_ins_bmd2_chq", "rhs_group_rus_ins_bmd2_squad", "rhs_group_rus_ins_bmd2_squad_2mg", "rhs_group_rus_ins_bmd2_squad_aa", "rhs_group_rus_ins_bmd2_squad_mg_sniper", "rhs_group_rus_ins_bmd2_squad_sniper", "rhs_group_indp_ins_bmp1_chq", "rhs_group_indp_ins_bmp1_squad", "rhs_group_indp_ins_bmp1_squad_2mg", "rhs_group_indp_ins_bmp1_squad_aa", "rhs_group_indp_ins_bmp1_squad_mg_sniper", "rhs_group_indp_ins_bmp1_squad_sniper", "rhs_group_indp_ins_bmp2_chq", "rhs_group_indp_ins_bmp2_squad", "rhs_group_indp_ins_bmp2_squad_2mg", "rhs_group_indp_ins_bmp2_squad_aa", "rhs_group_indp_ins_bmp2_squad_mg_sniper", "rhs_group_indp_ins_bmp2_squad_sniper"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_factionCustomGroups, "Armored", ["RHS_T72baPlatoon", "RHS_T72baPlatoon_AA", "RHS_T72baSection", "RHS_T72BBPlatoon", "RHS_T72BBPlatoon_AA", "RHS_T72BBSection", "RHS_t72bcPlatoon", "RHS_t72bcPlatoon_AA", "RHS_t72bcSection"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_factionCustomGroups, "Artillery", ["RHS_SPGPlatoon_ins_bm21", "RHS_SPGSection_ins_bm21"]] call ALIVE_fnc_hashSet;
 
 [rhsgref_faction_chdkz_mappings, "Groups", rhsgref_faction_chdkz_factionCustomGroups] call ALIVE_fnc_hashSet;
 
@@ -56,7 +64,9 @@ rhsgref_faction_chdkz_typeMappings = [] call ALIVE_fnc_hashCreate;
 [ALIVE_factionDefaultTransport, "rhsgref_faction_chdkz", []] call ALIVE_fnc_hashSet;
 [ALIVE_factionDefaultAirTransport, "rhsgref_faction_chdkz", []] call ALIVE_fnc_hashSet;
 
-// rhsgref_faction_cdf_ground
+//==========================================//
+// rhsgref_faction_cdf_ground               //
+//==========================================//
 
 rhsgref_faction_cdf_ground_mappings = [] call ALIVE_fnc_hashCreate;
 
@@ -71,11 +81,13 @@ rhsgref_faction_cdf_ground_typeMappings = [] call ALIVE_fnc_hashCreate;
 
 [rhsgref_faction_cdf_ground_mappings, "GroupFactionTypes", rhsgref_faction_cdf_ground_typeMappings] call ALIVE_fnc_hashSet;
 
-[rhsgref_faction_cdf_ground_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_ground_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_ground_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_ground_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_ground_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+// Remark: as for now, CfgGroups entries for: rhs_group_cdf_gaz66, rhs_group_cdf_gaz66_para and rhs_group_cdf_ural share the same group names.
+// Is there a way to distinguish them?
+[rhsgref_faction_cdf_ground_factionCustomGroups, "Infantry", ["rhsgref_group_cdf_reg_infantry_squad", "rhsgref_group_cdf_reg_infantry_squad_weap", "rhsgref_group_cdf_para_infantry_squad", "rhsgref_group_cdf_para_infantry_squad_weap"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ground_factionCustomGroups, "Motorized", ["rhs_group_cdf_btr60_chq", "rhs_group_cdf_btr60_squad", "rhs_group_cdf_btr60_squad_2mg", "rhs_group_cdf_btr60_squad_aa", "rhs_group_cdf_btr60_squad_mg_sniper", "rhs_group_cdf_btr60_squad_sniper", "rhs_group_cdf_btr70_chq", "rhs_group_cdf_btr70_squad", "rhs_group_cdf_btr70_squad_2mg", "rhs_group_cdf_btr70_squad_aa", "rhs_group_cdf_btr70_squad_mg_sniper", "rhs_group_cdf_btr70_squad_sniper", "rhs_group_cdf_ural_chq", "rhs_group_cdf_ural_squad", "rhs_group_cdf_ural_squad_2mg", "rhs_group_cdf_ural_squad_aa", "rhs_group_cdf_ural_squad_mg_sniper", "rhs_group_cdf_ural_squad_sniper", "BUS_MotInf_AA", "BUS_MotInf_AT", "BUS_MotInf_Team_GMG", "BUS_MotInf_Team_HMG"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ground_factionCustomGroups, "Mechanized", ["rhs_group_cdf_bmd1_chq", "rhs_group_cdf_bmd1_squad", "rhs_group_cdf_bmd1_squad_2mg", "rhs_group_cdf_bmd1_squad_aa", "rhs_group_cdf_bmd1_squad_mg_sniper", "rhs_group_cdf_bmd1_squad_sniper", "rhs_group_cdf_bmd2_chq", "rhs_group_cdf_bmd2_squad", "rhs_group_cdf_bmd2_squad_2mg", "rhs_group_cdf_bmd2_squad_aa", "rhs_group_cdf_bmd2_squad_mg_sniper", "rhs_group_cdf_bmd2_squad_sniper", "rhs_group_cdf_bmp1_chq", "rhs_group_cdf_bmp1_squad", "rhs_group_cdf_bmp1_squad_2mg", "rhs_group_cdf_bmp1_squad_aa", "rhs_group_cdf_bmp1_squad_mg_sniper", "rhs_group_cdf_bmp1_squad_sniper", "rhs_group_cdf_bmp2_chq", "rhs_group_cdf_bmp2_squad", "rhs_group_cdf_bmp2_squad_2mg", "rhs_group_cdf_bmp2_squad_aa", "rhs_group_cdf_bmp2_squad_mg_sniper", "rhs_group_cdf_bmp2_squad_sniper"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ground_factionCustomGroups, "Armored", ["RHS_T72baPlatoon", "RHS_T72baPlatoon_AA", "RHS_T72baSection"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ground_factionCustomGroups, "Artillery", ["RHS_SPGPlatoon_ins_g_bm21", "RHS_SPGSection_ins_g_bm21"]] call ALIVE_fnc_hashSet;
 
 [rhsgref_faction_cdf_ground_mappings, "Groups", rhsgref_faction_cdf_ground_factionCustomGroups] call ALIVE_fnc_hashSet;
 
@@ -85,7 +97,9 @@ rhsgref_faction_cdf_ground_typeMappings = [] call ALIVE_fnc_hashCreate;
 [ALIVE_factionDefaultTransport, "rhsgref_faction_cdf_ground", []] call ALIVE_fnc_hashSet;
 [ALIVE_factionDefaultAirTransport, "rhsgref_faction_cdf_ground", []] call ALIVE_fnc_hashSet;
 
-// rhsgref_faction_cdf_ng
+//==========================================//
+// rhsgref_faction_cdf_ng                   //
+//==========================================//
 
 rhsgref_faction_cdf_ng_mappings = [] call ALIVE_fnc_hashCreate;
 
@@ -100,11 +114,11 @@ rhsgref_faction_cdf_ng_typeMappings = [] call ALIVE_fnc_hashCreate;
 
 [rhsgref_faction_cdf_ng_mappings, "GroupFactionTypes", rhsgref_faction_cdf_ng_typeMappings] call ALIVE_fnc_hashSet;
 
-[rhsgref_faction_cdf_ng_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_ng_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_ng_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_ng_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_cdf_ng_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ng_factionCustomGroups, "Infantry", ["rhsgref_group_cdf_ngd_infantry_squad"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ng_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;  // This faction has no motorized groups defined.
+[rhsgref_faction_cdf_ng_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet; // This faction has no mechanized groups defined.
+[rhsgref_faction_cdf_ng_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;    // This faction has no armored groups defined.
+[rhsgref_faction_cdf_ng_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;  // This faction has no artillery groups defined.
 
 [rhsgref_faction_cdf_ng_mappings, "Groups", rhsgref_faction_cdf_ng_factionCustomGroups] call ALIVE_fnc_hashSet;
 
@@ -114,7 +128,9 @@ rhsgref_faction_cdf_ng_typeMappings = [] call ALIVE_fnc_hashCreate;
 [ALIVE_factionDefaultTransport, "rhsgref_faction_cdf_ng", []] call ALIVE_fnc_hashSet;
 [ALIVE_factionDefaultAirTransport, "rhsgref_faction_cdf_ng", []] call ALIVE_fnc_hashSet;
 
-// rhsgref_faction_chdkz_g
+//==========================================//
+// rhsgref_faction_chdkz_g                  //
+//==========================================//
 
 rhsgref_faction_chdkz_g_mappings = [] call ALIVE_fnc_hashCreate;
 
@@ -129,11 +145,13 @@ rhsgref_faction_chdkz_g_typeMappings = [] call ALIVE_fnc_hashCreate;
 
 [rhsgref_faction_chdkz_g_mappings, "GroupFactionTypes", rhsgref_faction_chdkz_g_typeMappings] call ALIVE_fnc_hashSet;
 
-[rhsgref_faction_chdkz_g_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_chdkz_g_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_chdkz_g_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_chdkz_g_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_chdkz_g_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+// Remark: as for now, CfgGroups entries for: rhs_group_indp_ins_g_gaz66 and rhs_group_indp_ins_g_ural share the same group names.
+// Is there a way to distinguish them?
+[rhsgref_faction_chdkz_g_factionCustomGroups, "Infantry", ["rhsgref_group_chdkz_infantry_aa", "rhsgref_group_chdkz_infantry_at", "rhsgref_group_chdkz_infantry_mg", "rhsgref_group_chdkz_infantry_patrol", "rhsgref_group_chdkz_ins_gurgents_squad"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_g_factionCustomGroups, "Motorized", ["rhs_group_chdkz_btr60_chq", "rhs_group_chdkz_btr60_squad", "rhs_group_chdkz_btr60_squad_2mg", "rhs_group_chdkz_btr60_squad_aa", "rhs_group_chdkz_btr60_squad_mg_sniper", "rhs_group_chdkz_btr60_squad_sniper", "rhs_group_chdkz_btr70_chq", "rhs_group_chdkz_btr70_squad", "rhs_group_chdkz_btr70_squad_2mg", "rhs_group_chdkz_btr70_squad_aa", "rhs_group_chdkz_btr70_squad_mg_sniper", "rhs_group_chdkz_btr70_squad_sniper", "rhs_group_chdkz_ural_chq", "rhs_group_chdkz_ural_squad", "rhs_group_chdkz_ural_squad_2mg", "rhs_group_chdkz_ural_squad_aa", "rhs_group_chdkz_ural_squad_mg_sniper", "rhs_group_chdkz_ural_squad_sniper", "BUS_MotInf_AA", "BUS_MotInf_AT", "BUS_MotInf_Team_GMG", "BUS_MotInf_Team_HMG"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_g_factionCustomGroups, "Mechanized", ["rhs_group_rus_ins_g_bmd1_chq", "rhs_group_rus_ins_g_bmd1_squad", "rhs_group_rus_ins_g_bmd1_squad_2mg", "rhs_group_rus_ins_g_bmd1_squad_aa", "rhs_group_rus_ins_g_bmd1_squad_mg_sniper", "rhs_group_rus_ins_g_bmd1_squad_sniper", "rhs_group_rus_ins_g_bmd2_chq", "rhs_group_rus_ins_g_bmd2_squad", "rhs_group_rus_ins_g_bmd2_squad_2mg", "rhs_group_rus_ins_g_bmd2_squad_aa", "rhs_group_rus_ins_g_bmd2_squad_mg_sniper", "rhs_group_rus_ins_g_bmd2_squad_sniper", "rhs_group_indp_ins_g_bmp1_chq", "rhs_group_indp_ins_g_bmp1_squad", "rhs_group_indp_ins_g_bmp1_squad_2mg", "rhs_group_indp_ins_g_bmp1_squad_aa", "rhs_group_indp_ins_g_bmp1_squad_mg_sniper", "rhs_group_indp_ins_g_bmp1_squad_sniper", "rhs_group_indp_ins_g_bmp2_chq", "rhs_group_indp_ins_g_bmp2_squad", "rhs_group_indp_ins_g_bmp2_squad_2mg", "rhs_group_indp_ins_g_bmp2_squad_aa", "rhs_group_indp_ins_g_bmp2_squad_mg_sniper", "rhs_group_indp_ins_g_bmp2_squad_sniper"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_g_factionCustomGroups, "Armored", ["RHS_T72baPlatoon", "RHS_T72baPlatoon_AA", "RHS_T72baSection", "RHS_T72BBPlatoon", "RHS_T72BBPlatoon_AA", "RHS_T72BBSection", "RHS_t72bcPlatoon", "RHS_t72bcPlatoon_AA", "RHS_t72bcSection"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_g_factionCustomGroups, "Artillery", ["RHS_SPGPlatoon_ins_g_bm21", "RHS_SPGSection_ins_g_bm21"]] call ALIVE_fnc_hashSet;
 
 [rhsgref_faction_chdkz_g_mappings, "Groups", rhsgref_faction_chdkz_g_factionCustomGroups] call ALIVE_fnc_hashSet;
 
@@ -143,7 +161,9 @@ rhsgref_faction_chdkz_g_typeMappings = [] call ALIVE_fnc_hashCreate;
 [ALIVE_factionDefaultTransport, "rhsgref_faction_chdkz_g", []] call ALIVE_fnc_hashSet;
 [ALIVE_factionDefaultAirTransport, "rhsgref_faction_chdkz_g", []] call ALIVE_fnc_hashSet;
 
-// rhsgref_faction_nationalist
+//==========================================//
+// rhsgref_faction_nationalist              //
+//==========================================//
 
 rhsgref_faction_nationalist_mappings = [] call ALIVE_fnc_hashCreate;
 
@@ -158,11 +178,11 @@ rhsgref_faction_nationalist_typeMappings = [] call ALIVE_fnc_hashCreate;
 
 [rhsgref_faction_nationalist_mappings, "GroupFactionTypes", rhsgref_faction_nationalist_typeMappings] call ALIVE_fnc_hashSet;
 
-[rhsgref_faction_nationalist_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_nationalist_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_nationalist_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_nationalist_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
-[rhsgref_faction_nationalist_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_nationalist_factionCustomGroups, "Infantry", ["rhsgref_group_national_infantry_at", "rhsgref_group_national_infantry_mg", "rhsgref_group_national_infantry_patrol", "rhsgref_group_national_infantry_squad", "rhsgref_group_national_infantry_squad_2""rhsgref_group_national_infantry_at", "rhsgref_group_national_infantry_mg", "rhsgref_group_national_infantry_patrol", "rhsgref_group_national_infantry_squad", "rhsgref_group_national_infantry_squad_2"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_nationalist_factionCustomGroups, "Motorized", ["rhs_group_nat_ural_chq", "rhs_group_nat_ural_squad", "rhs_group_nat_ural_squad_2mg", "rhs_group_nat_ural_squad_aa", "rhs_group_nat_ural_squad_mg_sniper", "rhs_group_nat_ural_squad_sniper", "BUS_MotInf_AA", "BUS_MotInf_AT", "BUS_MotInf_Team_GMG", "BUS_MotInf_Team_HMG"]] call ALIVE_fnc_hashSet;
+[rhsgref_faction_nationalist_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet; // This faction has no mechanized groups defined.
+[rhsgref_faction_nationalist_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;    // This faction has no armored groups defined.
+[rhsgref_faction_nationalist_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;  // This faction has no artillery groups defined.
 
 [rhsgref_faction_nationalist_mappings, "Groups", rhsgref_faction_nationalist_factionCustomGroups] call ALIVE_fnc_hashSet;
 

--- a/addons/main/static/include/rhs_gref_compat.hpp
+++ b/addons/main/static/include/rhs_gref_compat.hpp
@@ -1,0 +1,173 @@
+// rhsgref_faction_cdf_b_ground
+
+rhsgref_faction_cdf_b_ground_mappings = [] call ALIVE_fnc_hashCreate;
+
+rhsgref_faction_cdf_b_ground_factionCustomGroups = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_cdf_b_ground_mappings, "Side", "WEST"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_b_ground_mappings, "GroupSideName", "WEST"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_b_ground_mappings, "FactionName", "rhsgref_faction_cdf_b_ground"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_b_ground_mappings, "GroupFactionName", "rhsgref_faction_cdf_b_ground"] call ALIVE_fnc_hashSet;
+
+rhsgref_faction_cdf_b_ground_typeMappings = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_cdf_b_ground_mappings, "GroupFactionTypes", rhsgref_faction_cdf_b_ground_typeMappings] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_b_ground_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_cdf_b_ground_mappings, "Groups", rhsgref_faction_cdf_b_ground_factionCustomGroups] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionCustomMappings, "rhsgref_faction_cdf_b_ground", rhsgref_faction_cdf_b_ground_mappings] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionDefaultSupports, "rhsgref_faction_cdf_b_ground", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultTransport, "rhsgref_faction_cdf_b_ground", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultAirTransport, "rhsgref_faction_cdf_b_ground", []] call ALIVE_fnc_hashSet;
+
+// rhsgref_faction_chdkz
+
+rhsgref_faction_chdkz_mappings = [] call ALIVE_fnc_hashCreate;
+
+rhsgref_faction_chdkz_factionCustomGroups = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_chdkz_mappings, "Side", "EAST"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_mappings, "GroupSideName", "EAST"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_mappings, "FactionName", "rhsgref_faction_chdkz"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_mappings, "GroupFactionName", "rhsgref_faction_chdkz"] call ALIVE_fnc_hashSet;
+
+rhsgref_faction_chdkz_typeMappings = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_chdkz_mappings, "GroupFactionTypes", rhsgref_faction_chdkz_typeMappings] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_chdkz_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_chdkz_mappings, "Groups", rhsgref_faction_chdkz_factionCustomGroups] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionCustomMappings, "rhsgref_faction_chdkz", rhsgref_faction_chdkz_mappings] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionDefaultSupports, "rhsgref_faction_chdkz", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultTransport, "rhsgref_faction_chdkz", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultAirTransport, "rhsgref_faction_chdkz", []] call ALIVE_fnc_hashSet;
+
+// rhsgref_faction_cdf_ground
+
+rhsgref_faction_cdf_ground_mappings = [] call ALIVE_fnc_hashCreate;
+
+rhsgref_faction_cdf_ground_factionCustomGroups = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_cdf_ground_mappings, "Side", "GUER"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ground_mappings, "GroupSideName", "GUER"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ground_mappings, "FactionName", "rhsgref_faction_cdf_ground"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ground_mappings, "GroupFactionName", "rhsgref_faction_cdf_ground"] call ALIVE_fnc_hashSet;
+
+rhsgref_faction_cdf_ground_typeMappings = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_cdf_ground_mappings, "GroupFactionTypes", rhsgref_faction_cdf_ground_typeMappings] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_cdf_ground_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ground_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ground_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ground_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ground_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_cdf_ground_mappings, "Groups", rhsgref_faction_cdf_ground_factionCustomGroups] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionCustomMappings, "rhsgref_faction_cdf_ground", rhsgref_faction_cdf_ground_mappings] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionDefaultSupports, "rhsgref_faction_cdf_ground", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultTransport, "rhsgref_faction_cdf_ground", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultAirTransport, "rhsgref_faction_cdf_ground", []] call ALIVE_fnc_hashSet;
+
+// rhsgref_faction_cdf_ng
+
+rhsgref_faction_cdf_ng_mappings = [] call ALIVE_fnc_hashCreate;
+
+rhsgref_faction_cdf_ng_factionCustomGroups = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_cdf_ng_mappings, "Side", "GUER"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ng_mappings, "GroupSideName", "GUER"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ng_mappings, "FactionName", "rhsgref_faction_cdf_ng"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ng_mappings, "GroupFactionName", "rhsgref_faction_cdf_ng"] call ALIVE_fnc_hashSet;
+
+rhsgref_faction_cdf_ng_typeMappings = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_cdf_ng_mappings, "GroupFactionTypes", rhsgref_faction_cdf_ng_typeMappings] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_cdf_ng_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ng_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ng_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ng_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_cdf_ng_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_cdf_ng_mappings, "Groups", rhsgref_faction_cdf_ng_factionCustomGroups] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionCustomMappings, "rhsgref_faction_cdf_ng", rhsgref_faction_cdf_ng_mappings] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionDefaultSupports, "rhsgref_faction_cdf_ng", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultTransport, "rhsgref_faction_cdf_ng", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultAirTransport, "rhsgref_faction_cdf_ng", []] call ALIVE_fnc_hashSet;
+
+// rhsgref_faction_chdkz_g
+
+rhsgref_faction_chdkz_g_mappings = [] call ALIVE_fnc_hashCreate;
+
+rhsgref_faction_chdkz_g_factionCustomGroups = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_chdkz_g_mappings, "Side", "GUER"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_g_mappings, "GroupSideName", "GUER"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_g_mappings, "FactionName", "rhsgref_faction_chdkz_g"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_g_mappings, "GroupFactionName", "rhsgref_faction_chdkz_g"] call ALIVE_fnc_hashSet;
+
+rhsgref_faction_chdkz_g_typeMappings = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_chdkz_g_mappings, "GroupFactionTypes", rhsgref_faction_chdkz_g_typeMappings] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_chdkz_g_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_g_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_g_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_g_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_chdkz_g_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_chdkz_g_mappings, "Groups", rhsgref_faction_chdkz_g_factionCustomGroups] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionCustomMappings, "rhsgref_faction_chdkz_g", rhsgref_faction_chdkz_g_mappings] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionDefaultSupports, "rhsgref_faction_chdkz_g", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultTransport, "rhsgref_faction_chdkz_g", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultAirTransport, "rhsgref_faction_chdkz_g", []] call ALIVE_fnc_hashSet;
+
+// rhsgref_faction_nationalist
+
+rhsgref_faction_nationalist_mappings = [] call ALIVE_fnc_hashCreate;
+
+rhsgref_faction_nationalist_factionCustomGroups = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_nationalist_mappings, "Side", "GUER"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_nationalist_mappings, "GroupSideName", "GUER"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_nationalist_mappings, "FactionName", "rhsgref_faction_nationalist"] call ALIVE_fnc_hashSet;
+[rhsgref_faction_nationalist_mappings, "GroupFactionName", "rhsgref_faction_nationalist"] call ALIVE_fnc_hashSet;
+
+rhsgref_faction_nationalist_typeMappings = [] call ALIVE_fnc_hashCreate;
+
+[rhsgref_faction_nationalist_mappings, "GroupFactionTypes", rhsgref_faction_nationalist_typeMappings] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_nationalist_factionCustomGroups, "Infantry", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_nationalist_factionCustomGroups, "Motorized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_nationalist_factionCustomGroups, "Mechanized", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_nationalist_factionCustomGroups, "Armored", []] call ALIVE_fnc_hashSet;
+[rhsgref_faction_nationalist_factionCustomGroups, "Artillery", []] call ALIVE_fnc_hashSet;
+
+[rhsgref_faction_nationalist_mappings, "Groups", rhsgref_faction_nationalist_factionCustomGroups] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionCustomMappings, "rhsgref_faction_nationalist", rhsgref_faction_nationalist_mappings] call ALIVE_fnc_hashSet;
+
+[ALIVE_factionDefaultSupports, "rhsgref_faction_nationalist", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultTransport, "rhsgref_faction_nationalist", []] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultAirTransport, "rhsgref_faction_nationalist", []] call ALIVE_fnc_hashSet;

--- a/addons/main/static/staticData.sqf
+++ b/addons/main/static/staticData.sqf
@@ -5436,7 +5436,7 @@ If (_fileExists) then {
 		ALIVE_civilianFuelBuildingTypes = ALIVE_civilianFuelBuildingTypes + ["ca\misc\fuel_tank_small.p3d"];
 		ALIVE_civilianConstructionBuildingTypes = ALIVE_civilianConstructionBuildingTypes + ["ca\structures_e\misc\misc_construction\misc_concbox_ep1.p3d","opxbuildings\ruin.p3d"];
 	};
-	
+
 	//Kapaulio - index by psvialli
 	if(tolower(_worldName) == "kapaulio") then {
 		ALIVE_Indexing_Blacklist = ALIVE_Indexing_Blacklist + ["a3\structures_f_epa\civ\constructions\portablelight_double_f.p3d","a3\structures_f\naval\piers\pier_small_f.p3d","a3\structures_f_epb\naval\fishing\fishinggear_01_f.p3d","a3\structures_f\walls\cncwall4_f.p3d","a3\structures_f_epa\items\medical\defibrillator_f.p3d","a3\structures_f_epa\items\medical\disinfectantspray_f.p3d","a3\structures_f_epa\items\tools\ducttape_f.p3d","a3\structures_f_bootcamp\items\food\foodcontainer_01_f.p3d","a3\structures_f_epa\items\medical\antibiotic_f.p3d","a3\structures_f_epa\items\medical\bandage_f.p3d","a3\roads_f\runway\runwaylights\flush_light_red_f.p3d","a3\structures_f\wrecks\wreck_hunter_f.p3d","a3\structures_f\mil\bagfence\bagfence_long_f.p3d","a3\structures_f_epb\naval\fishing\fishinggear_02_f.p3d","a3\structures_f\ind\wavepowerplant\wavepowerplant_f.p3d","a3\structures_f\ind\wavepowerplant\wavepowerplantbroken_f.p3d","jbad_misc\misc_market\jbad_crates.p3d","a3\structures_f_epc\dominants\ghosthotel\gh_stairs_f.p3d","a3\structures_f\training\rampconcrete_f.p3d","a3\structures_f\training\rampconcretehigh_f.p3d","a3\structures_f\wrecks\wreck_ural_f.p3d","a3\structures_f\items\electronics\survivalradio_f.p3d","a3\structures_f\items\food\tacticalbacon_f.p3d","a3\structures_f_epa\mil\scrapyard\pallet_milboxes_f.p3d","a3\structures_f_epa\items\medical\vitaminbottle_f.p3d","a3\structures_f_epa\items\food\ricebox_f.p3d","a3\structures_f_epa\civ\camping\woodentable_large_f.p3d","a3\structures_f\walls\cncwall1_f.p3d","a3\structures_f_epa\mil\scrapyard\paperbox_open_full_f.p3d","a3\structures_f\items\food\bottleplastic_v1_f.p3d","a3\structures_f_epa\items\food\bottleplastic_v2_f.p3d","a3\structures_f_epa\items\tools\fireextinguisher_f.p3d","a3\structures_f\items\electronics\fmradio_f.p3d","a3\structures_f\civ\infoboards\mapboard_f.p3d","a3\structures_f_epa\mil\scrapyard\paperbox_closed_f.p3d","a3\structures_f_epa\items\food\canteen_f.p3d","a3\structures_f_epa\mil\scrapyard\paperbox_open_empty_f.p3d","a3\structures_f_epa\items\tools\metalwire_f.p3d","a3\structures_f_epb\civ\dead\grave_dirt_f.p3d","a3\structures_f_epa\civ\constructions\pallets_stack_f.p3d","a3\structures_f\research\dome_b_cargo_entrance_f.p3d","a3\structures_f\research\dome_b_person_entrance_f.p3d","a3\structures_f\civ\infoboards\billboard_f.p3d","a3\structures_f_epc\civ\accessories\bench_01_f.p3d","a3\structures_f_epa\civ\camping\woodentable_small_f.p3d","a3\structures_f_epa\items\tools\gascanister_f.p3d","a3\structures_f\items\tools\meter3m_f.p3d","a3\structures_f_epb\items\vessels\barrelsand_grey_f.p3d","a3\structures_f_epa\items\vessels\tincontainer_f.p3d","a3\structures_f_epa\items\food\bakedbeans_f.p3d","a3\structures_f_epa\items\medical\heatpack_f.p3d","a3\structures_f\walls\cncbarrier_stripes_f.p3d","a3\structures_f\walls\cncbarriermedium4_f.p3d","a3\structures_f\mil\flags\mast_f.p3d","a3\structures_f_epa\mil\scrapyard\scrap_mrap_01_f.p3d","a3\structures_f\wrecks\wreck_uaz_f.p3d","a3\structures_f\civ\lamps\lampsolar_f.p3d","a3\structures_f\ind\cargo\cargo40_color_v2_ruins_f.p3d","a3\structures_f\households\addons\metal_shed_ruins_f.p3d","a3\structures_f\mil\bagfence\bagfence_round_f.p3d","a3\structures_f\mil\bagfence\bagfence_short_f.p3d","a3\structures_f\items\tools\drillaku_f.p3d","a3\structures_f\items\electronics\extensioncord_f.p3d","a3\structures_f\civ\camping\sleeping_bag_blue_f.p3d","a3\structures_f\items\tools\hammer_f.p3d","a3\structures_f\items\tools\pliers_f.p3d","a3\structures_f\items\electronics\portable_generator_f.p3d","a3\structures_f_epa\items\medical\painkillers_f.p3d","a3\structures_f_epa\mil\scrapyard\scrapheap_2_f.p3d","a3\structures_f_epa\items\food\cerealsbox_f.p3d","a3\structures_f\items\vessels\canisterfuel_f.p3d","a3\structures_f\items\documents\map_f.p3d","a3\structures_f\items\electronics\portablelongrangeradio_f.p3d","a3\structures_f\walls\rampart_f.p3d","a3\structures_f\ind\windpowerplant\wpp_turbine_v2_f.p3d","a3\structures_f_epa\civ\constructions\portablelight_single_f.p3d","a3\structures_f\civ\market\marketshelter_f.p3d","a3\structures_f\walls\cncshelter_f.p3d","a3\structures_f\mil\fortification\hbarrier_3_f.p3d","a3\structures_f_epb\items\vessels\barrelempty_grey_f.p3d","a3\structures_f_epb\items\vessels\barrelwater_grey_f.p3d","a3\structures_f\items\tools\axe_f.p3d","a3\structures_f\civ\camping\sleeping_bag_f.p3d","a3\structures_f\items\food\can_v1_f.p3d","a3\structures_f\items\food\can_v2_f.p3d","a3\structures_f\items\tools\gloves_f.p3d","a3\structures_f\civ\camping\sleeping_bag_brown_f.p3d","a3\structures_f_epa\items\tools\shovel_f.p3d","a3\structures_f_epa\civ\camping\woodenlog_f.p3d","a3\structures_f_epa\items\tools\gascooker_f.p3d","a3\structures_f\items\vessels\barrelempty_f.p3d","a3\structures_f\wrecks\wreck_bmp2_f.p3d","a3\structures_f_epa\items\tools\butanetorch_f.p3d","a3\structures_f_epb\items\luggage\luggageheap_02_f.p3d","a3\structures_f_epb\items\luggage\luggageheap_04_f.p3d","a3\structures_f_epc\civ\camping\sunshade_04_f.p3d","a3\structures_f\walls\indfnc_corner_f.p3d","a3\structures_f\furniture\tabledesk_f.p3d","a3\structures_f_epb\furniture\shelveswooden_f.p3d","a3\structures_f\furniture\chairwood_f.p3d","a3\structures_f_epa\mil\scrapyard\scrapheap_1_f.p3d","a3\structures_f_epb\furniture\shelveswooden_khaki_f.p3d","a3\structures_f\items\tools\dustmask_f.p3d","a3\structures_f_epc\civ\accessories\tableplastic_01_f.p3d","a3\structures_f\civ\ancient\ancientpillar_damaged_f.p3d","a3\structures_f\items\vessels\barreltrash_f.p3d","rspn_assets\models\cover_bluntstone.p3d","a3\structures_f\wrecks\wreck_t72_turret_f.p3d","rspn_assets\models\cover_dirt_inset.p3d","rspn_assets\models\cover_grass_inset.p3d","a3\structures_f\mil\bagfence\bagfence_corner_f.p3d","a3\structures_f\mil\bagfence\bagfence_end_f.p3d","a3\structures_f\civ\accessories\water_source_f.p3d","a3\structures_f_epc\civ\camping\sunshade_01_f.p3d","a3\structures_f_epa\items\tools\butanecanister_f.p3d","a3\structures_f_epa\items\tools\canopener_f.p3d","a3\structures_f\walls\wired_fence_4md_f.p3d","a3\structures_f_epb\civ\graffiti\graffiti_03_f.p3d","a3\structures_f_epb\items\documents\poster_05_f.p3d","a3\structures_f\civ\camping\camping_light_off_f.p3d","a3\structures_f\civ\camping\pillow_old_f.p3d","a3\structures_f\civ\camping\sleeping_bag_blue_folded_f.p3d","a3\structures_f_epa\items\medical\waterpurificationtablets_f.p3d","a3\structures_f\civ\camping\ground_sheet_blue_f.p3d","a3\structures_f\civ\camping\ground_sheet_f.p3d","a3\structures_f\civ\camping\ground_sheet_opfor_f.p3d","a3\structures_f\civ\camping\pillow_camouflage_f.p3d","a3\structures_f\civ\camping\pillow_f.p3d","a3\structures_f\items\vessels\canisteroil_f.p3d","a3\structures_f\civ\camping\pillow_grey_f.p3d","a3\structures_f\civ\camping\sleeping_bag_brown_folded_f.p3d","a3\structures_f_epb\items\luggage\luggageheap_03_f.p3d","a3\structures_f\items\documents\map_unfolded_f.p3d","a3\structures_f\research\dome_small_plates_f.p3d"];
@@ -6192,7 +6192,16 @@ ALIVE_RHSResupplyVehicleOptions = [] call ALIVE_fnc_hashCreate;
 [ALIVE_factionDefaultResupplyVehicleOptions, "rhs_faction_rva", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
 [ALIVE_factionDefaultResupplyVehicleOptions, "rhs_faction_insurgents", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
 
-
+// RHS GREF.
+[ALIVE_factionDefaultResupplyVehicleOptions, "rhsgref_faction_cdf_air", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyVehicleOptions, "rhsgref_faction_cdf_air_b", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyVehicleOptions, "rhsgref_faction_cdf_ground", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyVehicleOptions, "rhsgref_faction_cdf_ground_b", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyVehicleOptions, "rhsgref_faction_cdf_ng", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyVehicleOptions, "rhsgref_faction_cdf_ng_b", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyVehicleOptions, "rhsgref_faction_chdkz", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyVehicleOptions, "rhsgref_faction_chdkz_g", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyVehicleOptions, "rhsgref_faction_nationalist", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
 
 ALIVE_RHSResupplyIndividualOptions = [] call ALIVE_fnc_hashCreate;
 [ALIVE_RHSResupplyIndividualOptions, "PR_AIRDROP", [["<< Back","Men","MenDiver","MenRecon","MenSniper","MenSupport","RHS Infantry"],["<< Back","Men","MenDiver","MenRecon","MenSniper","MenSupport","rhs_vehclass_infantry"]]] call ALIVE_fnc_hashSet;
@@ -6218,6 +6227,16 @@ ALIVE_RHSResupplyIndividualOptions = [] call ALIVE_fnc_hashCreate;
 [ALIVE_factionDefaultResupplyIndividualOptions, "rhs_faction_rva", ALIVE_RHSResupplyIndividualOptions] call ALIVE_fnc_hashSet;
 [ALIVE_factionDefaultResupplyIndividualOptions, "rhs_faction_insurgents", ALIVE_RHSResupplyIndividualOptions] call ALIVE_fnc_hashSet;
 
+// RHS GREF
+[ALIVE_factionDefaultResupplyIndividualOptions, "rhsgref_faction_cdf_air", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyIndividualOptions, "rhsgref_faction_cdf_air_b", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyIndividualOptions, "rhsgref_faction_cdf_ground", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyIndividualOptions, "rhsgref_faction_cdf_ground_b", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyIndividualOptions, "rhsgref_faction_cdf_ng", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyIndividualOptions, "rhsgref_faction_cdf_ng_b", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyIndividualOptions, "rhsgref_faction_chdkz", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyIndividualOptions, "rhsgref_faction_chdkz_g", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyIndividualOptions, "rhsgref_faction_nationalist", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
 
 
 ALIVE_RHSResupplyGroupOptions = [] call ALIVE_fnc_hashCreate;
@@ -6339,6 +6358,16 @@ ALIVE_RHSResupplyGroupOptions = [] call ALIVE_fnc_hashCreate;
 [ALIVE_factionDefaultResupplyGroupOptions, "rhs_faction_rva", ALIVE_RHSResupplyGroupOptions] call ALIVE_fnc_hashSet;
 [ALIVE_factionDefaultResupplyGroupOptions, "rhs_faction_insurgents", ALIVE_RHSResupplyGroupOptions] call ALIVE_fnc_hashSet;
 
+// RHS GREF
+[ALIVE_factionDefaultResupplyGroupOptions, "rhsgref_faction_cdf_air", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyGroupOptions, "rhsgref_faction_cdf_air_b", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyGroupOptions, "rhsgref_faction_cdf_ground", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyGroupOptions, "rhsgref_faction_cdf_ground_b", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyGroupOptions, "rhsgref_faction_cdf_ng", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyGroupOptions, "rhsgref_faction_cdf_ng_b", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyGroupOptions, "rhsgref_faction_chdkz", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyGroupOptions, "rhsgref_faction_chdkz_g", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
+[ALIVE_factionDefaultResupplyGroupOptions, "rhsgref_faction_nationalist", ALIVE_RHSResupplyVehicleOptions] call ALIVE_fnc_hashSet;
 
 
 // RHS USAF ----------------------------------------------------------------------------------------------------------------
@@ -7137,6 +7166,12 @@ rhs_faction_insurgents_typeMappings = [] call ALIVE_fnc_hashCreate;
 [ALIVE_factionDefaultAirTransport, "rhs_faction_insurgents", ["rhs_t72bb_chdkz"]] call ALIVE_fnc_hashSet;
 */
 
+// ------------------------------------------------------------------------------------------------------------------
+
+
+// RHS GREF -----------------------------------------------------------------------------------------------------
+
+#include "./include/rhs_gref_compat.hpp"
 
 // ---------------------------------------------------------------------------------------------------------------------
 

--- a/addons/main/static/staticData.sqf
+++ b/addons/main/static/staticData.sqf
@@ -6260,7 +6260,12 @@ ALIVE_RHSResupplyGroupOptions = [] call ALIVE_fnc_hashCreate;
 	"rhs_group_rus_tv_90",
 	"rhs_group_rus_tv_2s3",
 	"rhs_group_indp_ins_bm21",
-	"rhs_group_indp_ins_72"
+	"rhs_group_indp_ins_72",
+    "rhs_group_cdf_b_72", "rhs_group_cdf_b_bm21",           // RHS GREF CDF (BLUFOR).
+    "rhs_group_indp_ins_72", "rhs_group_indp_ins_bm21",     // RHS GREF CHDKZ (OPFOR).
+    "rhs_group_cdf_72", "rhs_group_cdf_bm21",               // RHS GREF CDF (GUER)
+    "rhs_group_indp_ins_g_72", "rhs_group_indp_ins_g_bm21"  // RHS GREF CHDKZ (GUER).
+                                                            // RHS GREF NATIONALISTS (GUER) without entries.
 ]] call ALIVE_fnc_hashSet;
 [ALIVE_RHSResupplyGroupOptions, "PR_HELI_INSERT", [
 	"Armored",
@@ -6326,16 +6331,26 @@ ALIVE_RHSResupplyGroupOptions = [] call ALIVE_fnc_hashCreate;
 	"rhs_group_rus_tv_80",
 	"rhs_group_rus_tv_90",
 	"rhs_group_rus_tv_2s3",
-	"rhs_group_indp_ins_uaz",
-	"rhs_group_indp_ins_ural",
-	"rhs_group_indp_ins_btr60",
-	"rhs_group_indp_ins_btr70",
-	"rhs_group_indp_ins_bmp1",
-	"rhs_group_indp_ins_bmp2",
-	"rhs_group_indp_ins_bmd1",
-	"rhs_group_indp_ins_bmd2",
-	"rhs_group_indp_ins_bm21",
-	"rhs_group_indp_ins_72"
+	"rhs_group_indp_ins_uaz",   // These are legacy entries and should be removed
+	"rhs_group_indp_ins_ural",  // These are legacy entries and should be removed
+	"rhs_group_indp_ins_btr60", // These are legacy entries and should be removed
+	"rhs_group_indp_ins_btr70", // These are legacy entries and should be removed
+	"rhs_group_indp_ins_bmp1",  // These are legacy entries and should be removed
+	"rhs_group_indp_ins_bmp2",  // These are legacy entries and should be removed
+	"rhs_group_indp_ins_bmd1",  // These are legacy entries and should be removed
+	"rhs_group_indp_ins_bmd2",  // These are legacy entries and should be removed
+	"rhs_group_indp_ins_bm21",  // These are legacy entries and should be removed
+	"rhs_group_indp_ins_72",    // These are legacy entries and should be removed
+    // RHS GREF CDF (BLUFOR).
+    "rhs_group_cdf_b_72", "rhs_group_cdf_b_bm21", "rhs_group_cdf_b_bmd1", "rhs_group_cdf_b_bmd2", "rhs_group_cdf_b_bmp1", "rhs_group_cdf_b_bmp2", "rhs_group_cdf_b_btr60", "rhs_group_cdf_b_btr70", "rhs_group_cdf_b_gaz66", "rhs_group_cdf_b_gaz66_para", "rhs_group_cdf_b_uaz", "rhs_group_cdf_b_ural",
+    // RHS GREF CHDKZ (OPFOR).
+    "rhs_group_indp_ins_72", "rhs_group_indp_ins_bm21", "rhs_group_indp_ins_bmd1", "rhs_group_indp_ins_bmd2", "rhs_group_indp_ins_bmp1", "rhs_group_indp_ins_bmp2", "rhs_group_indp_ins_btr60", "rhs_group_indp_ins_btr70", "rhs_group_indp_ins_gaz66", "rhs_group_indp_ins_uaz", "rhs_group_indp_ins_ural",
+    // RHS GREF CDF (GUER)
+    "rhs_group_cdf_72", "rhs_group_cdf_bm21", "rhs_group_cdf_bmd1", "rhs_group_cdf_bmd2", "rhs_group_cdf_bmp1", "rhs_group_cdf_bmp2", "rhs_group_cdf_btr60", "rhs_group_cdf_btr70", "rhs_group_cdf_gaz66", "rhs_group_cdf_gaz66_para", "rhs_group_cdf_uaz", "rhs_group_cdf_ural",
+    // RHS GREF CHDKZ (GUER).
+    "rhs_group_indp_ins_g_72", "rhs_group_indp_ins_g_bm21", "rhs_group_indp_ins_g_bmd1", "rhs_group_indp_ins_g_bmd2", "rhs_group_indp_ins_g_bmp1", "rhs_group_indp_ins_g_bmp2", "rhs_group_indp_ins_g_btr60", "rhs_group_indp_ins_g_btr70", "rhs_group_indp_ins_g_gaz66", "rhs_group_indp_ins_g_uaz",
+    // RHS GREF NATIONALISTS (GUER)
+    "rhs_group_indp_nat_ural", "rhs_group_national_uaz"
 ]] call ALIVE_fnc_hashSet;
 [ALIVE_RHSResupplyGroupOptions, "PR_STANDARD", ["Support"]] call ALIVE_fnc_hashSet;
 
@@ -7171,7 +7186,7 @@ rhs_faction_insurgents_typeMappings = [] call ALIVE_fnc_hashCreate;
 
 // RHS GREF -----------------------------------------------------------------------------------------------------
 
-#include "./include/rhs_gref_compat.hpp"
+#include ".\include\rhs_gref_compat.hpp"
 
 // ---------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
When merged this pull request will add compatibility for the factions within RHS GREF (partially closes #15).

TODO:
- [ ] rhsgref_faction_cdf_air
- [ ] rhsgref_faction_cdf_air_b
- [ ] rhsgref_faction_cdf_ground
- [ ] rhsgref_faction_cdf_ground_b
- [ ] rhsgref_faction_cdf_ng
- [ ] rhsgref_faction_cdf_ng_b
- [ ] rhsgref_faction_chdkz
- [ ] rhsgref_faction_chdkz_g
- [ ] rhsgref_faction_nationalist
- [ ] rhsgref_faction_un
- [ ] Clean up and squash commits.

When OK for the core dev-team I would prefer to work with a separate file that is included in "addons/main/static/staticData.sqf". Meanwhile, can the "WIP" and "needs testing" labels be added?
