### PR TITLE
Add log faction classes in 3den context menu

### DIFF
--- a/addons/ui/CfgFunctions.hpp
+++ b/addons/ui/CfgFunctions.hpp
@@ -28,6 +28,11 @@ class CfgFunctions {
                 file = "\x\alive\addons\ui\fnc_RscDisplayMPInterruptALiVE.sqf";
                 recompile = RECOMPILE;
             };
+            class copyFactionClasses {
+                description = "Copy faction classes from selected objects in 3DEN to clipboard";
+                file = "\x\alive\addons\ui\fnc_copyFactionClasses.sqf";
+                recompile = RECOMPILE;
+            };
         };
     };
 };

--- a/addons/ui/CfgPatches.hpp
+++ b/addons/ui/CfgPatches.hpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ALIVE_main"};
+        requiredAddons[] = {"ALIVE_main", "3DEN"};
         versionDesc = "ALiVE";
         //versionAct = "['UI',_this] execVM '\x\alive\addons\main\about.sqf';";
         VERSION_CONFIG;

--- a/addons/ui/config.cpp
+++ b/addons/ui/config.cpp
@@ -307,3 +307,19 @@ class ALIVE_ui_setNumberValue {
 
     };
 };
+
+class ctrlMenu;
+class display3DEN {
+    class ContextMenu: ctrlMenu {
+        class Items {
+            class Log {
+                items[] += {"ALIVE_LogFaction"};
+            };
+            class ALIVE_LogFaction {
+                text = "Log faction classes to clipboard";
+                conditionShow = "selectedObject";
+                action = "[get3DENSelected 'object'] call ALIVE_fnc_copyFactionClasses;";
+            };
+        };
+    };
+};

--- a/addons/ui/fnc_copyFactionClasses.sqf
+++ b/addons/ui/fnc_copyFactionClasses.sqf
@@ -1,0 +1,11 @@
+private _objects = param [0, []];
+private _factions = [];
+
+{
+    private _faction = faction _x;
+    if (!(_faction in _factions)) then {
+        _factions pushBack _faction;
+    };
+} forEach _objects;
+
+copyToClipboard (str _factions);


### PR DESCRIPTION
Adds a context menu item that copies the faction class names of selected objects to clipboard.