### PR TITLE
Allow mission makers to define factions/groups in description.ext

### DIFF
--- a/addons/amb_civ_placement/fnc_AMBCP.sqf
+++ b/addons/amb_civ_placement/fnc_AMBCP.sqf
@@ -604,7 +604,7 @@ switch(_operation) do {
             _ambientVehicleAmount = parseNumber([_logic, "ambientVehicleAmount"] call MAINCLASS);
             _ambientVehicleFaction = [_logic, "ambientVehicleFaction"] call MAINCLASS;
 
-            _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
+            _factionConfig = _faction call ALiVE_fnc_configGetFactionClass;
             _factionSideNumber = getNumber(_factionConfig >> "side");
             _side = _factionSideNumber call ALIVE_fnc_sideNumberToText;
             _sideObject = [_side] call ALIVE_fnc_sideTextToObject;

--- a/addons/amb_civ_placement/fnc_AMBCP.sqf
+++ b/addons/amb_civ_placement/fnc_AMBCP.sqf
@@ -111,7 +111,7 @@ switch(_operation) do {
     };
     // Determine force faction
     case "faction": {
-        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call BIS_fnc_getFactions] call ALIVE_fnc_OOsimpleOperation;
+        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_configGetFactions] call ALIVE_fnc_OOsimpleOperation;
     };
     // Return TAOR marker
     case "taor": {
@@ -159,7 +159,7 @@ switch(_operation) do {
     };
     // Ambient vehicle faction
     case "ambientVehicleFaction": {
-        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call BIS_fnc_getFactions] call ALIVE_fnc_OOsimpleOperation;
+        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_configGetFactions] call ALIVE_fnc_OOsimpleOperation;
     };
     // Return the objectives as an array of clusters
     case "objectives": {

--- a/addons/civ_placement/fnc_CP.sqf
+++ b/addons/civ_placement/fnc_CP.sqf
@@ -157,7 +157,7 @@ switch(_operation) do {
     };
     // Determine force faction
     case "faction": {
-        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_getFactions] call ALIVE_fnc_OOsimpleOperation;
+        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_configGetFactions] call ALIVE_fnc_OOsimpleOperation;
     };
     // Return TAOR marker
     case "taor": {
@@ -665,7 +665,7 @@ switch(_operation) do {
             _size = parseNumber([_logic, "size"] call MAINCLASS);
             _roadBlocks = parsenumber([_logic, "roadBlocks"] call MAINCLASS);
 
-            _factionConfig = _faction call ALiVE_fnc_getFactionConfig;
+            _factionConfig = _faction call ALiVE_fnc_configGetFactionClass;
             _factionSideNumber = getNumber(_factionConfig >> "side");
             _side = _factionSideNumber call ALIVE_fnc_sideNumberToText;
             _countProfiles = 0;

--- a/addons/civ_placement/fnc_CP.sqf
+++ b/addons/civ_placement/fnc_CP.sqf
@@ -157,7 +157,7 @@ switch(_operation) do {
     };
     // Determine force faction
     case "faction": {
-        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call BIS_fnc_getFactions] call ALIVE_fnc_OOsimpleOperation;
+        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_getFactions] call ALIVE_fnc_OOsimpleOperation;
     };
     // Return TAOR marker
     case "taor": {
@@ -665,7 +665,7 @@ switch(_operation) do {
             _size = parseNumber([_logic, "size"] call MAINCLASS);
             _roadBlocks = parsenumber([_logic, "roadBlocks"] call MAINCLASS);
 
-            _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
+            _factionConfig = _faction call ALiVE_fnc_getFactionConfig;
             _factionSideNumber = getNumber(_factionConfig >> "side");
             _side = _factionSideNumber call ALIVE_fnc_sideNumberToText;
             _countProfiles = 0;

--- a/addons/mil_c2istar/utils/fnc_taskCreateReward.sqf
+++ b/addons/mil_c2istar/utils/fnc_taskCreateReward.sqf
@@ -40,7 +40,7 @@ switch(_rewardType) do {
 
             // send radio broadcast
             _sideObject = [_taskSide] call ALIVE_fnc_sideTextToObject;
-            _factionName = getText(configfile >> "CfgFactionClasses" >> _taskFaction >> "displayName");
+            _factionName = getText((_taskFaction call ALiVE_fnc_configGetFactionClass) >> "displayName");
             _forcePool = [ALIVE_globalForcePool,_taskFaction] call ALIVE_fnc_hashGet;
 
             _forcePool = _forcePool + _reward;

--- a/addons/mil_logistics/fnc_ML.sqf
+++ b/addons/mil_logistics/fnc_ML.sqf
@@ -4013,7 +4013,7 @@ switch(_operation) do {
 
                 // send radio broadcast
                 _sideObject = [_eventSide] call ALIVE_fnc_sideTextToObject;
-                _factionName = getText(configfile >> "CfgFactionClasses" >> _eventFaction >> "displayName");
+                _factionName = getText((_eventFaction call ALiVE_fnc_configGetFactionClass) >> "displayName");
                 _forcePool = [ALIVE_globalForcePool,_eventFaction] call ALIVE_fnc_hashGet;
 
                 // send a message to all side players from HQ

--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -151,7 +151,7 @@ switch(_operation) do {
                     };
 
                     _side = "EAST";
-                    switch (getNumber(((_factions select 0) call ALiVE_fnc_getFactionConfig) >> "side")) do {
+                    switch (getNumber(((_factions select 0) call ALiVE_fnc_configGetFactionClass) >> "side")) do {
                         case 0 : {_side = "EAST"};
                         case 1 : {_side = "WEST"};
                         case 2 : {_side = "GUER"};
@@ -380,7 +380,7 @@ switch(_operation) do {
                     //Still there? Awesome, check if there are different sides within the factions
                     _errorMessage = "There are different sides within this OPCOM %1! Please only select one side per OPCOM!%2";
                     _error1 = _side; _error2 = ""; _exit = false;  //defaults
-                    _exit = !(({(getNumber(((_factions select 0) call ALiVE_fnc_getFactionConfig) >> "side")) == (getNumber((_x call ALiVE_fnc_getFactionConfig) >> "side"))} count _factions) == (count _factions));
+                    _exit = !(({(getNumber(((_factions select 0) call ALiVE_fnc_configGetFactionClass) >> "side")) == (getNumber((_x call ALiVE_fnc_configGetFactionClass) >> "side"))} count _factions) == (count _factions));
                     if (_exit) exitwith {
                         [_errorMessage,_error1,_error2] call ALIVE_fnc_dumpR;
                     };

--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -151,7 +151,7 @@ switch(_operation) do {
                     };
 
                     _side = "EAST";
-                    switch (getNumber(configfile >> "CfgFactionClasses" >> _factions select 0 >> "side")) do {
+                    switch (getNumber(((_factions select 0) call ALiVE_fnc_getFactionConfig) >> "side")) do {
                         case 0 : {_side = "EAST"};
                         case 1 : {_side = "WEST"};
                         case 2 : {_side = "GUER"};
@@ -380,7 +380,7 @@ switch(_operation) do {
                     //Still there? Awesome, check if there are different sides within the factions
                     _errorMessage = "There are different sides within this OPCOM %1! Please only select one side per OPCOM!%2";
                     _error1 = _side; _error2 = ""; _exit = false;  //defaults
-                    _exit = !(({(getNumber(configfile >> "CfgFactionClasses" >> (_factions select 0) >> "side")) == (getNumber(configfile >> "CfgFactionClasses" >> _x >> "side"))} count _factions) == (count _factions));
+                    _exit = !(({(getNumber(((_factions select 0) call ALiVE_fnc_getFactionConfig) >> "side")) == (getNumber((_x call ALiVE_fnc_getFactionConfig) >> "side"))} count _factions) == (count _factions));
                     if (_exit) exitwith {
                         [_errorMessage,_error1,_error2] call ALIVE_fnc_dumpR;
                     };

--- a/addons/mil_placement/fnc_MP.sqf
+++ b/addons/mil_placement/fnc_MP.sqf
@@ -149,7 +149,7 @@ switch(_operation) do {
     };
     // Determine force faction
     case "faction": {
-        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call BIS_fnc_getFactions] call ALIVE_fnc_OOsimpleOperation;
+        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_getFactions] call ALIVE_fnc_OOsimpleOperation;
     };
     // Return the Ambient Vehicle Amount
     case "ambientVehicleAmount": {
@@ -679,7 +679,7 @@ switch(_operation) do {
             _placeHelis = [_logic, "placeHelis"] call MAINCLASS;
             _placeSupplies = [_logic, "placeSupplies"] call MAINCLASS;
 
-            _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
+            _factionConfig = _faction call ALiVE_fnc_getFactionConfig;
             _factionSideNumber = getNumber(_factionConfig >> "side");
             _side = _factionSideNumber call ALIVE_fnc_sideNumberToText;
             _countProfiles = 0;

--- a/addons/mil_placement/fnc_MP.sqf
+++ b/addons/mil_placement/fnc_MP.sqf
@@ -149,7 +149,7 @@ switch(_operation) do {
     };
     // Determine force faction
     case "faction": {
-        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_getFactions] call ALIVE_fnc_OOsimpleOperation;
+        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_configGetFactions] call ALIVE_fnc_OOsimpleOperation;
     };
     // Return the Ambient Vehicle Amount
     case "ambientVehicleAmount": {
@@ -679,7 +679,7 @@ switch(_operation) do {
             _placeHelis = [_logic, "placeHelis"] call MAINCLASS;
             _placeSupplies = [_logic, "placeSupplies"] call MAINCLASS;
 
-            _factionConfig = _faction call ALiVE_fnc_getFactionConfig;
+            _factionConfig = _faction call ALiVE_fnc_configGetFactionClass;
             _factionSideNumber = getNumber(_factionConfig >> "side");
             _side = _factionSideNumber call ALIVE_fnc_sideNumberToText;
             _countProfiles = 0;

--- a/addons/mil_placement_custom/fnc_CMP.sqf
+++ b/addons/mil_placement_custom/fnc_CMP.sqf
@@ -124,7 +124,7 @@ switch(_operation) do {
         _result = [_logic,_operation,_args,DEFAULT_NO_TEXT] call ALIVE_fnc_OOsimpleOperation;
     };
     case "faction": {
-        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_getFactions] call ALIVE_fnc_OOsimpleOperation;
+        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_configGetFactions] call ALIVE_fnc_OOsimpleOperation;
     };
     case "size": {
         _result = [_logic,_operation,_args,DEFAULT_SIZE] call ALIVE_fnc_OOsimpleOperation;
@@ -295,7 +295,7 @@ switch(_operation) do {
             _createHQ = [_logic, "createHQ"] call MAINCLASS;
             _placeHelis = [_logic, "placeHelis"] call MAINCLASS;
             _placeSupplies = [_logic, "placeSupplies"] call MAINCLASS;
-            _factionConfig = _faction call ALiVE_fnc_getFactionConfig;
+            _factionConfig = _faction call ALiVE_fnc_configGetFactionClass;
             _factionSideNumber = getNumber(_factionConfig >> "side");
             _side = _factionSideNumber call ALIVE_fnc_sideNumberToText;
             _countProfiles = 0;

--- a/addons/mil_placement_custom/fnc_CMP.sqf
+++ b/addons/mil_placement_custom/fnc_CMP.sqf
@@ -124,7 +124,7 @@ switch(_operation) do {
         _result = [_logic,_operation,_args,DEFAULT_NO_TEXT] call ALIVE_fnc_OOsimpleOperation;
     };
     case "faction": {
-        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call BIS_fnc_getFactions] call ALIVE_fnc_OOsimpleOperation;
+        _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_getFactions] call ALIVE_fnc_OOsimpleOperation;
     };
     case "size": {
         _result = [_logic,_operation,_args,DEFAULT_SIZE] call ALIVE_fnc_OOsimpleOperation;
@@ -295,7 +295,7 @@ switch(_operation) do {
             _createHQ = [_logic, "createHQ"] call MAINCLASS;
             _placeHelis = [_logic, "placeHelis"] call MAINCLASS;
             _placeSupplies = [_logic, "placeSupplies"] call MAINCLASS;
-            _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
+            _factionConfig = _faction call ALiVE_fnc_getFactionConfig;
             _factionSideNumber = getNumber(_factionConfig >> "side");
             _side = _factionSideNumber call ALIVE_fnc_sideNumberToText;
             _countProfiles = 0;

--- a/addons/sup_command/fnc_SCOM.sqf
+++ b/addons/sup_command/fnc_SCOM.sqf
@@ -3828,7 +3828,7 @@ switch(_operation) do {
 
                 _faction = faction _unit;
                 _nearestTown = [position _unit] call ALIVE_fnc_taskGetNearestLocationName;
-                _factionName = getText(configfile >> "CfgFactionClasses" >> _faction >> "displayName");
+                _factionName = getText((_faction call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
                 _title = "<t size='1.5' color='#68a7b7' shadow='1'>Joining Group</t><br/>";
                 _text = format["%1<t>%2 group %3 near %4</t>",_title,_factionName,_group,_nearestTown];
@@ -3931,7 +3931,7 @@ switch(_operation) do {
 
                 _faction = faction _unit;
                 _nearestTown = [position _unit] call ALIVE_fnc_taskGetNearestLocationName;
-                _factionName = getText(configfile >> "CfgFactionClasses" >> _faction >> "displayName");
+                _factionName = getText((_faction call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
                 _title = "<t size='1.5' color='#68a7b7' shadow='1'>Group</t><br/>";
                 _text = format["%1<t>%2 group %3 near %4</t>",_title,_factionName,_group,_nearestTown];

--- a/addons/sup_multispawn/fnc_multispawn.sqf
+++ b/addons/sup_multispawn/fnc_multispawn.sqf
@@ -123,7 +123,7 @@ switch(_operation) do {
                         {
                             _id = _x;
 
-                            if !(getNumber(configfile >> "CfgFactionClasses" >> _id >> "side") > 3) then {
+                            if !(getNumber((_id call ALiVE_fnc_configGetFactionClass) >> "side") > 3) then {
 
                                 // Create Default RespawnMarkers if not existing
                                 if !(("Respawn_" + str(_id call ALiVE_fnc_factionSide)) call ALIVE_fnc_markerExists) then {createMarker ["Respawn_" + str(_id call ALiVE_fnc_factionSide), getposATL _logic]};

--- a/addons/sup_multispawn/fnc_multispawn.sqf
+++ b/addons/sup_multispawn/fnc_multispawn.sqf
@@ -174,7 +174,7 @@ switch(_operation) do {
 
                                 [GVAR(STORE),_id,_factionData] call ALiVE_fnc_HashSet;
                             };
-                        } foreach ([] call BIS_fnc_getFactions);
+                        } foreach ([] call ALiVE_fnc_configGetFactions);
 
                         PublicVariable QGVAR(DEBUG);
                         PublicVariable QGVAR(MULTISPAWN_TYPE);

--- a/addons/sup_player_resupply/fnc_PR.sqf
+++ b/addons/sup_player_resupply/fnc_PR.sqf
@@ -2106,7 +2106,7 @@ switch(_operation) do {
                         _vehsize = [(configFile >> "CfgVehicles" >> _class >> "mapSize")] call ALiVE_fnc_getConfigValue;
                         _weight = [_class] call ALIVE_fnc_getObjectWeight;
                         _faction = [(configFile >> "CfgVehicles" >> _class >> "faction")] call ALiVE_fnc_getConfigValue;
-                        _faction = [(configFile >> "CfgFactionClasses" >> _faction >> "displayname")] call ALiVE_fnc_getConfigValue;
+                        _faction = [((_faction call ALiVE_fnc_configGetFactionClass) >> "displayname")] call ALiVE_fnc_getConfigValue;
                         _side = [[[(configFile >> "CfgVehicles" >> _class >> "side")] call ALiVE_fnc_getConfigValue] call ALIVE_fnc_sideNumberToText] call ALIVE_fnc_sideTextToLong;
                     };
 

--- a/addons/sys_data/fnc_DataInit.sqf
+++ b/addons/sys_data/fnc_DataInit.sqf
@@ -369,7 +369,7 @@ if (isDedicated) then {
                             [_playerHash, "AAR_class", getText (configFile >> "cfgVehicles" >> (typeof _unit) >> "displayName")] call ALIVE_fnc_hashSet;
                             [_playerHash, "AAR_damage", damage _unit] call ALIVE_fnc_hashSet;
                             [_playerHash, "AAR_side", side (group _unit)] call ALIVE_fnc_hashSet;
-                            [_playerHash, "AAR_fac", getText (configFile >> "cfgFactionClasses" >> (faction _unit) >> "displayName")] call ALIVE_fnc_hashSet;
+                            [_playerHash, "AAR_fac", getText (((faction _unit) call ALiVE_fnc_configGetFactionClass) >> "displayName")] call ALIVE_fnc_hashSet;
                             [_playerHash, "AAR_isLeader", _unit == leader (group _unit)] call ALIVE_fnc_hashSet;
                             [_playerHash, "AAR_isPlayer", isPlayer _unit] call ALIVE_fnc_hashSet;
                             [_playerHash, "AAR_group", str (group _unit)] call ALIVE_fnc_hashSet;

--- a/addons/sys_marker/fnc_markerLBSelChanged.sqf
+++ b/addons/sys_marker/fnc_markerLBSelChanged.sqf
@@ -95,7 +95,7 @@ switch _idc do {
         _temp = [_class, "/"] call CBA_fnc_split;
         _side = _temp select 2;
         _faction = _temp select 3;
-        _config = (configFile >> "CfgGroups" >> _side >> _faction);
+        _config = _faction call ALiVE_fnc_configGetFactionGroups;
         for "_i" from 0 to count _config -1 do {
             private ["_type","_f"];
             _type = _config select _i;

--- a/addons/sys_marker/fnc_markerOnLoad.sqf
+++ b/addons/sys_marker/fnc_markerOnLoad.sqf
@@ -268,7 +268,7 @@ _eyesControl = _display displayctrl 801019;
 _eyes = [
     ["UNCLASSIFIED (PUBLIC)", "GLOBAL"],
     [format ["CLASSIFIED Confidential (%1 ONLY)", side player], "SIDE"],
-    [format ["CLASSIFIED Secret (%1 ONLY)", getText (configFile >> "CfgFactionClasses" >> faction player >> "displayName")], "FACTION"],
+    [format ["CLASSIFIED Secret (%1 ONLY)", getText (((faction player) call ALiVE_fnc_configGetFactionClass) >> "displayName")], "FACTION"],
     [format ["CLASSIFIED Top Secret (%1 ONLY)", group player], "GROUP"],
     ["PRIVATE", "LOCAL"]
 ];

--- a/addons/sys_patrolrep/fnc_patrolrepOnLoad.sqf
+++ b/addons/sys_patrolrep/fnc_patrolrepOnLoad.sqf
@@ -98,7 +98,7 @@ _eyesControl = _display displayctrl EYES_LIST;
 _eyes = [
     ["UNCLASSIFIED (PUBLIC)", "GLOBAL"],
     [format ["CLASSIFIED Confidential (%1 ONLY)", side player], "SIDE"],
-    [format ["CLASSIFIED Secret (%1 ONLY)", getText (configFile >> "CfgFactionClasses" >> faction player >> "displayName")], "FACTION"],
+    [format ["CLASSIFIED Secret (%1 ONLY)", getText (((faction player) call ALiVE_fnc_configGetFactionClass) >> "displayName")], "FACTION"],
     [format ["CLASSIFIED Top Secret (%1 ONLY)", group player], "GROUP"],
     ["PRIVATE", "LOCAL"]
 ];

--- a/addons/sys_sitrep/fnc_sitrepOnLoad.sqf
+++ b/addons/sys_sitrep/fnc_sitrepOnLoad.sqf
@@ -78,7 +78,7 @@ _eyesControl = _display displayctrl EYES_LIST;
 _eyes = [
     ["UNCLASSIFIED (PUBLIC)", "GLOBAL"],
     [format ["CLASSIFIED Confidential (%1 ONLY)", side player], "SIDE"],
-    [format ["CLASSIFIED Secret (%1 ONLY)", getText (configFile >> "CfgFactionClasses" >> faction player >> "displayName")], "FACTION"],
+    [format ["CLASSIFIED Secret (%1 ONLY)", getText (((faction player) call ALiVE_fnc_configGetFactionClass) >> "displayName")], "FACTION"],
     [format ["CLASSIFIED Top Secret (%1 ONLY)", group player], "GROUP"],
     ["PRIVATE", "LOCAL"]
 ];

--- a/addons/sys_statistics/fnc_divingEH.sqf
+++ b/addons/sys_statistics/fnc_divingEH.sqf
@@ -49,7 +49,7 @@ if (GVAR(ENABLED)) then {
 
         _sideunit = side (group _unit); // group side is more reliable
 
-        _factionunit = getText (configFile >> "cfgFactionClasses" >> (faction _unit) >> "displayName");
+        _factionunit = getText (((faction _unit) call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
         _unitType = getText (configFile >> "cfgVehicles" >> (typeof _unit) >> "displayName");
 

--- a/addons/sys_statistics/fnc_getInEH.sqf
+++ b/addons/sys_statistics/fnc_getInEH.sqf
@@ -53,8 +53,8 @@ if (GVAR(ENABLED)) then {
         _sideunit = side (group _unit); // group side is more reliable
         _sidevehicle = side _vehicle;
 
-        _factionvehicle = getText (configFile >> "cfgFactionClasses" >> (faction _vehicle) >> "displayName");
-        _factionunit = getText (configFile >> "cfgFactionClasses" >> (faction _unit) >> "displayName");
+        _factionvehicle = getText (((faction _vehicle) call ALiVE_fnc_configGetFactionClass) >> "displayName");
+        _factionunit = getText (((faction _unit) call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
         _unittype = getText (configFile >> "cfgVehicles" >> (typeof _unit) >> "displayName");
         _vehicletype = getText (configFile >> "cfgVehicles" >> (typeof _vehicle) >> "displayName");

--- a/addons/sys_statistics/fnc_getOutEH.sqf
+++ b/addons/sys_statistics/fnc_getOutEH.sqf
@@ -52,8 +52,8 @@ if (GVAR(ENABLED)) then {
         _sideunit = side (group _unit); // group side is more reliable
         _sidevehicle = side _vehicle;
 
-        _factionvehicle = getText (configFile >> "cfgFactionClasses" >> (faction _vehicle) >> "displayName");
-        _factionunit = getText (configFile >> "cfgFactionClasses" >> (faction _unit) >> "displayName");
+        _factionvehicle = getText (((faction _vehicle) call ALiVE_fnc_configGetFactionClass) >> "displayName");
+        _factionunit = getText (((faction _unit) call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
         _unittype = getText (configFile >> "cfgVehicles" >> (typeof _unit) >> "displayName");
         _vehicletype = getText (configFile >> "cfgVehicles" >> (typeof _vehicle) >> "displayName");

--- a/addons/sys_statistics/fnc_handleDamageEH.sqf
+++ b/addons/sys_statistics/fnc_handleDamageEH.sqf
@@ -34,8 +34,8 @@ if (GVAR(ENABLED)) then {
         _sideWounded = side (group _wounded); // group side is more reliable
         _sidesource = side _source;
 
-        _factionsource = getText (configFile >> "cfgFactionClasses" >> (faction _source) >> "displayName");
-        _factionwounded = getText (configFile >> "cfgFactionClasses" >> (faction _wounded) >> "displayName");
+        _factionsource = getText (((faction _source) call ALiVE_fnc_configGetFactionClass) >> "displayName");
+        _factionwounded = getText (((faction _wounded) call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
         _woundedtype = getText (configFile >> "cfgVehicles" >> (typeof _wounded) >> "displayName");
         _sourcetype = getText (configFile >> "cfgVehicles" >> (typeof _source) >> "displayName");

--- a/addons/sys_statistics/fnc_handleHealEH.sqf
+++ b/addons/sys_statistics/fnc_handleHealEH.sqf
@@ -29,8 +29,8 @@ if (GVAR(ENABLED)) then {
         _sidepatient = side (group _patient); // group side is more reliable
         _sidemedic = side _medic;
 
-        _factionmedic = getText (configFile >> "cfgFactionClasses" >> (faction _medic) >> "displayName");
-        _factionpatient = getText (configFile >> "cfgFactionClasses" >> (faction _patient) >> "displayName");
+        _factionmedic = getText (((faction _medic) call ALiVE_fnc_configGetFactionClass) >> "displayName");
+        _factionpatient = getText (((faction _patient) call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
         _patienttype = getText (configFile >> "cfgVehicles" >> (typeof _patient) >> "displayName");
         _medictype = getText (configFile >> "cfgVehicles" >> (typeof _medic) >> "displayName");

--- a/addons/sys_statistics/fnc_hitEH.sqf
+++ b/addons/sys_statistics/fnc_hitEH.sqf
@@ -54,8 +54,8 @@ if (GVAR(ENABLED)) then {
         _sidehit = side (group _hit); // group side is more reliable
         _sidesource = side _source;
 
-        _factionsource = getText (configFile >> "cfgFactionClasses" >> (faction _source) >> "displayName");
-        _factionhit = getText (configFile >> "cfgFactionClasses" >> (faction _hit) >> "displayName");
+        _factionsource = getText (((faction _source) call ALiVE_fnc_configGetFactionClass) >> "displayName");
+        _factionhit = getText (((faction _hit) call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
         _hittype = getText (configFile >> "cfgVehicles" >> (typeof _hit) >> "displayName");
         _sourcetype = getText (configFile >> "cfgVehicles" >> (typeof _source) >> "displayName");

--- a/addons/sys_statistics/fnc_incomingMissileEH.sqf
+++ b/addons/sys_statistics/fnc_incomingMissileEH.sqf
@@ -31,8 +31,8 @@ if (GVAR(ENABLED)) then {
             _sideTarget = side (group _target); // group side is more reliable
             _sidesource = side _source;
 
-            _factionsource = getText (configFile >> "cfgFactionClasses" >> (faction _source) >> "displayName");
-            _factionTarget = getText (configFile >> "cfgFactionClasses" >> (faction _target) >> "displayName");
+            _factionsource = getText (((faction _source) call ALiVE_fnc_configGetFactionClass) >> "displayName");
+            _factionTarget = getText (((faction _target) call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
             _targettype = getText (configFile >> "cfgVehicles" >> (typeof _target) >> "displayName");
             _sourcetype = getText (configFile >> "cfgVehicles" >> (typeof _source) >> "displayName");

--- a/addons/sys_statistics/fnc_landedTouchDownEH.sqf
+++ b/addons/sys_statistics/fnc_landedTouchDownEH.sqf
@@ -53,7 +53,7 @@ if (GVAR(ENABLED)) then {
         if (_LandedInterval > 30) then {
             _sidevehicle = side (group _vehicle); // group side is more reliable
 
-            _factionvehicle = getText (configFile >> "cfgFactionClasses" >> (faction _vehicle) >> "displayName");
+            _factionvehicle = getText (((faction _vehicle) call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
             _vehicletype = getText (configFile >> "cfgVehicles" >> (typeof _vehicle) >> "displayName");
             _vehicleConfig = typeOf _vehicle;

--- a/addons/sys_statistics/fnc_statisticsInit.sqf
+++ b/addons/sys_statistics/fnc_statisticsInit.sqf
@@ -160,7 +160,7 @@ if (isDedicated && GVAR(ENABLED)) then {
                     _class = getText (configFile >> "cfgVehicles" >> (typeof _unit) >> "displayName");
                     _damage = damage _unit;
                     _side = side (group _unit);
-                    _fac = getText (configFile >> "cfgFactionClasses" >> (faction _unit) >> "displayName");
+                    _fac = getText (((faction _unit) call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
                     _icon = switch (_side) do
                     {

--- a/addons/sys_statistics/fnc_unitKilledEH.sqf
+++ b/addons/sys_statistics/fnc_unitKilledEH.sqf
@@ -73,8 +73,8 @@ if (GVAR(ENABLED)) then {
         _sideKilled = side (group _killed); // group side is more reliable
         _sideKiller = side _killer;
 
-        _factionKiller = getText (configFile >> "cfgFactionClasses" >> (faction _killer) >> "displayName");
-        _factionKilled = getText (configFile >> "cfgFactionClasses" >> (faction _killed) >> "displayName");
+        _factionKiller = getText (((faction _killer) call ALiVE_fnc_configGetFactionClass) >> "displayName");
+        _factionKilled = getText (((faction _killed) call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
         _killedtype = getText (configFile >> "cfgVehicles" >> (typeof _killed) >> "displayName");
         _killertype = getText (configFile >> "cfgVehicles" >> (typeof _killer) >> "displayName");

--- a/addons/sys_tour/fnc_tour.sqf
+++ b/addons/sys_tour/fnc_tour.sqf
@@ -1918,7 +1918,7 @@ switch(_operation) do {
                         ["closeSplash"] call ALIVE_fnc_displayMenu;
 
                         _nearestTown = [_position] call ALIVE_fnc_taskGetNearestLocationName;
-                        _factionName = getText(configfile >> "CfgFactionClasses" >> _faction >> "displayName");
+                        _factionName = getText((_faction call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
                         _title = "<t size='1.5' color='#68a7b7' shadow='1'>OPCOM Troops</t><br/>";
                         _text = format["%1<t>%2 group %3 near %4</t> %5",_title,_factionName,_group,_nearestTown,_action];
@@ -2075,7 +2075,7 @@ switch(_operation) do {
 
 
                         _nearestTown = [_position] call ALIVE_fnc_taskGetNearestLocationName;
-                        _factionName = getText(configfile >> "CfgFactionClasses" >> _faction >> "displayName");
+                        _factionName = getText((_faction call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
                         _title = "<t size='1.5' color='#68a7b7' shadow='1'>Military Objective</t><br/>";
                         _text = format["%1<t>Objective near %2 initially held by: %3</t>",_title,_nearestTown,_factionName];
@@ -2138,7 +2138,7 @@ switch(_operation) do {
                     ["closeSplash"] call ALIVE_fnc_displayMenu;
 
                     _nearestTown = [_position] call ALIVE_fnc_taskGetNearestLocationName;
-                    _factionName = getText(configfile >> "CfgFactionClasses" >> _faction >> "displayName");
+                    _factionName = getText((_faction call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
                     _title = "<t size='1.5' color='#68a7b7' shadow='1'>Military Objective</t><br/>";
                     _text = format["%1<t>Objective near %2 initially held by: %3</t>",_title,_nearestTown,_factionName];
@@ -2413,7 +2413,7 @@ switch(_operation) do {
                         ["closeSplash"] call ALIVE_fnc_displayMenu;
 
                         _nearestTown = [_position] call ALIVE_fnc_taskGetNearestLocationName;
-                        _factionName = getText(configfile >> "CfgFactionClasses" >> _faction >> "displayName");
+                        _factionName = getText((_faction call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
                         _title = "<t size='1.5' color='#68a7b7' shadow='1'>CQB Units</t><br/>";
                         _text = format["%1<t>%2 units near %3</t><br/>",_title,_factionName,_nearestTown];
@@ -2588,7 +2588,7 @@ switch(_operation) do {
                             [_logic, "createDynamicCamera", [_duration,player,_unit,_target]] call MAINCLASS;
 
                             _nearestTown = [_position] call ALIVE_fnc_taskGetNearestLocationName;
-                            _factionName = getText(configfile >> "CfgFactionClasses" >> _faction >> "displayName");
+                            _factionName = getText((_faction call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
                             _title = "<t size='1.5' color='#68a7b7' shadow='1'>Civilian</t><br/>";
                             _text = format["%1<t>%2 is %3 near %4</t><br/>",_title,name _unit,_action,_nearestTown];
@@ -2898,7 +2898,7 @@ switch(_operation) do {
                                     if!(isNil "_unit") then {
 
                                         _nearestTown = [_position] call ALIVE_fnc_taskGetNearestLocationName;
-                                        _factionName = getText(configfile >> "CfgFactionClasses" >> _faction >> "displayName");
+                                        _factionName = getText((_faction call ALiVE_fnc_configGetFactionClass) >> "displayName");
 
                                         _title = "<t size='1.5' color='#68a7b7' shadow='1'>Joining Group</t><br/>";
                                         _text = format["%1<t>%2 group %3 near %4</t> %5",_title,_factionName,_group,_nearestTown,_action];

--- a/addons/x_lib/config/CfgFunctions.hpp
+++ b/addons/x_lib/config/CfgFunctions.hpp
@@ -1245,6 +1245,20 @@ class getEnvironment
     recompile = RECOMPILE;
 };
 
+class getFactionConfig
+{
+    file = "\x\alive\addons\x_lib\functions\misc\fnc_getFactionConfig.sqf";
+    ext = ".sqf";
+    recompile = RECOMPILE;
+};
+
+class getFactions
+{
+    file = "\x\alive\addons\x_lib\functions\misc\fnc_getFactions.sqf";
+    ext = ".sqf";
+    recompile = RECOMPILE;
+};
+
 class getPos
 {
     file = "\x\alive\addons\x_lib\functions\misc\fnc_getPos.sqf";

--- a/addons/x_lib/config/CfgFunctions.hpp
+++ b/addons/x_lib/config/CfgFunctions.hpp
@@ -328,6 +328,34 @@ class configFindEntries
     recompile = RECOMPILE;
 };
 
+class configGetFactionClass
+{
+    file = "\x\alive\addons\x_lib\functions\config\fnc_configGetFactionClass.sqf";
+    ext = ".sqf";
+    recompile = RECOMPILE;
+};
+
+class configGetFactionGroups
+{
+    file = "\x\alive\addons\x_lib\functions\config\fnc_configGetFactionGroups.sqf";
+    ext = ".sqf";
+    recompile = RECOMPILE;
+};
+
+class configGetFactions
+{
+    file = "\x\alive\addons\x_lib\functions\config\fnc_configGetFactions.sqf";
+    ext = ".sqf";
+    recompile = RECOMPILE;
+};
+
+class configGetFactionUnitsByGroups
+{
+    file = "\x\alive\addons\x_lib\functions\config\fnc_configGetFactionUnitsByGroups.sqf";
+    ext = ".sqf";
+    recompile = RECOMPILE;
+};
+
 class configGetVehicleClass
 {
     file = "\x\alive\addons\x_lib\functions\config\fnc_configGetVehicleClass.sqf";
@@ -1241,20 +1269,6 @@ class sortBy
 class getEnvironment
 {
     file = "\x\alive\addons\x_lib\functions\misc\fnc_getEnvironment.sqf";
-    ext = ".sqf";
-    recompile = RECOMPILE;
-};
-
-class getFactionConfig
-{
-    file = "\x\alive\addons\x_lib\functions\misc\fnc_getFactionConfig.sqf";
-    ext = ".sqf";
-    recompile = RECOMPILE;
-};
-
-class getFactions
-{
-    file = "\x\alive\addons\x_lib\functions\misc\fnc_getFactions.sqf";
     ext = ".sqf";
     recompile = RECOMPILE;
 };

--- a/addons/x_lib/functions/config/fnc_configGetFactionClass.sqf
+++ b/addons/x_lib/functions/config/fnc_configGetFactionClass.sqf
@@ -1,8 +1,8 @@
 #include <\x\alive\addons\x_lib\script_component.hpp>
-SCRIPT(getFactionConfig);
+SCRIPT(configGetFactionClass);
 
 /* ----------------------------------------------------------------------------
-Function: ALiVE_fnc_getFactionConfig
+Function: ALiVE_fnc_configGetFactionClass
 
 Description:
 Returns config path of given faction
@@ -16,7 +16,7 @@ Config Path - path to faction config
 
 Examples:
 (begin example)
-_side = "OPF_F" call ALiVE_fnc_getFactionConfig;
+_side = "OPF_F" call ALiVE_fnc_configGetFactionClass;
 (end)
 
 See Also:
@@ -29,9 +29,7 @@ Peer reviewed:
 nil
 ---------------------------------------------------------------------------- */
 
-private "_path";
-
-_path = missionConfigFile >> "CfgFactionClasses" >> _this;
+private _path = missionConfigFile >> "CfgFactionClasses" >> _this;
 
 if !(isClass _path) then {_path = configFile >> "CfgFactionClasses" >> _this};
 

--- a/addons/x_lib/functions/config/fnc_configGetFactionGroups.sqf
+++ b/addons/x_lib/functions/config/fnc_configGetFactionGroups.sqf
@@ -29,16 +29,27 @@ Peer reviewed:
 nil
 ---------------------------------------------------------------------------- */
 
-private _factionSide = _this call ALiVE_fnc_factionSide;
+private _faction = _this;
+private _factionSide = _faction call ALiVE_fnc_factionSide;
 
-if (_factionSide == RESISTANCE) then {
-    _factionSide = "Indep";
-} else {
-    _factionSide = str _factionSide;
+if (!isnil "ALiVE_factionCustomMappings") then {
+    if (_faction in (ALiVE_factionCustomMappings select 1)) then {
+        private _factionData = [ALiVE_factionCustomMappings, _faction] call ALiVE_fnc_hashGet;
+        _factionSide = [_factionData,"GroupSideName"] call ALiVE_fnc_hashGet;
+        _faction = [_factionData,"GroupFactionName"] call ALiVE_fnc_hashGet;
+    };
 };
 
-private _path = missionConfigFile >> "CfgGroups" >> _factionSide >> _this;
+if !(_factionSide isEqualType "") then {
+    if (_factionSide isEqualTo RESISTANCE) then {
+        _factionSide = "Indep";
+    } else {
+        _factionSide = str _factionSide;
+    };
+};
 
-if !(isClass _path) then {_path = configFile >> "CfgGroups" >> _factionSide >> _this};
+private _path = missionConfigFile >> "CfgGroups" >> _factionSide >> _faction;
+
+if !(isClass _path) then {_path = configFile >> "CfgGroups" >> _factionSide >> _faction};
 
 _path

--- a/addons/x_lib/functions/config/fnc_configGetFactionGroups.sqf
+++ b/addons/x_lib/functions/config/fnc_configGetFactionGroups.sqf
@@ -1,0 +1,44 @@
+#include <\x\alive\addons\x_lib\script_component.hpp>
+SCRIPT(configGetFactionGroups);
+
+/* ----------------------------------------------------------------------------
+Function: ALiVE_fnc_configGetFactionGroups
+
+Description:
+Returns config path of given faction's CfgGroups
+searches missionConfigFile before configFile
+
+Parameters:
+String - faction
+
+Returns:
+Config Path - path to faction config
+
+Examples:
+(begin example)
+_side = "OPF_F" call ALiVE_fnc_configGetFactionGroups;
+(end)
+
+See Also:
+- nil
+
+Author:
+SpyderBlack723
+
+Peer reviewed:
+nil
+---------------------------------------------------------------------------- */
+
+private _factionSide = _this call ALiVE_fnc_factionSide;
+
+if (_factionSide == RESISTANCE) then {
+    _factionSide = "Indep";
+} else {
+    _factionSide = str _factionSide;
+};
+
+private _path = missionConfigFile >> "CfgGroups" >> _factionSide >> _this;
+
+if !(isClass _path) then {_path = configFile >> "CfgGroups" >> _factionSide >> _this};
+
+_path

--- a/addons/x_lib/functions/config/fnc_configGetFactionUnitsByGroups.sqf
+++ b/addons/x_lib/functions/config/fnc_configGetFactionUnitsByGroups.sqf
@@ -1,0 +1,53 @@
+#include <\x\alive\addons\x_lib\script_component.hpp>
+SCRIPT(configGetFactionUnitsByGroups);
+
+/* ----------------------------------------------------------------------------
+Function: ALiVE_fnc_configGetFactionUnitsByGroups
+
+Description:
+Returns config path of given faction
+searches missionConfigFile before configFile
+
+Parameters:
+String - faction
+
+Returns:
+Config Path - path to faction config
+
+Examples:
+(begin example)
+_side = "OPF_F" call ALiVE_fnc_configGetFactionUnitsByGroups;
+(end)
+
+See Also:
+- nil
+
+Author:
+SpyderBlack723
+
+Peer reviewed:
+nil
+---------------------------------------------------------------------------- */
+
+private ["_groupCategory","_group","_unit"];
+
+private _units = [];
+private _groups = _this call ALiVE_fnc_configGetFactionGroups;
+
+for "_i" from 0 to (count _groups - 1) do {
+    _groupCategory = _groups select _i;
+
+    for "_j" from 0 to (count _groupCategory - 1) do {
+        _group = _groupCategory select _j;
+
+        for "_k" from 0 to (count _group - 1) do {
+            _unit = _group select _k;
+
+            if (isClass _unit) then {
+                _units pushbackunique (getText (_unit >> "vehicle"));
+            };
+        };
+    };
+};
+
+_units

--- a/addons/x_lib/functions/config/fnc_configGetFactions.sqf
+++ b/addons/x_lib/functions/config/fnc_configGetFactions.sqf
@@ -1,8 +1,8 @@
 #include <\x\alive\addons\x_lib\script_component.hpp>
-SCRIPT(getFactions);
+SCRIPT(configGetFactions);
 
 /* ----------------------------------------------------------------------------
-Function: ALiVE_fnc_getFactions
+Function: ALiVE_fnc_configGetFactions
 
 Description:
 Returns all config factions
@@ -16,7 +16,7 @@ Array - All factions
 
 Examples:
 (begin example)
-_side = [] call ALiVE_fnc_getFactions;
+_side = [] call ALiVE_fnc_configGetFactions;
 (end)
 
 See Also:

--- a/addons/x_lib/functions/config/fnc_configGetGroup.sqf
+++ b/addons/x_lib/functions/config/fnc_configGetGroup.sqf
@@ -16,7 +16,7 @@ Group data
 Examples:
 (begin example)
 // get config group
-_result = "OIA_InfWepTeam" call ALIVE_fnc_configGetGroup;
+_result = ["OPF_F","OIA_InfWepTeam"] call ALIVE_fnc_configGetGroup;
 (end)
 
 See Also:
@@ -44,7 +44,9 @@ _config = [];
 if!(isNil "_groupData") then {
     //["CDATA: %1 %2",_groupData,_groupClass] call ALIVE_fnc_dump;
     //["CDATA COUNT: %1 %2",count _groupData,_groupClass] call ALIVE_fnc_dump;
-    _config = (configFile >> "CfgGroups");
+
+    _groupData params ["_configRoot","_groupData"];
+    _config = _configRoot >> "CfgGroups";
 
     for "_i" from 0 to count _groupData -1 do {
         _config = _config select (_groupData select _i);

--- a/addons/x_lib/functions/config/fnc_configGetRandomGroup.sqf
+++ b/addons/x_lib/functions/config/fnc_configGetRandomGroup.sqf
@@ -75,39 +75,27 @@ if(!isNil "ALIVE_factionCustomMappings") then {
 
                 } else {
                     ["Warning Side: %1 Faction: %3 could not find a %2 group",_side,_type,_faction] call ALIVE_fnc_dump;
-                    _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
-                    if !(isClass _factionConfig) then {
-                        _factionConfig = (missionConfigFile >> "CfgFactionClasses" >> _faction);
-                    };
+                    _factionConfig = _faction call ALiVE_fnc_configGetFactionClass;
 
                     _factionSide = getNumber(_factionConfig >> "side");
                     _side = _factionSide call ALIVE_fnc_sideNumberToText;
                 };
             } else {
                 ["Warning Side: %1 Faction: %3 maybe incorrectly configured for ALiVE (Group Type: %2)",_side,_type,_faction] call ALIVE_fnc_dump;
-                _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
-                if !(isClass _factionConfig) then {
-                    _factionConfig = (missionConfigFile >> "CfgFactionClasses" >> _faction);
-                };
+                _factionConfig = _faction call ALiVE_fnc_configGetFactionClass;
 
                 _factionSide = getNumber(_factionConfig >> "side");
                 _side = _factionSide call ALIVE_fnc_sideNumberToText;
             };
         };
     }else{
-        _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
-        if !(isClass _factionConfig) then {
-            _factionConfig = (missionconfigfile >> "CfgFactionClasses" >> _faction);
-        };
+        _factionConfig = _faction call ALiVE_fnc_configGetFactionClass;
 
         _factionSide = getNumber(_factionConfig >> "side");
         _side = _factionSide call ALIVE_fnc_sideNumberToText;
     };
 }else{
-    _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
-    if !(isClass _factionConfig) then {
-        _factionConfig = (missionConfigFile >> "CfgFactionClasses" >> _faction);
-    };
+    _factionConfig = _faction call ALiVE_fnc_configGetFactionClass;
 
     _factionSide = getNumber(_factionConfig >> "side");
     _side = _factionSide call ALIVE_fnc_sideNumberToText;
@@ -126,10 +114,7 @@ if(typename _type == "ARRAY") then {
 
 if!(_customGroup) then {
 
-    _typeConfig = (configFile >> "CfgGroups" >> _side >> _faction >> _type);
-    if !(isClass _typeConfig) then {
-        _typeConfig = (missionConfigFile >> "CfgGroups" >> _side >> _faction >> _type);
-    };
+    _typeConfig = (_faction call ALiVE_fnc_configGetFactionGroups) >> _type;
 
     _groups = [];
 

--- a/addons/x_lib/functions/config/fnc_configGetRandomGroup.sqf
+++ b/addons/x_lib/functions/config/fnc_configGetRandomGroup.sqf
@@ -18,7 +18,7 @@ String group name
 Examples:
 (begin example)
 // get random group config group
-_result = [] call ALIVE_fnc_configGetRandomGroup;
+_result = ["Infantry","OPF_F"] call ALIVE_fnc_configGetRandomGroup;
 (end)
 
 See Also:
@@ -27,11 +27,13 @@ Author:
 ARJay
 ---------------------------------------------------------------------------- */
 
-private ["_type","_typeg","_faction","_side","_factionConfig","_factionSide","_typeConfig","_groups","_class","_countUnits", "_unit","_group","_groupName","_customMappings","_groupFactionTypes","_customGroup","_mappedType"];
+private ["_factionConfig","_factionSide","_typeConfig","_groups","_class","_countUnits", "_unit","_group","_groupName","_customMappings","_groupFactionTypes","_customGroup","_mappedType"];
 
-_type = if(count _this > 0) then {_this select 0} else {"Infantry"};
-_faction = if(count _this > 1) then {_this select 1} else {"OPF_F"};
-_side = if(count _this > 2) then {_this select 2} else {"EAST"};
+params [
+    ["_type","Infantry"],
+    ["_faction","OPF_F"],
+    ["_side","EAST"]
+];
 
 // ["Side: %1 Type: %2 Faction: %3",_side,_type,_faction] call ALIVE_fnc_dump;
 
@@ -74,23 +76,39 @@ if(!isNil "ALIVE_factionCustomMappings") then {
                 } else {
                     ["Warning Side: %1 Faction: %3 could not find a %2 group",_side,_type,_faction] call ALIVE_fnc_dump;
                     _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
+                    if !(isClass _factionConfig) then {
+                        _factionConfig = (missionConfigFile >> "CfgFactionClasses" >> _faction);
+                    };
+
                     _factionSide = getNumber(_factionConfig >> "side");
                     _side = _factionSide call ALIVE_fnc_sideNumberToText;
                 };
             } else {
                 ["Warning Side: %1 Faction: %3 maybe incorrectly configured for ALiVE (Group Type: %2)",_side,_type,_faction] call ALIVE_fnc_dump;
                 _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
+                if !(isClass _factionConfig) then {
+                    _factionConfig = (missionConfigFile >> "CfgFactionClasses" >> _faction);
+                };
+
                 _factionSide = getNumber(_factionConfig >> "side");
                 _side = _factionSide call ALIVE_fnc_sideNumberToText;
             };
         };
     }else{
         _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
+        if !(isClass _factionConfig) then {
+            _factionConfig = (missionconfigfile >> "CfgFactionClasses" >> _faction);
+        };
+
         _factionSide = getNumber(_factionConfig >> "side");
         _side = _factionSide call ALIVE_fnc_sideNumberToText;
     };
 }else{
     _factionConfig = (configFile >> "CfgFactionClasses" >> _faction);
+    if !(isClass _factionConfig) then {
+        _factionConfig = (missionConfigFile >> "CfgFactionClasses" >> _faction);
+    };
+
     _factionSide = getNumber(_factionConfig >> "side");
     _side = _factionSide call ALIVE_fnc_sideNumberToText;
 };
@@ -109,6 +127,10 @@ if(typename _type == "ARRAY") then {
 if!(_customGroup) then {
 
     _typeConfig = (configFile >> "CfgGroups" >> _side >> _faction >> _type);
+    if !(isClass _typeConfig) then {
+        _typeConfig = (missionConfigFile >> "CfgGroups" >> _side >> _faction >> _type);
+    };
+
     _groups = [];
 
     // ["Config: %1",_typeConfig] call ALIVE_fnc_dump;

--- a/addons/x_lib/functions/config/fnc_sortCFGGroupsByFaction.sqf
+++ b/addons/x_lib/functions/config/fnc_sortCFGGroupsByFaction.sqf
@@ -37,7 +37,7 @@ if(_side == "GUER") then {
     _side = "INDEP";
 };
 
-_configPath = configfile >> "CfgGroups" >> _side >> _faction;
+_configPath = _faction call ALiVE_fnc_configGetFactionGroups;
 
 _sortedGroups = [] call ALIVE_fnc_hashCreate;
 _categories = [] call ALIVE_fnc_hashCreate;

--- a/addons/x_lib/functions/diagnostics/fnc_checkConfigCompatibility.sqf
+++ b/addons/x_lib/functions/diagnostics/fnc_checkConfigCompatibility.sqf
@@ -161,7 +161,7 @@ _text = "Checking faction is found in CfgFactionClasses";
 [_text] call _dump;
 
 
-_config = configfile >> "CfgFactionClasses" >> _faction;
+_config = _faction call ALiVE_fnc_configGetFactionClass;
 
 if(count _config > 0) then {
     _displayName = [_config >> "displayName"] call _cfgValue;

--- a/addons/x_lib/functions/diagnostics/fnc_checkConfigCompatibility.sqf
+++ b/addons/x_lib/functions/diagnostics/fnc_checkConfigCompatibility.sqf
@@ -190,7 +190,7 @@ _text = "Checking faction has a direct relationship to CfgGroups entry";
 [_text] call _dump;
 
 
-_config = configfile >> "CfgGroups" >> _sideToText >> _faction;
+_config = _faction call ALiVE_fnc_configGetFactionGroups;
 
 if(count _config > 0) then {
     ["faction found in CfgGroups >> %2 >> %1",_faction,_sideToText] call _dump;
@@ -247,7 +247,7 @@ if(_groupToFactionMappingOK || _factionToGroupMappingOK && (count _factionGroups
 
     _cfgGroupFactionName = _splitEntry select 3;
 
-    _config = configfile >> "CfgGroups" >> _sideToText >> _cfgGroupFactionName;
+    _config = _cfgGroupFactionName call ALiVE_fnc_configGetFactionGroups;
 
     _standardCategories = ["Infantry","SpecOps","Support","Motorized","Mechanized","Armored","Air"];
 

--- a/addons/x_lib/functions/diagnostics/fnc_checkStaticDataMapping.sqf
+++ b/addons/x_lib/functions/diagnostics/fnc_checkStaticDataMapping.sqf
@@ -65,7 +65,7 @@ _faction = _this select 0;
 
     private ["_config","_factionOK","_displayName","_side","_sideToText","_spawnPosition"];
 
-    _config = configfile >> "CfgFactionClasses" >> _faction;
+    _config = _faction call ALiVE_fnc_configGetFactionClass;
     _factionOK = false;
 
     if(count _config > 0) then {

--- a/addons/x_lib/functions/diagnostics/fnc_factionCreateStaticData.sqf
+++ b/addons/x_lib/functions/diagnostics/fnc_factionCreateStaticData.sqf
@@ -121,7 +121,7 @@ private ["_factionToGroupMappingOK","_factionGroups"];
 
 _factionToGroupMappingOK = false;
 
-_config = configfile >> "CfgGroups" >> _sideToText >> _faction;
+_config = _faction call ALiVE_fnc_configGetFactionGroups;
 
 if(count _config > 0) then {
     _factionToGroupMappingOK = true;
@@ -154,7 +154,7 @@ _factionCategoryGroups = [] call ALIVE_fnc_hashCreate;
 
 if(_factionToGroupMappingOK) then {
 
-    _config = configfile >> "CfgGroups" >> _sideToText >> _faction;
+    _config = _faction call ALiVE_fnc_configGetFactionGroups;
 
     _arrayContent = "";
 

--- a/addons/x_lib/functions/diagnostics/fnc_factionCreateStaticData.sqf
+++ b/addons/x_lib/functions/diagnostics/fnc_factionCreateStaticData.sqf
@@ -104,7 +104,7 @@ private ["_factionOK","_text","_config","_displayName","_side","_sideToText"];
 
 _factionOK = false;
 
-_config = configfile >> "CfgFactionClasses" >> _faction;
+_config = _faction call ALiVE_fnc_configGetFactionClass;
 
 if(count _config > 0) then {
     _displayName = [_config >> "displayName"] call ALIVE_fnc_getConfigValue;

--- a/addons/x_lib/functions/function_list.txt
+++ b/addons/x_lib/functions/function_list.txt
@@ -63,6 +63,10 @@ composition
 
 config
 
+    ALiVE_fnc_configGetFactionClass
+    ALiVE_fnc_configGetFactionGroups
+    ALiVE_fnc_configGetFactions
+    ALiVE_fnc_configGetFactionUnitsByGroups
     ALiVE_fnc_configGetGroup
     ALiVE_fnc_configGetRandomGroup
     ALiVE_fnc_configGetVehicleClass
@@ -224,8 +228,6 @@ misc
     ALiVE_fnc_factionSide
     ALiVE_fnc_getDominantFaction
     ALiVE_fnc_getEnvironment
-    ALiVE_fnc_getFactionConfig
-    ALiVE_fnc_getFactions
     ALiVE_fnc_getPos
     ALiVE_fnc_getSideFactions
     ALiVE_fnc_isAbleToHost

--- a/addons/x_lib/functions/function_list.txt
+++ b/addons/x_lib/functions/function_list.txt
@@ -224,6 +224,8 @@ misc
     ALiVE_fnc_factionSide
     ALiVE_fnc_getDominantFaction
     ALiVE_fnc_getEnvironment
+    ALiVE_fnc_getFactionConfig
+    ALiVE_fnc_getFactions
     ALiVE_fnc_getPos
     ALiVE_fnc_getSideFactions
     ALiVE_fnc_isAbleToHost

--- a/addons/x_lib/functions/groups/fnc_groupFinder.sqf
+++ b/addons/x_lib/functions/groups/fnc_groupFinder.sqf
@@ -98,14 +98,14 @@ if(!isNil "_facs") then {
                 private ["_x"];
                 // Confirm there are units for this faction in this type
                 {
-                    _typex = count(configFile >> "CfgGroups" >> _s >> _x);
+                    _typex = count(_x call ALiVE_fnc_configGetFactionGroups);
                     for "_z" from 0 to _typex - 1 do {
 
-                        _type = configName((configFile >> "CfgGroups" >> _s >> _x) select _z);
+                        _type = configName((_x call ALiVE_fnc_configGetFactionGroups) select _z);
 
-                        _grpx = count(configFile >> "CfgGroups" >> _s >> _x >> _type);
+                        _grpx = count((_x call ALiVE_fnc_configGetFactionGroups) >> _type);
                         for "_y" from 1 to _grpx - 1 do {
-                             _entry = configName((configFile >> "CfgGroups" >> _s >> _x >> _type) select _y);
+                             _entry = configName(((_x call ALiVE_fnc_configGetFactionGroups) >> _type) select _y);
 
                             if (_entry find _find > -1) then {
                                 _grps pushback _entry;

--- a/addons/x_lib/functions/groups/fnc_groupFinder.sqf
+++ b/addons/x_lib/functions/groups/fnc_groupFinder.sqf
@@ -65,7 +65,7 @@ if (typeName _fac == "ANY" || {typeName _fac == "SIDE"}) then {
         };
 
         {
-                _fx = getNumber(configFile >> "CfgFactionClasses" >> _x >> "side");
+                _fx = getNumber((_x call ALiVE_fnc_configGetFactionClass) >> "side");
                 if (_fx == _sidex) then {
                         _facs pushback _x;
                 };

--- a/addons/x_lib/functions/groups/fnc_groupFinder.sqf
+++ b/addons/x_lib/functions/groups/fnc_groupFinder.sqf
@@ -39,7 +39,7 @@ _side = nil;
 
 // get all factions
 if(isNil QGVAR(ALLFACTIONS)) then {
-    GVAR(ALLFACTIONS) = [] call BIS_fnc_getFactions;
+    GVAR(ALLFACTIONS) = [] call ALiVE_fnc_configGetFactions;
 };
 
 // if default or selection by side

--- a/addons/x_lib/functions/groups/fnc_groupGenerateConfigData.sqf
+++ b/addons/x_lib/functions/groups/fnc_groupGenerateConfigData.sqf
@@ -23,12 +23,12 @@ Author:
 ARJay
 ---------------------------------------------------------------------------- */
 
-private ["_class","_findRecurse"];
+private ["_findRecurse"];
 
 ALIVE_groupConfig = [] call ALIVE_fnc_hashCreate;
 
 _findRecurse = {
-    private ["_root","_class","_path","_currentPath","_className"];
+    private ["_root","_path","_class","_currentPath","_className"];
 
     _root = (_this select 0);
     _path = +(_this select 1);
@@ -44,9 +44,10 @@ _findRecurse = {
             if(count _currentPath == 4) then {
                 // Hack to add support for factions
                 private "_faction";
-                _faction = configname ((configHierarchy _class) select 3);
+                _configHierarchy = configHierarchy _class;
+                _faction = configname (_configHierarchy select 3);
                 _className = format ["%1_%2", _faction, _className];
-                [ALIVE_groupConfig, _className, _currentPath] call ALIVE_fnc_hashSet;
+                [ALIVE_groupConfig, _className, [_configHierarchy select 0,_currentPath]] call ALIVE_fnc_hashSet;
             };
 
             [_class, _currentPath] call _findRecurse;
@@ -54,6 +55,5 @@ _findRecurse = {
     };
 };
 
-_class = (configFile >> "CfgGroups");
-
-[_class, []] call _findRecurse;
+[missionConfigFile >> "CfgGroups", []] call _findRecurse;
+[configFile >> "CfgGroups", []] call _findRecurse;

--- a/addons/x_lib/functions/groups/fnc_randomGroup.sqf
+++ b/addons/x_lib/functions/groups/fnc_randomGroup.sqf
@@ -1,8 +1,8 @@
 #include <\x\alive\addons\x_lib\script_component.hpp>
-SCRIPT(RandomGroup);
+SCRIPT(randomGroup);
 
 /* ----------------------------------------------------------------------------
-Function: ALIVE_fnc_spawnRandomGroup
+Function: ALIVE_fnc_randomGroup
 
 Description:
 Spawns a random group by config type and faction
@@ -17,7 +17,7 @@ created group
 
 Examples:
 (begin example)
-_grp = [getPos player,"Motorized","BLU_F"] call ALIVE_fnc_getRandomManNear;
+_grp = [getPos player,"Motorized","BLU_F"] call ALIVE_fnc_randomGroup;
 (end)
 
 See Also:
@@ -43,7 +43,7 @@ _facs = [];
 _side = nil;
 // get all factions
 if(isNil QGVAR(ALLFACTIONS)) then {
-    GVAR(ALLFACTIONS) = [] call BIS_fnc_getFactions;
+    GVAR(ALLFACTIONS) = [] call ALiVE_fnc_configGetFactions;
     //hint str CONVOY_ALLFACS;
 };
 // if default or selection by side
@@ -68,7 +68,7 @@ if(typeName _fac == "ANY" || typeName _fac == "SIDE") then {
         };
 
         {
-                _fx = getNumber(configFile >> "CfgFactionClasses" >> _x >> "side");
+                _fx = getNumber((_x call ALiVE_fnc_configGetFactionClass) >> "side");
                 if (_fx == _sidex) then {
                         _facs pushback _x;
                 };
@@ -100,7 +100,7 @@ if(!isNil "_facs") then {
                 private ["_x"];
                 // Confirm there are units for this faction in this type
                 {
-                        _grpx = count(configFile >> "CfgGroups" >> _s >> _x >> _type);
+                        _grpx = count((_x call ALiVE_fnc_configGetFactionGroups) >> _type);
                         for "_y" from 1 to _grpx - 1 do {
                                 if (!(_x in _facx)) then {
                                         _facx pushback _x;
@@ -120,7 +120,7 @@ if !(count _facs == 0) then {
     _fac = _facs select floor(random count _facs);
 
     if(isNil "_side") then {
-            _sidex = getNumber(configFile >> "CfgFactionClasses" >> _fac >> "side");
+            _sidex = getNumber((_fac call ALiVE_fnc_configGetFactionClass) >> "side");
             _side = nil;
             switch(_sidex) do {
                     case 0: {
@@ -141,18 +141,19 @@ if !(count _facs == 0) then {
 
     _grps = [];
     _s = switch(_side) do {
-            case resistance: {"Guerrila";};
+            case resistance: {"Indep";};
             case civilian: {"Civilian";};
             default {str _side;};
     };
 
     //hint str _s;
-    _grpx = count(configFile >> "CfgGroups" >> _s >> _fac >> _type);
+    _grpx = count((_fac call ALiVE_fnc_configGetFactionGroups) >> _type);
     for "_y" from 1 to _grpx - 1 do {
-            private "_cx";
-            _cx = configName ((configFile >> "CfgGroups" >> _s >> _fac >> _type) select _y);
+            private ["_facGroupCfg","_cx"];
+            _facGroupCfg = _fac call ALiVE_fnc_configGetFactionGroups;
+            _cx = configName ((_facGroupCfg >> _type) select _y);
             if ( {(_cx == _x)} count _nonConfigs == 0 ) then {
-                _grps pushback ((configFile >> "CfgGroups" >> _s >> _fac >> _type) select _y);
+                _grps pushback ((_facGroupCfg >> _type) select _y);
             };
     };
     //hint str _grps;

--- a/addons/x_lib/functions/groups/fnc_randomGroupByType.sqf
+++ b/addons/x_lib/functions/groups/fnc_randomGroupByType.sqf
@@ -1,8 +1,8 @@
 #include <\x\alive\addons\x_lib\script_component.hpp>
-SCRIPT(RandomGroupByType);
+SCRIPT(randomGroupByType);
 
 /* ----------------------------------------------------------------------------
-Function: ALIVE_fnc_spawnRandomGroupByType
+Function: ALIVE_fnc_randomGroupByType
 
 Description:
 Compiles a group of units/vehicles of type Infantry,Motorized,Mechanized,Armored,Air
@@ -18,7 +18,7 @@ created group
 
 Examples:
 (begin example)
-_grp = [getPos player,WEST,"Motorized","BLU_F"] call ALIVE_fnc_spawnRandomGroupByType;
+_grp = [getPos player,WEST,"Motorized","BLU_F"] call ALIVE_fnc_randomGroupByType;
 (end)
 
 See Also:
@@ -27,12 +27,9 @@ Author:
 Wolffy, Highhead
 ---------------------------------------------------------------------------- */
 
-private ["_logic","_pos","_side","_type","_i","_group","_facs","_unit","_leader","_unittype","_newpos"];
+private ["_logic","_i","_group","_unit","_leader","_unittype","_newpos"];
 
-_pos = _this select 0;
-_side = _this select 1;
-_type = _this select 2;
-_facs = _this select 3;
+params ["_pos","_side","_type","_facs"];
 
 _group = creategroup _side;
 
@@ -91,5 +88,5 @@ if (_type == "Man") then {
     };
 };
 
-["ALIVE-%1 group with name %4 and %2 units created at %3.", time, count units _group, _pos, _group] call ALiVE_fnc_Dump;
+//["ALIVE-%1 group with name %4 and %2 units created at %3.", time, count units _group, _pos, _group] call ALiVE_fnc_Dump;
 _group;

--- a/addons/x_lib/functions/misc/fnc_exportCfgVehicles.sqf
+++ b/addons/x_lib/functions/misc/fnc_exportCfgVehicles.sqf
@@ -162,7 +162,7 @@ switch tolower _mode do {
                         };
                         diag_log format["{'type':'%1',", _newType];
                         diag_log format["'side':'%1',", [_side] call ALiVE_fnc_sideNumberToText];
-                        diag_log format["'faction':'%1',", [(configFile >> "CfgFactionClasses" >> _faction >> "displayName")] call ALiVE_fnc_getConfigValue];
+                        diag_log format["'faction':'%1',", [((_faction call ALiVE_fnc_configGetFactionClass) >> "displayName")] call ALiVE_fnc_getConfigValue];
                         diag_log format["'class':'%1',", _class];
                         diag_log format["'name':'%1'},", _disName];
                     };

--- a/addons/x_lib/functions/misc/fnc_factionSide.sqf
+++ b/addons/x_lib/functions/misc/fnc_factionSide.sqf
@@ -29,7 +29,7 @@ nil
 ---------------------------------------------------------------------------- */
 private ["_side"];
 
-switch (getnumber(configfile >> "CfgFactionClasses" >> _this >> "side")) do {
+switch (getnumber((_this call ALiVE_fnc_configGetFactionClass) >> "side")) do {
     case 0 : {_side = EAST};
     case 1 : {_side = WEST};
     case 2 : {_side = RESISTANCE};

--- a/addons/x_lib/functions/misc/fnc_getFactionConfig.sqf
+++ b/addons/x_lib/functions/misc/fnc_getFactionConfig.sqf
@@ -1,0 +1,38 @@
+#include <\x\alive\addons\x_lib\script_component.hpp>
+SCRIPT(getFactionConfig);
+
+/* ----------------------------------------------------------------------------
+Function: ALiVE_fnc_getFactionConfig
+
+Description:
+Returns config path of given faction
+searches missionConfigFile before configFile
+
+Parameters:
+String - faction
+
+Returns:
+Config Path - path to faction config
+
+Examples:
+(begin example)
+_side = "OPF_F" call ALiVE_fnc_getFactionConfig;
+(end)
+
+See Also:
+- nil
+
+Author:
+SpyderBlack723
+
+Peer reviewed:
+nil
+---------------------------------------------------------------------------- */
+
+private "_path";
+
+_path = missionConfigFile >> "CfgFactionClasses" >> _this;
+
+if !(isClass _path) then {_path = configFile >> "CfgFactionClasses" >> _this};
+
+_path

--- a/addons/x_lib/functions/misc/fnc_getFactions.sqf
+++ b/addons/x_lib/functions/misc/fnc_getFactions.sqf
@@ -1,0 +1,46 @@
+#include <\x\alive\addons\x_lib\script_component.hpp>
+SCRIPT(getFactions);
+
+/* ----------------------------------------------------------------------------
+Function: ALiVE_fnc_getFactions
+
+Description:
+Returns all config factions
+checks configFile and missionConfigFile
+
+Parameters:
+None
+
+Returns:
+Array - All factions
+
+Examples:
+(begin example)
+_side = [] call ALiVE_fnc_getFactions;
+(end)
+
+See Also:
+- nil
+
+Author:
+SpyderBlack723
+
+Peer reviewed:
+nil
+---------------------------------------------------------------------------- */
+
+private _faction = [];
+
+private _configPaths = [
+    missionConfigFile,
+    configFile
+];
+
+{
+    _configPath = _x;
+
+    for "_i" from 0 to (count _configPath - 1) do {
+        _faction = _configPath select _i;
+
+    };
+} foreach _configPaths;

--- a/addons/x_lib/functions/misc/fnc_getFactions.sqf
+++ b/addons/x_lib/functions/misc/fnc_getFactions.sqf
@@ -29,7 +29,7 @@ Peer reviewed:
 nil
 ---------------------------------------------------------------------------- */
 
-private _faction = [];
+private _factions = [];
 
 private _configPaths = [
     missionConfigFile,
@@ -42,5 +42,10 @@ private _configPaths = [
     for "_i" from 0 to (count _configPath - 1) do {
         _faction = _configPath select _i;
 
+        if (isClass _faction) then {
+            _factions pushback _faction;
+        };
     };
 } foreach _configPaths;
+
+_factions

--- a/addons/x_lib/functions/misc/fnc_getFactions.sqf
+++ b/addons/x_lib/functions/misc/fnc_getFactions.sqf
@@ -32,8 +32,8 @@ nil
 private _factions = [];
 
 private _configPaths = [
-    missionConfigFile,
-    configFile
+    missionConfigFile >> "CfgFactionClasses",
+    configFile >> "CfgFactionClasses"
 ];
 
 {
@@ -43,7 +43,7 @@ private _configPaths = [
         _faction = _configPath select _i;
 
         if (isClass _faction) then {
-            _factions pushback _faction;
+            _factions pushback (configname _faction);
         };
     };
 } foreach _configPaths;

--- a/addons/x_lib/functions/misc/fnc_getSideFactions.sqf
+++ b/addons/x_lib/functions/misc/fnc_getSideFactions.sqf
@@ -27,24 +27,30 @@ Tupolov
 Peer reviewed:
 nil
 ---------------------------------------------------------------------------- */
-private ["_factions","_side"];
 
-_side = _this;
+private ["_side","_factions","_configPaths","_configPath"];
 
+_sideNum = [_this] call ALIVE_fnc_sideTextToNumber;
 _factions = [];
 
-_factionClasses = (configFile >> "CfgFactionClasses");
+_configPaths = [
+    missionConfigFile >> "CfgFactionClasses",
+    configFile >> "CfgFactionClasses"
+];
 
-for "_i" from 1 to (count _factionClasses - 1) do {
-    private ["_element","_classSide"];
-    _element = _factionClasses select _i;
-    if (isclass _element) then {
-        _classSide = getnumber(_element >> "side");
-        if (_classSide == [_side] call ALIVE_fnc_sideTextToNumber) then {
-            _factions = _factions + [configname _element];
+{
+    _configPath = _x;
+
+    for "_i" from 0 to (count _configPath - 1) do {
+
+        private _element = _configPath select _i;
+
+        if (isclass _element) then {
+            if ((getnumber(_element >> "side")) == _sideNum) then {
+                _factions pushbackunique (configname _element);
+            };
         };
     };
-};
-
+} foreach _configPaths;
 
 _factions

--- a/addons/x_lib/functions/vehicles/fnc_findVehicleType.sqf
+++ b/addons/x_lib/functions/vehicles/fnc_findVehicleType.sqf
@@ -25,7 +25,7 @@ Author:
 Wolffy.au
 ---------------------------------------------------------------------------- */
 
-private ["_id","_fac","_allvehs","_vehx","_fx","_cx","_cargoslots","_type","_noWeapons","_nonconfigs","_nonsims","_err"];
+private ["_id","_fac","_allvehs","_vehx","_cx","_cargoslots","_type","_noWeapons","_nonconfigs","_nonsims","_facUnits","_err"];
 
 PARAMS_1(_cargoslots);
 _err = "cargo slots not valid";
@@ -53,6 +53,13 @@ if !(isnil {call compile _searchBag}) exitwith {call compile _searchBag};
 _nonConfigs = ["StaticWeapon","CruiseMissile1","CruiseMissile2","Chukar_EP1","Chukar","Chukar_AllwaysEnemy_EP1"];
 _nonSims = ["parachute","house"];
 
+if (typename _fac == "STRING") then {
+    _facUnits = _fac call ALiVE_fnc_configGetFactionUnitsByGroups;
+} else {
+    _facUnits = [];
+    {_facUnits append (_fac call ALiVE_fnc_configGetFactionUnitsByGroups)} foreach _fac;
+};
+
 _allvehs = [];
 for "_y" from 1 to count(configFile >> "CfgVehicles") - 1 do {
     _vehx = (configFile >> "CfgVehicles") select _y;
@@ -62,44 +69,20 @@ for "_y" from 1 to count(configFile >> "CfgVehicles") - 1 do {
             if ({(_cx isKindOf _x)} count _nonconfigs == 0) then {
                 if (getNumber(_vehx >> "TransportSoldier") >= _cargoslots) then {
                     if (!isNil "_fac") then {
-                        _fx = getText(_vehx >> "faction");
-                        switch(toUpper(typeName _fac)) do {
-                            case "STRING": {
-                                if(_fx == _fac) then {
-                                    if (!isnil "_type") then {
-                                        if (_cx isKindOf _type) then {
-                                            if (_noWeapons) then {
-                                                if ([_cx] call ALiVE_fnc_isArmed) then {_allvehs pushback _cx};
-                                            } else {
-                                                _allvehs pushback _cx;
-                                            };
-                                        };
+                        if (_cx in _facUnits) then {
+                            if (!isnil "_type") then {
+                                if (_cx isKindOf _type) then {
+                                    if (_noWeapons) then {
+                                        if ([_cx] call ALiVE_fnc_isArmed) then {_allvehs pushback _cx};
                                     } else {
-                                        if (_noWeapons) then {
-                                            if ([_cx] call ALiVE_fnc_isArmed) then {_allvehs pushback _cx};
-                                        } else {
-                                            _allvehs pushback _cx;
-                                        };
+                                        _allvehs pushback _cx;
                                     };
                                 };
-                            };
-                            case "ARRAY": {
-                                if(_fx in _fac) then {
-                                    if (!isnil "_type") then {
-                                        if (_cx isKindOf _type) then {
-                                            if (_noWeapons) then {
-                                                if ([_cx] call ALiVE_fnc_isArmed) then {_allvehs pushback _cx};
-                                            } else {
-                                                _allvehs pushback _cx;
-                                            };
-                                        };
-                                    } else {
-                                        if (_noWeapons) then {
-                                            if ([_cx] call ALiVE_fnc_isArmed) then {_allvehs pushback _cx};
-                                        } else {
-                                            _allvehs pushback _cx;
-                                        };
-                                    };
+                            } else {
+                                if (_noWeapons) then {
+                                    if ([_cx] call ALiVE_fnc_isArmed) then {_allvehs pushback _cx};
+                                } else {
+                                    _allvehs pushback _cx;
                                 };
                             };
                         };
@@ -110,6 +93,6 @@ for "_y" from 1 to count(configFile >> "CfgVehicles") - 1 do {
     };
 };
 
-call compile (format["%1 = %2",_searchbag,_allvehs]);
+//call compile (format["%1 = %2",_searchbag,_allvehs]);
 
 _allvehs;


### PR DESCRIPTION
This pull request will allow mission makers to overwrite or create brand new factions/groups in their mission's description.ext file

Here's an example description.ext

```
class CfgFactionClasses {

    class Spyder_Faction {
        displayName = "Spyder's Faction";
        flag = "\a3\Data_F_Exp\Flags\flag_GEN_CO.paa";
        icon = "\a3\Data_F_Exp\FactionIcons\icon_GEN_CA.paa";
        priority = 5;
        side = 1;
    };

};



class CfgGroups {

    class Spyder_Faction_groupBase {
        name = "groupbase";
        side = 1;
        faction = "Spyder_Faction";
        rarityGroup = 0.5;
    };

    class WEST {

        class Spyder_Faction {

            class Infantry {

                class inf_light_patrol : Spyder_Faction_groupBase {
                    name = "Some Awesome Group";

                    class Unit0 {
                        position[] = {0,0,0};
                        rank = "SERGEANT";
                        side = 1;
                        vehicle = "B_GEN_Commander_F";
                    };

                    class Unit1 {
                        position[] = {5,-5,0};
                        rank = "CORPORAL";
                        side = 1;
                        vehicle = "B_GEN_Soldier_F";
                    };

                };

            };

            class Motorized {

                class motorized_light_patrol : Spyder_Faction_groupBase {
                    name = "Slightly less awesome group";

                    class Unit0 {
                        position[] = {0,0,0};
                        rank = "SERGEANT";
                        side = 1;
                        vehicle = "B_GEN_Offroad_01_gen_F";
                    };

                    class Unit1 {
                        position[] = {5,-5,0};
                        rank = "CORPORAL";
                        side = 1;
                        vehicle = "B_GEN_Soldier_F";
                    };

                };

            };

        };

    };

};
```

Notes:
 - If using Player Resupply with a completely new faction, you must set the Player Resupply "Restrict To" option to "Side" in order for players to be able to access the new faction's assets.