### PR TITLE
Added new macro 'PATHTO_FUNC'

### DIFF
--- a/addons/amb_civ_command/CfgFunctions.hpp
+++ b/addons/amb_civ_command/CfgFunctions.hpp
@@ -3,102 +3,102 @@ class cfgFunctions {
         class COMPONENT {
             class civCommandRouter {
                 description = "civCommandRouter";
-                file = "\x\alive\addons\amb_civ_command\fnc_civCommandRouter.sqf";
+                file = PATHTO_FUNC(civCommandRouter);
                 recompile = RECOMPILE;
             };
             class selectCivilianCommand {
                 description = "Select a random civilian command from a list of available commands";
-                file = "\x\alive\addons\amb_civ_command\fnc_selectCivilianCommand.sqf";
+                file = PATHTO_FUNC(selectCivilianCommand);
                 recompile = RECOMPILE;
             };
             class cc_randomMovement {
                 description = "Random movement within a given radius";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_randomMovement.sqf";
+                file = PATHTO_FUNC(cc_randomMovement);
                 recompile = RECOMPILE;
             };
             class cc_idle {
                 description = "Idle command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_idle.sqf";
+                file = PATHTO_FUNC(cc_idle);
                 recompile = RECOMPILE;
             };
             class cc_housework {
                 description = "Housework command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_housework.sqf";
+                file = PATHTO_FUNC(cc_housework);
                 recompile = RECOMPILE;
             };
             class cc_sleep {
                 description = "Sleep command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_sleep.sqf";
+                file = PATHTO_FUNC(cc_sleep);
                 recompile = RECOMPILE;
             };
             class cc_campfire {
                 description = "Campfire command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_campfire.sqf";
+                file = PATHTO_FUNC(cc_campfire);
                 recompile = RECOMPILE;
             };
             class cc_observe {
                 description = "Observe command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_observe.sqf";
+                file = PATHTO_FUNC(cc_observe);
                 recompile = RECOMPILE;
             };
             class cc_suicide {
                 description = "Suicide command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_suicide.sqf";
+                file = PATHTO_FUNC(cc_suicide);
                 recompile = RECOMPILE;
             };
             class cc_rogue {
                 description = "Rogue command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_rogue.sqf";
+                file = PATHTO_FUNC(cc_rogue);
                 recompile = RECOMPILE;
             };
             class cc_journey {
                 description = "Random journey command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_journey.sqf";
+                file = PATHTO_FUNC(cc_journey);
                 recompile = RECOMPILE;
             };
             class cc_driveTo {
                 description = "Drive to command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_driveTo.sqf";
+                file = PATHTO_FUNC(cc_driveTo);
                 recompile = RECOMPILE;
             };
             class cc_startMeeting {
                 description = "Start meeting command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_startMeeting.sqf";
+                file = PATHTO_FUNC(cc_startMeeting);
                 recompile = RECOMPILE;
             };
             class cc_joinMeeting {
                 description = "Join meeting command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_joinMeeting.sqf";
+                file = PATHTO_FUNC(cc_joinMeeting);
                 recompile = RECOMPILE;
             };
             class cc_startGathering {
                 description = "Start gathering command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_startGathering.sqf";
+                file = PATHTO_FUNC(cc_startGathering);
                 recompile = RECOMPILE;
             };
             class cc_joinGathering {
                 description = "Join gathering command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_joinGathering.sqf";
+                file = PATHTO_FUNC(cc_joinGathering);
                 recompile = RECOMPILE;
             };
             class cc_suicideTarget {
                 description = "Targeted Suicide command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_suicideTarget.sqf";
+                file = PATHTO_FUNC(cc_suicideTarget);
                 recompile = RECOMPILE;
             };
             class cc_rogueTarget {
                 description = "Targeted Rogue command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_rogueTarget.sqf";
+                file = PATHTO_FUNC(cc_rogueTarget);
                 recompile = RECOMPILE;
             };
             class cc_getWeapons {
                 description = "Get weapons from depot command";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_getWeapons.sqf";
+                file = PATHTO_FUNC(cc_getWeapons);
                 recompile = RECOMPILE;
             };
             class cc_sabotage {
                 description = "Sabotage a building";
-                file = "\x\alive\addons\amb_civ_command\fnc_cc_sabotage.sqf";
+                file = PATHTO_FUNC(cc_sabotage);
                 recompile = RECOMPILE;
             };
 

--- a/addons/amb_civ_command/CfgFunctions.hpp
+++ b/addons/amb_civ_command/CfgFunctions.hpp
@@ -1,107 +1,26 @@
 class cfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class civCommandRouter {
-                description = "civCommandRouter";
-                file = PATHTO_FUNC(civCommandRouter);
-                recompile = RECOMPILE;
-            };
-            class selectCivilianCommand {
-                description = "Select a random civilian command from a list of available commands";
-                file = PATHTO_FUNC(selectCivilianCommand);
-                recompile = RECOMPILE;
-            };
-            class cc_randomMovement {
-                description = "Random movement within a given radius";
-                file = PATHTO_FUNC(cc_randomMovement);
-                recompile = RECOMPILE;
-            };
-            class cc_idle {
-                description = "Idle command";
-                file = PATHTO_FUNC(cc_idle);
-                recompile = RECOMPILE;
-            };
-            class cc_housework {
-                description = "Housework command";
-                file = PATHTO_FUNC(cc_housework);
-                recompile = RECOMPILE;
-            };
-            class cc_sleep {
-                description = "Sleep command";
-                file = PATHTO_FUNC(cc_sleep);
-                recompile = RECOMPILE;
-            };
-            class cc_campfire {
-                description = "Campfire command";
-                file = PATHTO_FUNC(cc_campfire);
-                recompile = RECOMPILE;
-            };
-            class cc_observe {
-                description = "Observe command";
-                file = PATHTO_FUNC(cc_observe);
-                recompile = RECOMPILE;
-            };
-            class cc_suicide {
-                description = "Suicide command";
-                file = PATHTO_FUNC(cc_suicide);
-                recompile = RECOMPILE;
-            };
-            class cc_rogue {
-                description = "Rogue command";
-                file = PATHTO_FUNC(cc_rogue);
-                recompile = RECOMPILE;
-            };
-            class cc_journey {
-                description = "Random journey command";
-                file = PATHTO_FUNC(cc_journey);
-                recompile = RECOMPILE;
-            };
-            class cc_driveTo {
-                description = "Drive to command";
-                file = PATHTO_FUNC(cc_driveTo);
-                recompile = RECOMPILE;
-            };
-            class cc_startMeeting {
-                description = "Start meeting command";
-                file = PATHTO_FUNC(cc_startMeeting);
-                recompile = RECOMPILE;
-            };
-            class cc_joinMeeting {
-                description = "Join meeting command";
-                file = PATHTO_FUNC(cc_joinMeeting);
-                recompile = RECOMPILE;
-            };
-            class cc_startGathering {
-                description = "Start gathering command";
-                file = PATHTO_FUNC(cc_startGathering);
-                recompile = RECOMPILE;
-            };
-            class cc_joinGathering {
-                description = "Join gathering command";
-                file = PATHTO_FUNC(cc_joinGathering);
-                recompile = RECOMPILE;
-            };
-            class cc_suicideTarget {
-                description = "Targeted Suicide command";
-                file = PATHTO_FUNC(cc_suicideTarget);
-                recompile = RECOMPILE;
-            };
-            class cc_rogueTarget {
-                description = "Targeted Rogue command";
-                file = PATHTO_FUNC(cc_rogueTarget);
-                recompile = RECOMPILE;
-            };
-            class cc_getWeapons {
-                description = "Get weapons from depot command";
-                file = PATHTO_FUNC(cc_getWeapons);
-                recompile = RECOMPILE;
-            };
-            class cc_sabotage {
-                description = "Sabotage a building";
-                file = PATHTO_FUNC(cc_sabotage);
-                recompile = RECOMPILE;
-            };
-
-        };
-    };
+						FUNC_FILEPATH(civCommandRouter,"civCommandRouter");
+						FUNC_FILEPATH(selectCivilianCommand,"Select a random civilian command from a list of available commands");
+						FUNC_FILEPATH(cc_randomMovement,"Random movement within a given radius");
+						FUNC_FILEPATH(cc_idle,"Idle command");
+						FUNC_FILEPATH(cc_housework,"Housework command");
+						FUNC_FILEPATH(cc_sleep,"Sleep command");
+						FUNC_FILEPATH(cc_campfire,"Campfire command");
+						FUNC_FILEPATH(cc_observe,"Observe command");
+						FUNC_FILEPATH(cc_suicide,"Suicide command");
+						FUNC_FILEPATH(cc_rogue,"Rogue command");
+						FUNC_FILEPATH(cc_journey,"Random journey command");
+						FUNC_FILEPATH(cc_driveTo,"Drive to command");
+						FUNC_FILEPATH(cc_startMeeting,"Start meeting command");
+						FUNC_FILEPATH(cc_joinMeeting,"Join meeting command");
+						FUNC_FILEPATH(cc_startGathering,"Start gathering command");
+						FUNC_FILEPATH(cc_joinGathering,"Join gathering command");
+						FUNC_FILEPATH(cc_suicideTarget,"Targeted Suicide command");
+						FUNC_FILEPATH(cc_rogueTarget,"Targeted Rogue command");
+						FUNC_FILEPATH(cc_getWeapons,"Get weapons from depot command");
+						FUNC_FILEPATH(cc_sabotage,"Sabotage a building");
+				};
+		};
 };

--- a/addons/amb_civ_placement/CfgFunctions.hpp
+++ b/addons/amb_civ_placement/CfgFunctions.hpp
@@ -3,12 +3,12 @@ class cfgFunctions {
                 class COMPONENT {
                         class AMBCP {
                                 description = "The main class";
-                                file = "\x\alive\addons\amb_civ_placement\fnc_AMBCP.sqf";
+                                file = PATHTO_FUNC(AMBCP);
                                 recompile = RECOMPILE;
                         };
                         class AMBCPInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\amb_civ_placement\fnc_AMBCPInit.sqf";
+                                file = PATHTO_FUNC(AMBCPInit);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/amb_civ_placement/CfgFunctions.hpp
+++ b/addons/amb_civ_placement/CfgFunctions.hpp
@@ -1,16 +1,8 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class AMBCP {
-                                description = "The main class";
-                                file = PATHTO_FUNC(AMBCP);
-                                recompile = RECOMPILE;
-                        };
-                        class AMBCPInit {
-                                description = "The module initialisation function";
-                                file = PATHTO_FUNC(AMBCPInit);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(AMBCP,"The main class");
+												FUNC_FILEPATH(AMBCPInit,"The module initialisation function");
+								};
+				};
 };

--- a/addons/amb_civ_population/CfgFunctions.hpp
+++ b/addons/amb_civ_population/CfgFunctions.hpp
@@ -3,102 +3,102 @@ class cfgFunctions {
         class COMPONENT {
             class civilianPopulationSystemInit {
                 description = "civilianPopulationSystemInit";
-                file = "\x\alive\addons\amb_civ_population\fnc_civilianPopulationSystemInit.sqf";
+                file = PATHTO_FUNC(civilianPopulationSystemInit);
                 recompile = RECOMPILE;
             };
             class civilianPopulationSystem {
                 description = "civilianPopulationSystem";
-                file = "\x\alive\addons\amb_civ_population\fnc_civilianPopulationSystem.sqf";
+                file = PATHTO_FUNC(civilianPopulationSystem);
                 recompile = RECOMPILE;
             };
             class civilianPopulationMenuDef {
                 description = "civilianPopulationMenuDef";
-                file = "\x\alive\addons\amb_civ_population\fnc_civilianPopulationMenuDef.sqf";
+                file = PATHTO_FUNC(civilianPopulationMenuDef);
                 recompile = RECOMPILE;
             };
             class clusterHandler {
                 description = "clusterHandler";
-                file = "\x\alive\addons\amb_civ_population\fnc_clusterHandler.sqf";
+                file = PATHTO_FUNC(clusterHandler);
                 recompile = RECOMPILE;
             };
             class civilianAgent {
                 description = "civilianAgent";
-                file = "\x\alive\addons\amb_civ_population\fnc_civilianAgent.sqf";
+                file = PATHTO_FUNC(civilianAgent);
                 recompile = RECOMPILE;
             };
             class civilianVehicle {
                 description = "civilianVehicle";
-                file = "\x\alive\addons\amb_civ_population\fnc_civilianVehicle.sqf";
+                file = PATHTO_FUNC(civilianVehicle);
                 recompile = RECOMPILE;
             };
             class createCivilianVehicle {
                 description = "createCivilianVehicle";
-                file = "\x\alive\addons\amb_civ_population\fnc_createCivilianVehicle.sqf";
+                file = PATHTO_FUNC(createCivilianVehicle);
                 recompile = RECOMPILE;
             };
             class agentKilledEventHandler {
                 description = "agentKilledEventHandler";
-                file = "\x\alive\addons\amb_civ_population\fnc_agentKilledEventHandler.sqf";
+                file = PATHTO_FUNC(agentKilledEventHandler);
                 recompile = RECOMPILE;
             };
             class agentGetInEventHandler {
                 description = "agentGetInEventHandler";
-                file = "\x\alive\addons\amb_civ_population\fnc_agentGetInEventHandler.sqf";
+                file = PATHTO_FUNC(agentGetInEventHandler);
                 recompile = RECOMPILE;
             };
             class agentHandler {
                 description = "agentHandler";
-                file = "\x\alive\addons\amb_civ_population\fnc_agentHandler.sqf";
+                file = PATHTO_FUNC(agentHandler);
                 recompile = RECOMPILE;
             };
             class addAmbientRoomMusic {
                 description = "addAmbientRoomMusic";
-                file = "\x\alive\addons\amb_civ_population\fnc_addAmbientRoomMusic.sqf";
+                file = PATHTO_FUNC(addAmbientRoomMusic);
                 recompile = RECOMPILE;
             };
             class clientAddAmbientRoomMusic {
                 description = "clientAddAmbientRoomMusic";
-                file = "\x\alive\addons\amb_civ_population\fnc_clientAddAmbientRoomMusic.sqf";
+                file = PATHTO_FUNC(clientAddAmbientRoomMusic);
                 recompile = RECOMPILE;
             };
             class addAmbientRoomLight {
                 description = "addAmbientRoomLight";
-                file = "\x\alive\addons\amb_civ_population\fnc_addAmbientRoomLight.sqf";
+                file = PATHTO_FUNC(addAmbientRoomLight);
                 recompile = RECOMPILE;
             };
             class clientAddAmbientRoomLight {
                 description = "clientAddAmbientRoomLight";
-                file = "\x\alive\addons\amb_civ_population\fnc_clientAddAmbientRoomLight.sqf";
+                file = PATHTO_FUNC(clientAddAmbientRoomLight);
                 recompile = RECOMPILE;
             };
             class agentSelectSpeedMode {
                 description = "agentSelectSpeedMode";
-                file = "\x\alive\addons\amb_civ_population\fnc_agentSelectSpeedMode.sqf";
+                file = PATHTO_FUNC(agentSelectSpeedMode);
                 recompile = RECOMPILE;
             };
             class getAgentEnemyNear {
                 description = "getAgentEnemyNear";
-                file = "\x\alive\addons\amb_civ_population\fnc_getAgentEnemyNear.sqf";
+                file = PATHTO_FUNC(getAgentEnemyNear);
                 recompile = RECOMPILE;
             };
             class getGlobalPosture {
                 description = "getGlobalPosture";
-                file = "\x\alive\addons\amb_civ_population\fnc_getGlobalPosture.sqf";
+                file = PATHTO_FUNC(getGlobalPosture);
                 recompile = RECOMPILE;
             };
             class getAgentData {
                 description = "getAgentData";
-                file = "\x\alive\addons\amb_civ_population\fnc_getAgentData.sqf";
+                file = PATHTO_FUNC(getAgentData);
                 recompile = RECOMPILE;
             };
             class addCivilianActions {
                 description = "addCivilianActions";
-                file = "\x\alive\addons\amb_civ_population\fnc_addCivilianActions.sqf";
+                file = PATHTO_FUNC(addCivilianActions);
                 recompile = RECOMPILE;
             };
             class selectRoleAction {
                 description = "addCivilianActions";
-                file = "\x\alive\addons\amb_civ_population\fnc_selectRoleAction.sqf";
+                file = PATHTO_FUNC(selectRoleAction);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/amb_civ_population/CfgFunctions.hpp
+++ b/addons/amb_civ_population/CfgFunctions.hpp
@@ -1,106 +1,26 @@
 class cfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class civilianPopulationSystemInit {
-                description = "civilianPopulationSystemInit";
-                file = PATHTO_FUNC(civilianPopulationSystemInit);
-                recompile = RECOMPILE;
-            };
-            class civilianPopulationSystem {
-                description = "civilianPopulationSystem";
-                file = PATHTO_FUNC(civilianPopulationSystem);
-                recompile = RECOMPILE;
-            };
-            class civilianPopulationMenuDef {
-                description = "civilianPopulationMenuDef";
-                file = PATHTO_FUNC(civilianPopulationMenuDef);
-                recompile = RECOMPILE;
-            };
-            class clusterHandler {
-                description = "clusterHandler";
-                file = PATHTO_FUNC(clusterHandler);
-                recompile = RECOMPILE;
-            };
-            class civilianAgent {
-                description = "civilianAgent";
-                file = PATHTO_FUNC(civilianAgent);
-                recompile = RECOMPILE;
-            };
-            class civilianVehicle {
-                description = "civilianVehicle";
-                file = PATHTO_FUNC(civilianVehicle);
-                recompile = RECOMPILE;
-            };
-            class createCivilianVehicle {
-                description = "createCivilianVehicle";
-                file = PATHTO_FUNC(createCivilianVehicle);
-                recompile = RECOMPILE;
-            };
-            class agentKilledEventHandler {
-                description = "agentKilledEventHandler";
-                file = PATHTO_FUNC(agentKilledEventHandler);
-                recompile = RECOMPILE;
-            };
-            class agentGetInEventHandler {
-                description = "agentGetInEventHandler";
-                file = PATHTO_FUNC(agentGetInEventHandler);
-                recompile = RECOMPILE;
-            };
-            class agentHandler {
-                description = "agentHandler";
-                file = PATHTO_FUNC(agentHandler);
-                recompile = RECOMPILE;
-            };
-            class addAmbientRoomMusic {
-                description = "addAmbientRoomMusic";
-                file = PATHTO_FUNC(addAmbientRoomMusic);
-                recompile = RECOMPILE;
-            };
-            class clientAddAmbientRoomMusic {
-                description = "clientAddAmbientRoomMusic";
-                file = PATHTO_FUNC(clientAddAmbientRoomMusic);
-                recompile = RECOMPILE;
-            };
-            class addAmbientRoomLight {
-                description = "addAmbientRoomLight";
-                file = PATHTO_FUNC(addAmbientRoomLight);
-                recompile = RECOMPILE;
-            };
-            class clientAddAmbientRoomLight {
-                description = "clientAddAmbientRoomLight";
-                file = PATHTO_FUNC(clientAddAmbientRoomLight);
-                recompile = RECOMPILE;
-            };
-            class agentSelectSpeedMode {
-                description = "agentSelectSpeedMode";
-                file = PATHTO_FUNC(agentSelectSpeedMode);
-                recompile = RECOMPILE;
-            };
-            class getAgentEnemyNear {
-                description = "getAgentEnemyNear";
-                file = PATHTO_FUNC(getAgentEnemyNear);
-                recompile = RECOMPILE;
-            };
-            class getGlobalPosture {
-                description = "getGlobalPosture";
-                file = PATHTO_FUNC(getGlobalPosture);
-                recompile = RECOMPILE;
-            };
-            class getAgentData {
-                description = "getAgentData";
-                file = PATHTO_FUNC(getAgentData);
-                recompile = RECOMPILE;
-            };
-            class addCivilianActions {
-                description = "addCivilianActions";
-                file = PATHTO_FUNC(addCivilianActions);
-                recompile = RECOMPILE;
-            };
-            class selectRoleAction {
-                description = "addCivilianActions";
-                file = PATHTO_FUNC(selectRoleAction);
-                recompile = RECOMPILE;
-            };
-        };
-    };
+						FUNC_FILEPATH(civilianPopulationSystemInit,"civilianPopulationSystemInit");
+						FUNC_FILEPATH(civilianPopulationSystem,"civilianPopulationSystem");
+						FUNC_FILEPATH(civilianPopulationMenuDef,"civilianPopulationMenuDef");
+						FUNC_FILEPATH(clusterHandler,"clusterHandler");
+						FUNC_FILEPATH(civilianAgent,"civilianAgent");
+						FUNC_FILEPATH(civilianVehicle,"civilianVehicle");
+						FUNC_FILEPATH(createCivilianVehicle,"createCivilianVehicle");
+						FUNC_FILEPATH(agentKilledEventHandler,"agentKilledEventHandler");
+						FUNC_FILEPATH(agentGetInEventHandler,"agentGetInEventHandler");
+						FUNC_FILEPATH(agentHandler,"agentHandler");
+						FUNC_FILEPATH(addAmbientRoomMusic,"addAmbientRoomMusic");
+						FUNC_FILEPATH(clientAddAmbientRoomMusic,"clientAddAmbientRoomMusic");
+						FUNC_FILEPATH(addAmbientRoomLight,"addAmbientRoomLight");
+						FUNC_FILEPATH(clientAddAmbientRoomLight,"clientAddAmbientRoomLight");
+						FUNC_FILEPATH(agentSelectSpeedMode,"agentSelectSpeedMode");
+						FUNC_FILEPATH(getAgentEnemyNear,"getAgentEnemyNear");
+						FUNC_FILEPATH(getGlobalPosture,"getGlobalPosture");
+						FUNC_FILEPATH(getAgentData,"getAgentData");
+						FUNC_FILEPATH(addCivilianActions,"addCivilianActions");
+						FUNC_FILEPATH(selectRoleAction,"addCivilianActions");
+				};
+		};
 };

--- a/addons/civ_placement/CfgFunctions.hpp
+++ b/addons/civ_placement/CfgFunctions.hpp
@@ -3,27 +3,27 @@ class cfgFunctions {
                 class COMPONENT {
                         class CP {
                                 description = "The main class";
-                                file = "\x\alive\addons\civ_placement\fnc_CP.sqf";
+                                file = PATHTO_FUNC(CP);
                                 recompile = RECOMPILE;
                         };
                         class CPInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\civ_placement\fnc_CPInit.sqf";
+                                file = PATHTO_FUNC(CPInit);
                                 recompile = RECOMPILE;
                         };
             class civClusterGeneration {
                                 description = "Generates static cluster output";
-                                file = "\x\alive\addons\civ_placement\fnc_civClusterGeneration.sqf";
+                                file = PATHTO_FUNC(civClusterGeneration);
                                 recompile = RECOMPILE;
                         };
                         class auto_civClusterGeneration {
                                 description = "Auto generates static cluster output";
-                                file = "\x\alive\addons\civ_placement\fnc_auto_civClusterGeneration.sqf";
+                                file = PATHTO_FUNC(auto_civClusterGeneration);
                                 recompile = RECOMPILE;
                         };
                         class createRoadblock {
                                 description = "Create a road block";
-                                file = "\x\alive\addons\civ_placement\fnc_createRoadblock.sqf";
+                                file = PATHTO_FUNC(createRoadblock);
                                 recompile = 1;
                         };
                 };

--- a/addons/civ_placement/CfgFunctions.hpp
+++ b/addons/civ_placement/CfgFunctions.hpp
@@ -1,26 +1,10 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class CP {
-                                description = "The main class";
-                                file = PATHTO_FUNC(CP);
-                                recompile = RECOMPILE;
-                        };
-                        class CPInit {
-                                description = "The module initialisation function";
-                                file = PATHTO_FUNC(CPInit);
-                                recompile = RECOMPILE;
-                        };
-            class civClusterGeneration {
-                                description = "Generates static cluster output";
-                                file = PATHTO_FUNC(civClusterGeneration);
-                                recompile = RECOMPILE;
-                        };
-                        class auto_civClusterGeneration {
-                                description = "Auto generates static cluster output";
-                                file = PATHTO_FUNC(auto_civClusterGeneration);
-                                recompile = RECOMPILE;
-                        };
+												FUNC_FILEPATH(CP,"The main class");
+												FUNC_FILEPATH(CPInit,"The module initialisation function");
+						            FUNC_FILEPATH(civClusterGeneration,"Generates static cluster output");
+												FUNC_FILEPATH(auto_civClusterGeneration,"Auto generates static cluster output");
                         class createRoadblock {
                                 description = "Create a road block";
                                 file = PATHTO_FUNC(createRoadblock);

--- a/addons/fnc_analysis/CfgFunctions.hpp
+++ b/addons/fnc_analysis/CfgFunctions.hpp
@@ -3,202 +3,202 @@ class cfgFunctions {
         class COMPONENT {
             class sector {
                 description = "sector";
-                file = "\x\alive\addons\fnc_analysis\fnc_sector.sqf";
+                file = PATHTO_FUNC(sector);
                 recompile = RECOMPILE;
             };
             class sectorGrid {
                 description = "sectorGrid";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorGrid.sqf";
+                file = PATHTO_FUNC(sectorGrid);
                 recompile = RECOMPILE;
             };
             class sectorSubGrid {
                 description = "sectorSubGrid";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorSubGrid.sqf";
+                file = PATHTO_FUNC(sectorSubGrid);
                 recompile = RECOMPILE;
             };
             class sectorPlot {
                 description = "sectorPlot";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorPlot.sqf";
+                file = PATHTO_FUNC(sectorPlot);
                 recompile = RECOMPILE;
             };
             class plotSectors {
                 description = "plotSectors";
-                file = "\x\alive\addons\fnc_analysis\fnc_plotSectors.sqf";
+                file = PATHTO_FUNC(plotSectors);
                 recompile = RECOMPILE;
             };
             class gridAnalysisProfileEntity {
                 description = "gridAnalysisProfileEntity";
-                file = "\x\alive\addons\fnc_analysis\fnc_gridAnalysisProfileEntity.sqf";
+                file = PATHTO_FUNC(gridAnalysisProfileEntity);
                 recompile = RECOMPILE;
             };
             class gridAnalysisProfileVehicle {
                 description = "gridAnalysisProfileVehicle";
-                file = "\x\alive\addons\fnc_analysis\fnc_gridAnalysisProfileVehicle.sqf";
+                file = PATHTO_FUNC(gridAnalysisProfileVehicle);
                 recompile = RECOMPILE;
             };
             class gridAnalysisActive {
                 description = "gridAnalysisActive";
-                file = "\x\alive\addons\fnc_analysis\fnc_gridAnalysisActive.sqf";
+                file = PATHTO_FUNC(gridAnalysisActive);
                 recompile = RECOMPILE;
             };
             class sectorFilterProfiles {
                 description = "sectorFilterProfiles";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorFilterProfiles.sqf";
+                file = PATHTO_FUNC(sectorFilterProfiles);
                 recompile = RECOMPILE;
             };
             class gridMapAnalysis {
                 description = "gridMapAnalysis";
-                file = "\x\alive\addons\fnc_analysis\fnc_gridMapAnalysis.sqf";
+                file = PATHTO_FUNC(gridMapAnalysis);
                 recompile = RECOMPILE;
             };
             class auto_gridMapAnalysis {
                 description = "auto_gridMapAnalysis";
-                file = "\x\alive\addons\fnc_analysis\fnc_auto_gridMapAnalysis.sqf";
+                file = PATHTO_FUNC(auto_gridMapAnalysis);
                 recompile = RECOMPILE;
             };
             class sectorAnalysisBestPlaces {
                 description = "sectorAnalysisBestPlaces";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorAnalysisBestPlaces.sqf";
+                file = PATHTO_FUNC(sectorAnalysisBestPlaces);
                 recompile = RECOMPILE;
             };
             class sectorFilterBestPlaces {
                 description = "sectorFilterBestPlaces";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorFilterBestPlaces.sqf";
+                file = PATHTO_FUNC(sectorFilterBestPlaces);
                 recompile = RECOMPILE;
             };
             class sectorAnalysisFlatEmpty {
                 description = "sectorAnalysisFlatEmpty";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorAnalysisFlatEmpty.sqf";
+                file = PATHTO_FUNC(sectorAnalysisFlatEmpty);
                 recompile = RECOMPILE;
             };
             class sectorFilterFlatEmpty {
                 description = "sectorFilterFlatEmpty";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorFilterFlatEmpty.sqf";
+                file = PATHTO_FUNC(sectorFilterFlatEmpty);
                 recompile = RECOMPILE;
             };
             class sectorAnalysisUnits {
                 description = "sectorAnalysisUnits";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorAnalysisUnits.sqf";
+                file = PATHTO_FUNC(sectorAnalysisUnits);
                 recompile = RECOMPILE;
             };
             class sectorFilterUnits {
                 description = "sectorFilterUnits";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorFilterUnits.sqf";
+                file = PATHTO_FUNC(sectorFilterUnits);
                 recompile = RECOMPILE;
             };
             class sectorFilterClusters {
                 description = "sectorFilterClusters";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorFilterClusters.sqf";
+                file = PATHTO_FUNC(sectorFilterClusters);
                 recompile = RECOMPILE;
             };
             class sectorAnalysisTerrain {
                 description = "sectorAnalysisTerrain";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorAnalysisTerrain.sqf";
+                file = PATHTO_FUNC(sectorAnalysisTerrain);
                 recompile = RECOMPILE;
             };
             class sectorAnalysisClustersMil {
                 description = "sectorAnalysisClustersMil";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorAnalysisClustersMil.sqf";
+                file = PATHTO_FUNC(sectorAnalysisClustersMil);
                 recompile = RECOMPILE;
             };
             class sectorAnalysisClustersCiv {
                 description = "sectorAnalysisClustersCiv";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorAnalysisClustersCiv.sqf";
+                file = PATHTO_FUNC(sectorAnalysisClustersCiv);
                 recompile = RECOMPILE;
             };
             class sectorFilterTerrain {
                 description = "sectorFilterTerrain";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorFilterTerrain.sqf";
+                file = PATHTO_FUNC(sectorFilterTerrain);
                 recompile = RECOMPILE;
             };
             class sectorAnalysisElevation {
                 description = "sectorAnalysisElevation";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorAnalysisElevation.sqf";
+                file = PATHTO_FUNC(sectorAnalysisElevation);
                 recompile = RECOMPILE;
             };
             class sectorFilterElevation {
                 description = "sectorFilterElevation";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorFilterElevation.sqf";
+                file = PATHTO_FUNC(sectorFilterElevation);
                 recompile = RECOMPILE;
             };
             class sectorAnalysisRoads {
                 description = "sectorAnalysisRoads";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorAnalysisRoads.sqf";
+                file = PATHTO_FUNC(sectorAnalysisRoads);
                 recompile = RECOMPILE;
             };
             class sectorFilterRoads {
                 description = "sectorFilterRoads";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorFilterRoads.sqf";
+                file = PATHTO_FUNC(sectorFilterRoads);
                 recompile = RECOMPILE;
             };
             class sectorSortDistance {
                 description = "sectorSortDistance";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorSortDistance.sqf";
+                file = PATHTO_FUNC(sectorSortDistance);
                 recompile = RECOMPILE;
             };
             class gridImportStaticMapAnalysis {
                 description = "gridImportStaticMapAnalysis";
-                file = "\x\alive\addons\fnc_analysis\fnc_gridImportStaticMapAnalysis.sqf";
+                file = PATHTO_FUNC(gridImportStaticMapAnalysis);
                 recompile = RECOMPILE;
             };
             class sectorDataSort {
                 description = "sectorDataSort";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorDataSort.sqf";
+                file = PATHTO_FUNC(sectorDataSort);
                 recompile = RECOMPILE;
             };
             class sectorDataMerge {
                 description = "sectorDataMerge";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorDataMerge.sqf";
+                file = PATHTO_FUNC(sectorDataMerge);
                 recompile = RECOMPILE;
             };
             class unitArrayFilterInSector {
                 description = "unitArrayFilterInSector";
-                file = "\x\alive\addons\fnc_analysis\fnc_unitArrayFilterInSector.sqf";
+                file = PATHTO_FUNC(unitArrayFilterInSector);
                 recompile = RECOMPILE;
             };
             class getClosestLand {
                 description = "getClosestLand";
-                file = "\x\alive\addons\fnc_analysis\fnc_getClosestLand.sqf";
+                file = PATHTO_FUNC(getClosestLand);
                 recompile = RECOMPILE;
             };
             class getClosestSea {
                 description = "getClosestSea";
-                file = "\x\alive\addons\fnc_analysis\fnc_getClosestSea.sqf";
+                file = PATHTO_FUNC(getClosestSea);
                 recompile = RECOMPILE;
             };
             class getClosestRoad {
                 description = "getClosestRoad";
-                file = "\x\alive\addons\fnc_analysis\fnc_getClosestRoad.sqf";
+                file = PATHTO_FUNC(getClosestRoad);
                 recompile = RECOMPILE;
             };
             class getClosestInActive {
                 description = "getClosestInActive";
-                file = "\x\alive\addons\fnc_analysis\fnc_getClosestInActive.sqf";
+                file = PATHTO_FUNC(getClosestInActive);
                 recompile = RECOMPILE;
             };
             class sectorFilterActive {
                 description = "sectorFilterActive";
-                file = "\x\alive\addons\fnc_analysis\fnc_sectorFilterActive.sqf";
+                file = PATHTO_FUNC(sectorFilterActive);
                 recompile = RECOMPILE;
             };
             class getPositionDistancePlayers {
                 description = "getPositionDistancePlayers";
-                file = "\x\alive\addons\fnc_analysis\fnc_getPositionDistancePlayers.sqf";
+                file = PATHTO_FUNC(getPositionDistancePlayers);
                 recompile = RECOMPILE;
             };
             class liveAnalysis {
                 description = "liveAnalysis";
-                file = "\x\alive\addons\fnc_analysis\fnc_liveAnalysis.sqf";
+                file = PATHTO_FUNC(liveAnalysis);
                 recompile = RECOMPILE;
             };
             class battlefieldAnalysis {
                 description = "battlefieldAnalysis";
-                file = "\x\alive\addons\fnc_analysis\fnc_battlefieldAnalysis.sqf";
+                file = PATHTO_FUNC(battlefieldAnalysis);
                 recompile = RECOMPILE;
             };
             class militaryIntel {
                 description = "militaryIntel";
-                file = "\x\alive\addons\fnc_analysis\fnc_militaryIntel.sqf";
+                file = PATHTO_FUNC(militaryIntel);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/fnc_analysis/CfgFunctions.hpp
+++ b/addons/fnc_analysis/CfgFunctions.hpp
@@ -1,206 +1,46 @@
 class cfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class sector {
-                description = "sector";
-                file = PATHTO_FUNC(sector);
-                recompile = RECOMPILE;
-            };
-            class sectorGrid {
-                description = "sectorGrid";
-                file = PATHTO_FUNC(sectorGrid);
-                recompile = RECOMPILE;
-            };
-            class sectorSubGrid {
-                description = "sectorSubGrid";
-                file = PATHTO_FUNC(sectorSubGrid);
-                recompile = RECOMPILE;
-            };
-            class sectorPlot {
-                description = "sectorPlot";
-                file = PATHTO_FUNC(sectorPlot);
-                recompile = RECOMPILE;
-            };
-            class plotSectors {
-                description = "plotSectors";
-                file = PATHTO_FUNC(plotSectors);
-                recompile = RECOMPILE;
-            };
-            class gridAnalysisProfileEntity {
-                description = "gridAnalysisProfileEntity";
-                file = PATHTO_FUNC(gridAnalysisProfileEntity);
-                recompile = RECOMPILE;
-            };
-            class gridAnalysisProfileVehicle {
-                description = "gridAnalysisProfileVehicle";
-                file = PATHTO_FUNC(gridAnalysisProfileVehicle);
-                recompile = RECOMPILE;
-            };
-            class gridAnalysisActive {
-                description = "gridAnalysisActive";
-                file = PATHTO_FUNC(gridAnalysisActive);
-                recompile = RECOMPILE;
-            };
-            class sectorFilterProfiles {
-                description = "sectorFilterProfiles";
-                file = PATHTO_FUNC(sectorFilterProfiles);
-                recompile = RECOMPILE;
-            };
-            class gridMapAnalysis {
-                description = "gridMapAnalysis";
-                file = PATHTO_FUNC(gridMapAnalysis);
-                recompile = RECOMPILE;
-            };
-            class auto_gridMapAnalysis {
-                description = "auto_gridMapAnalysis";
-                file = PATHTO_FUNC(auto_gridMapAnalysis);
-                recompile = RECOMPILE;
-            };
-            class sectorAnalysisBestPlaces {
-                description = "sectorAnalysisBestPlaces";
-                file = PATHTO_FUNC(sectorAnalysisBestPlaces);
-                recompile = RECOMPILE;
-            };
-            class sectorFilterBestPlaces {
-                description = "sectorFilterBestPlaces";
-                file = PATHTO_FUNC(sectorFilterBestPlaces);
-                recompile = RECOMPILE;
-            };
-            class sectorAnalysisFlatEmpty {
-                description = "sectorAnalysisFlatEmpty";
-                file = PATHTO_FUNC(sectorAnalysisFlatEmpty);
-                recompile = RECOMPILE;
-            };
-            class sectorFilterFlatEmpty {
-                description = "sectorFilterFlatEmpty";
-                file = PATHTO_FUNC(sectorFilterFlatEmpty);
-                recompile = RECOMPILE;
-            };
-            class sectorAnalysisUnits {
-                description = "sectorAnalysisUnits";
-                file = PATHTO_FUNC(sectorAnalysisUnits);
-                recompile = RECOMPILE;
-            };
-            class sectorFilterUnits {
-                description = "sectorFilterUnits";
-                file = PATHTO_FUNC(sectorFilterUnits);
-                recompile = RECOMPILE;
-            };
-            class sectorFilterClusters {
-                description = "sectorFilterClusters";
-                file = PATHTO_FUNC(sectorFilterClusters);
-                recompile = RECOMPILE;
-            };
-            class sectorAnalysisTerrain {
-                description = "sectorAnalysisTerrain";
-                file = PATHTO_FUNC(sectorAnalysisTerrain);
-                recompile = RECOMPILE;
-            };
-            class sectorAnalysisClustersMil {
-                description = "sectorAnalysisClustersMil";
-                file = PATHTO_FUNC(sectorAnalysisClustersMil);
-                recompile = RECOMPILE;
-            };
-            class sectorAnalysisClustersCiv {
-                description = "sectorAnalysisClustersCiv";
-                file = PATHTO_FUNC(sectorAnalysisClustersCiv);
-                recompile = RECOMPILE;
-            };
-            class sectorFilterTerrain {
-                description = "sectorFilterTerrain";
-                file = PATHTO_FUNC(sectorFilterTerrain);
-                recompile = RECOMPILE;
-            };
-            class sectorAnalysisElevation {
-                description = "sectorAnalysisElevation";
-                file = PATHTO_FUNC(sectorAnalysisElevation);
-                recompile = RECOMPILE;
-            };
-            class sectorFilterElevation {
-                description = "sectorFilterElevation";
-                file = PATHTO_FUNC(sectorFilterElevation);
-                recompile = RECOMPILE;
-            };
-            class sectorAnalysisRoads {
-                description = "sectorAnalysisRoads";
-                file = PATHTO_FUNC(sectorAnalysisRoads);
-                recompile = RECOMPILE;
-            };
-            class sectorFilterRoads {
-                description = "sectorFilterRoads";
-                file = PATHTO_FUNC(sectorFilterRoads);
-                recompile = RECOMPILE;
-            };
-            class sectorSortDistance {
-                description = "sectorSortDistance";
-                file = PATHTO_FUNC(sectorSortDistance);
-                recompile = RECOMPILE;
-            };
-            class gridImportStaticMapAnalysis {
-                description = "gridImportStaticMapAnalysis";
-                file = PATHTO_FUNC(gridImportStaticMapAnalysis);
-                recompile = RECOMPILE;
-            };
-            class sectorDataSort {
-                description = "sectorDataSort";
-                file = PATHTO_FUNC(sectorDataSort);
-                recompile = RECOMPILE;
-            };
-            class sectorDataMerge {
-                description = "sectorDataMerge";
-                file = PATHTO_FUNC(sectorDataMerge);
-                recompile = RECOMPILE;
-            };
-            class unitArrayFilterInSector {
-                description = "unitArrayFilterInSector";
-                file = PATHTO_FUNC(unitArrayFilterInSector);
-                recompile = RECOMPILE;
-            };
-            class getClosestLand {
-                description = "getClosestLand";
-                file = PATHTO_FUNC(getClosestLand);
-                recompile = RECOMPILE;
-            };
-            class getClosestSea {
-                description = "getClosestSea";
-                file = PATHTO_FUNC(getClosestSea);
-                recompile = RECOMPILE;
-            };
-            class getClosestRoad {
-                description = "getClosestRoad";
-                file = PATHTO_FUNC(getClosestRoad);
-                recompile = RECOMPILE;
-            };
-            class getClosestInActive {
-                description = "getClosestInActive";
-                file = PATHTO_FUNC(getClosestInActive);
-                recompile = RECOMPILE;
-            };
-            class sectorFilterActive {
-                description = "sectorFilterActive";
-                file = PATHTO_FUNC(sectorFilterActive);
-                recompile = RECOMPILE;
-            };
-            class getPositionDistancePlayers {
-                description = "getPositionDistancePlayers";
-                file = PATHTO_FUNC(getPositionDistancePlayers);
-                recompile = RECOMPILE;
-            };
-            class liveAnalysis {
-                description = "liveAnalysis";
-                file = PATHTO_FUNC(liveAnalysis);
-                recompile = RECOMPILE;
-            };
-            class battlefieldAnalysis {
-                description = "battlefieldAnalysis";
-                file = PATHTO_FUNC(battlefieldAnalysis);
-                recompile = RECOMPILE;
-            };
-            class militaryIntel {
-                description = "militaryIntel";
-                file = PATHTO_FUNC(militaryIntel);
-                recompile = RECOMPILE;
-            };
-        };
-    };
+						FUNC_FILEPATH(sector,"sector");
+						FUNC_FILEPATH(sectorGrid,"sectorGrid");
+						FUNC_FILEPATH(sectorSubGrid,"sectorSubGrid");
+						FUNC_FILEPATH(sectorPlot,"sectorPlot");
+						FUNC_FILEPATH(plotSectors,"plotSectors");
+						FUNC_FILEPATH(gridAnalysisProfileEntity,"gridAnalysisProfileEntity");
+						FUNC_FILEPATH(gridAnalysisProfileVehicle,"gridAnalysisProfileVehicle");
+						FUNC_FILEPATH(gridAnalysisActive,"gridAnalysisActive");
+						FUNC_FILEPATH(sectorFilterProfiles,"sectorFilterProfiles");
+						FUNC_FILEPATH(gridMapAnalysis,"gridMapAnalysis");
+						FUNC_FILEPATH(auto_gridMapAnalysis,"auto_gridMapAnalysis");
+						FUNC_FILEPATH(sectorAnalysisBestPlaces,"sectorAnalysisBestPlaces");
+						FUNC_FILEPATH(sectorFilterBestPlaces,"sectorFilterBestPlaces");
+						FUNC_FILEPATH(sectorAnalysisFlatEmpty,"sectorAnalysisFlatEmpty");
+						FUNC_FILEPATH(sectorFilterFlatEmpty,"sectorFilterFlatEmpty");
+						FUNC_FILEPATH(sectorAnalysisUnits,"sectorAnalysisUnits");
+						FUNC_FILEPATH(sectorFilterUnits,"sectorFilterUnits");
+						FUNC_FILEPATH(sectorFilterClusters,"sectorFilterClusters");
+						FUNC_FILEPATH(sectorAnalysisTerrain,"sectorAnalysisTerrain");
+						FUNC_FILEPATH(sectorAnalysisClustersMil,"sectorAnalysisClustersMil");
+						FUNC_FILEPATH(sectorAnalysisClustersCiv,"sectorAnalysisClustersCiv");
+						FUNC_FILEPATH(sectorFilterTerrain,"sectorFilterTerrain");
+						FUNC_FILEPATH(sectorAnalysisElevation,"sectorAnalysisElevation");
+						FUNC_FILEPATH(sectorFilterElevation,"sectorFilterElevation");
+						FUNC_FILEPATH(sectorAnalysisRoads,"sectorAnalysisRoads");
+						FUNC_FILEPATH(sectorFilterRoads,"sectorFilterRoads");
+						FUNC_FILEPATH(sectorSortDistance,"sectorSortDistance");
+						FUNC_FILEPATH(gridImportStaticMapAnalysis,"gridImportStaticMapAnalysis");
+						FUNC_FILEPATH(sectorDataSort,"sectorDataSort");
+						FUNC_FILEPATH(sectorDataMerge,"sectorDataMerge");
+						FUNC_FILEPATH(unitArrayFilterInSector,"unitArrayFilterInSector");
+						FUNC_FILEPATH(getClosestLand,"getClosestLand");
+						FUNC_FILEPATH(getClosestSea,"getClosestSea");
+						FUNC_FILEPATH(getClosestRoad,"getClosestRoad");
+						FUNC_FILEPATH(getClosestInActive,"getClosestInActive");
+						FUNC_FILEPATH(sectorFilterActive,"sectorFilterActive");
+						FUNC_FILEPATH(getPositionDistancePlayers,"getPositionDistancePlayers");
+						FUNC_FILEPATH(liveAnalysis,"liveAnalysis");
+						FUNC_FILEPATH(battlefieldAnalysis,"battlefieldAnalysis");
+						FUNC_FILEPATH(militaryIntel,"militaryIntel");
+				};
+		};
 };

--- a/addons/fnc_strategic/CfgFunctions.hpp
+++ b/addons/fnc_strategic/CfgFunctions.hpp
@@ -1,86 +1,22 @@
 class CfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class getNearestClusterInArray {
-                description = "Returns the nearest cluster to the given cluster from a list of clusters";
-								file = PATHTO_FUNC(getNearestClusterInArray);
-                recompile = RECOMPILE;
-            };
-            class findClusterCenter {
-                description = "Return the centre position of an object cluster";
-								file = PATHTO_FUNC(findClusterCenter);
-                recompile = RECOMPILE;
-            };
-            class consolidateClusters {
-                description = "Merge cluster objects if they are within close proximity";
-								file = PATHTO_FUNC(consolidateClusters);
-                recompile = RECOMPILE;
-            };
-            class findClusters {
-                description = "Returns a list of object clusters";
-								file = PATHTO_FUNC(findClusters);
-                recompile = RECOMPILE;
-            };
-            class cluster {
-                description = "Builds clusters";
-								file = PATHTO_FUNC(cluster);
-                recompile = RECOMPILE;
-            };
-            class findTargets {
-                description = "Identify targets within the TAOR";
-								file = PATHTO_FUNC(findTargets);
-                recompile = RECOMPILE;
-            };
-            class setTargets {
-                description = "Set basic params on clusters";
-								file = PATHTO_FUNC(setTargets);
-                recompile = RECOMPILE;
-            };
-            class clustersInsideMarker {
-                description = "Return list of clusters inside a marker";
-								file = PATHTO_FUNC(clustersInsideMarker);
-                recompile = RECOMPILE;
-            };
-            class clustersOutsideMarker {
-                description = "Return list of clusters outside a marker";
-								file = PATHTO_FUNC(clustersOutsideMarker);
-                recompile = RECOMPILE;
-            };
-            class staticClusterOutput {
-                description = "Returns clusters in string format for static file storage";
-								file = PATHTO_FUNC(staticClusterOutput);
-                recompile = RECOMPILE;
-            };
-            class auto_staticClusterOutput {
-                description = "Returns clusters in string format for static file storage";
-								file = PATHTO_FUNC(auto_staticClusterOutput);
-                recompile = RECOMPILE;
-            };
-            class copyClusters {
-                description = "Duplicate an array of clusters";
-								file = PATHTO_FUNC(copyClusters);
-                recompile = RECOMPILE;
-            };
-            class generateParkingPositions {
-                description = "Generate parking positions for cluster nodes";
-								file = PATHTO_FUNC(generateParkingPositions);
-                recompile = RECOMPILE;
-            };
-            class generateParkingPosition {
-                description = "Generate parking position for building";
-								file = PATHTO_FUNC(generateParkingPosition);
-                recompile = RECOMPILE;
-            };
-            class getParkingPosition {
-                description = "Gets a parking position for a building";
-								file = PATHTO_FUNC(getParkingPosition);
-                recompile = RECOMPILE;
-            };
-            class findBuildingsInClusterNodes {
-                description = "Find building names in cluster nodes";
-								file = PATHTO_FUNC(findBuildingsInClusterNodes);
-                recompile = RECOMPILE;
-            };
-        };
-    };
+						FUNC_FILEPATH(getNearestClusterInArray,"Returns the nearest cluster to the given cluster from a list of clusters");
+						FUNC_FILEPATH(findClusterCenter,"Return the centre position of an object cluster");
+						FUNC_FILEPATH(consolidateClusters,"Merge cluster objects if they are within close proximity");
+						FUNC_FILEPATH(findClusters,"Returns a list of object clusters");
+						FUNC_FILEPATH(cluster,"Builds clusters");
+						FUNC_FILEPATH(findTargets,"Identify targets within the TAOR");
+						FUNC_FILEPATH(setTargets,"Set basic params on clusters");
+						FUNC_FILEPATH(clustersInsideMarker,"Return list of clusters inside a marker");
+						FUNC_FILEPATH(clustersOutsideMarker,"Return list of clusters outside a marker");
+						FUNC_FILEPATH(staticClusterOutput,"Returns clusters in string format for static file storage");
+						FUNC_FILEPATH(auto_staticClusterOutput,"Returns clusters in string format for static file storage");
+						FUNC_FILEPATH(copyClusters,"Duplicate an array of clusters");
+						FUNC_FILEPATH(generateParkingPositions,"Generate parking positions for cluster nodes");
+						FUNC_FILEPATH(generateParkingPosition,"Generate parking position for building");
+						FUNC_FILEPATH(getParkingPosition,"Gets a parking position for a building");
+						FUNC_FILEPATH(findBuildingsInClusterNodes,"Find building names in cluster nodes");
+				};
+		};
 };

--- a/addons/fnc_strategic/CfgFunctions.hpp
+++ b/addons/fnc_strategic/CfgFunctions.hpp
@@ -1,84 +1,84 @@
-class cfgFunctions {
+class CfgFunctions {
     class PREFIX {
         class COMPONENT {
             class getNearestClusterInArray {
                 description = "Returns the nearest cluster to the given cluster from a list of clusters";
-                file = "\x\alive\addons\fnc_strategic\fnc_getNearestClusterInArray.sqf";
+								file = PATHTO_FUNC(getNearestClusterInArray);
                 recompile = RECOMPILE;
             };
             class findClusterCenter {
                 description = "Return the centre position of an object cluster";
-                file = "\x\alive\addons\fnc_strategic\fnc_findClusterCenter.sqf";
+								file = PATHTO_FUNC(findClusterCenter);
                 recompile = RECOMPILE;
             };
             class consolidateClusters {
                 description = "Merge cluster objects if they are within close proximity";
-                file = "\x\alive\addons\fnc_strategic\fnc_consolidateClusters.sqf";
+								file = PATHTO_FUNC(consolidateClusters);
                 recompile = RECOMPILE;
             };
             class findClusters {
                 description = "Returns a list of object clusters";
-                file = "\x\alive\addons\fnc_strategic\fnc_findClusters.sqf";
+								file = PATHTO_FUNC(findClusters);
                 recompile = RECOMPILE;
             };
             class cluster {
                 description = "Builds clusters";
-                file = "\x\alive\addons\fnc_strategic\fnc_cluster.sqf";
+								file = PATHTO_FUNC(cluster);
                 recompile = RECOMPILE;
             };
             class findTargets {
                 description = "Identify targets within the TAOR";
-                file = "\x\alive\addons\fnc_strategic\fnc_findTargets.sqf";
+								file = PATHTO_FUNC(findTargets);
                 recompile = RECOMPILE;
             };
             class setTargets {
                 description = "Set basic params on clusters";
-                file = "\x\alive\addons\fnc_strategic\fnc_setTargets.sqf";
+								file = PATHTO_FUNC(setTargets);
                 recompile = RECOMPILE;
             };
             class clustersInsideMarker {
                 description = "Return list of clusters inside a marker";
-                file = "\x\alive\addons\fnc_strategic\fnc_clustersInsideMarker.sqf";
+								file = PATHTO_FUNC(clustersInsideMarker);
                 recompile = RECOMPILE;
             };
             class clustersOutsideMarker {
                 description = "Return list of clusters outside a marker";
-                file = "\x\alive\addons\fnc_strategic\fnc_clustersOutsideMarker.sqf";
+								file = PATHTO_FUNC(clustersOutsideMarker);
                 recompile = RECOMPILE;
             };
             class staticClusterOutput {
                 description = "Returns clusters in string format for static file storage";
-                file = "\x\alive\addons\fnc_strategic\fnc_staticClusterOutput.sqf";
+								file = PATHTO_FUNC(staticClusterOutput);
                 recompile = RECOMPILE;
             };
             class auto_staticClusterOutput {
                 description = "Returns clusters in string format for static file storage";
-                file = "\x\alive\addons\fnc_strategic\fnc_auto_staticClusterOutput.sqf";
+								file = PATHTO_FUNC(auto_staticClusterOutput);
                 recompile = RECOMPILE;
             };
             class copyClusters {
                 description = "Duplicate an array of clusters";
-                file = "\x\alive\addons\fnc_strategic\fnc_copyClusters.sqf";
+								file = PATHTO_FUNC(copyClusters);
                 recompile = RECOMPILE;
             };
             class generateParkingPositions {
                 description = "Generate parking positions for cluster nodes";
-                file = "\x\alive\addons\fnc_strategic\fnc_generateParkingPositions.sqf";
+								file = PATHTO_FUNC(generateParkingPositions);
                 recompile = RECOMPILE;
             };
             class generateParkingPosition {
                 description = "Generate parking position for building";
-                file = "\x\alive\addons\fnc_strategic\fnc_generateParkingPosition.sqf";
+								file = PATHTO_FUNC(generateParkingPosition);
                 recompile = RECOMPILE;
             };
             class getParkingPosition {
                 description = "Gets a parking position for a building";
-                file = "\x\alive\addons\fnc_strategic\fnc_getParkingPosition.sqf";
+								file = PATHTO_FUNC(getParkingPosition);
                 recompile = RECOMPILE;
             };
             class findBuildingsInClusterNodes {
                 description = "Find building names in cluster nodes";
-                file = "\x\alive\addons\fnc_strategic\fnc_findBuildingsInClusterNodes.sqf";
+								file = PATHTO_FUNC(findBuildingsInClusterNodes);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/main/CfgFunctions.hpp
+++ b/addons/main/CfgFunctions.hpp
@@ -3,67 +3,67 @@ class cfgFunctions {
         class COMPONENT {
             class buttonAbort {
                 description = "Calls any scripts required when the user disconnects";
-                file = "\x\alive\addons\main\fnc_buttonAbort.sqf";
+                file = PATHTO_FUNC(buttonAbort);
                 recompile = RECOMPILE;
             };
             class aliveInit {
                 description = "ALiVE init function";
-                file = "\x\alive\addons\main\fnc_aliveInit.sqf";
+                file = PATHTO_FUNC(aliveInit);
                 recompile = RECOMPILE;
             };
             class Nuke {
                 description = "Fires a Nuke at given position";
-                file = "\x\alive\addons\main\fnc_Nuke.sqf";
+                file = PATHTO_FUNC(Nuke);
                 recompile = RECOMPILE;
             };
             class isModuleSynced {
                 description = "Checks if modules are synced";
-                file = "\x\alive\addons\main\fnc_isModuleSynced.sqf";
+                file = PATHTO_FUNC(isModuleSynced);
                 recompile = RECOMPILE;
             };
             class isModuleAvailable {
                 description = "Checks if modules are available";
-                file = "\x\alive\addons\main\fnc_isModuleAvailable.sqf";
+                file = PATHTO_FUNC(isModuleAvailable);
                 recompile = RECOMPILE;
             };
             class versioning {
                 description = "Warns or kicks players on version mismatch";
-                file = "\x\alive\addons\main\fnc_versioning.sqf";
+                file = PATHTO_FUNC(versioning);
                 recompile = RECOMPILE;
             };
             class isModuleInitialised {
                 description = "Checks if given modules are initialised";
-                file = "\x\alive\addons\main\fnc_isModuleInitialised.sqf";
+                file = PATHTO_FUNC(isModuleInitialised);
                 recompile = RECOMPILE;
             };
             class pauseModule {
                 description = "Pauses given module(s)";
-                file = "\x\alive\addons\main\fnc_pauseModule.sqf";
+                file = PATHTO_FUNC(pauseModule);
                 recompile = RECOMPILE;
             };
             class unPauseModule {
                 description = "activates given module(s) after pausing";
-                file = "\x\alive\addons\main\fnc_unPauseModule.sqf";
+                file = PATHTO_FUNC(unPauseModule);
                 recompile = RECOMPILE;
             };
             class pauseModulesAuto {
                 description = "Adds EHs to pause all main modules if no players are on server";
-                file = "\x\alive\addons\main\fnc_pauseModulesAuto.sqf";
+                file = PATHTO_FUNC(pauseModulesAuto);
                 recompile = RECOMPILE;
             };
             class ZEUSinit {
                 description = "Initialises Zeus for ALiVE";
-                file = "\x\alive\addons\main\fnc_ZEUSinit.sqf";
+                file = PATHTO_FUNC(ZEUSinit);
                 recompile = RECOMPILE;
             };
             class mainTablet {
                 description = "ALiVE Main Tablet";
-                file = "\x\alive\addons\main\fnc_mainTablet.sqf";
+                file = PATHTO_FUNC(mainTablet);
                 recompile = RECOMPILE;
             };
             class AI_Distributor {
                 description = "Distributes AI to all headless clients";
-                file = "\x\alive\addons\main\fnc_AI_Distributor.sqf";
+                file = PATHTO_FUNC(AI_Distributor);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/main/CfgFunctions.hpp
+++ b/addons/main/CfgFunctions.hpp
@@ -1,71 +1,19 @@
 class cfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class buttonAbort {
-                description = "Calls any scripts required when the user disconnects";
-                file = PATHTO_FUNC(buttonAbort);
-                recompile = RECOMPILE;
-            };
-            class aliveInit {
-                description = "ALiVE init function";
-                file = PATHTO_FUNC(aliveInit);
-                recompile = RECOMPILE;
-            };
-            class Nuke {
-                description = "Fires a Nuke at given position";
-                file = PATHTO_FUNC(Nuke);
-                recompile = RECOMPILE;
-            };
-            class isModuleSynced {
-                description = "Checks if modules are synced";
-                file = PATHTO_FUNC(isModuleSynced);
-                recompile = RECOMPILE;
-            };
-            class isModuleAvailable {
-                description = "Checks if modules are available";
-                file = PATHTO_FUNC(isModuleAvailable);
-                recompile = RECOMPILE;
-            };
-            class versioning {
-                description = "Warns or kicks players on version mismatch";
-                file = PATHTO_FUNC(versioning);
-                recompile = RECOMPILE;
-            };
-            class isModuleInitialised {
-                description = "Checks if given modules are initialised";
-                file = PATHTO_FUNC(isModuleInitialised);
-                recompile = RECOMPILE;
-            };
-            class pauseModule {
-                description = "Pauses given module(s)";
-                file = PATHTO_FUNC(pauseModule);
-                recompile = RECOMPILE;
-            };
-            class unPauseModule {
-                description = "activates given module(s) after pausing";
-                file = PATHTO_FUNC(unPauseModule);
-                recompile = RECOMPILE;
-            };
-            class pauseModulesAuto {
-                description = "Adds EHs to pause all main modules if no players are on server";
-                file = PATHTO_FUNC(pauseModulesAuto);
-                recompile = RECOMPILE;
-            };
-            class ZEUSinit {
-                description = "Initialises Zeus for ALiVE";
-                file = PATHTO_FUNC(ZEUSinit);
-                recompile = RECOMPILE;
-            };
-            class mainTablet {
-                description = "ALiVE Main Tablet";
-                file = PATHTO_FUNC(mainTablet);
-                recompile = RECOMPILE;
-            };
-            class AI_Distributor {
-                description = "Distributes AI to all headless clients";
-                file = PATHTO_FUNC(AI_Distributor);
-                recompile = RECOMPILE;
-            };
+            FUNC_FILEPATH(buttonAbort,"Calls any scripts required when the user disconnects");
+            FUNC_FILEPATH(aliveInit,"ALiVE init function");
+            FUNC_FILEPATH(Nuke,"Fires a Nuke at a given position");
+            FUNC_FILEPATH(isModuleSynced,"Checks if modules are synced");
+            FUNC_FILEPATH(isModuleAvailable,"Checks if modules are available");
+            FUNC_FILEPATH(versioning,"Warns or kicks players on a version mismatch");
+            FUNC_FILEPATH(isModuleInitialised,"Checks if given modules are initialised");
+            FUNC_FILEPATH(pauseModule,"Pauses given module(s)");
+            FUNC_FILEPATH(unPauseModule,"Activates given module(s) after pausing");
+            FUNC_FILEPATH(pauseModulesAuto,"Adds EHs to pause all main modules if no players are on server");
+            FUNC_FILEPATH(ZEUSinit,"Initialises Zeus for ALiVE");
+            FUNC_FILEPATH(mainTablet,"ALiVE Main Tablet");
+            FUNC_FILEPATH(AI_Distributor,"Distributes AI to all headless clients");
         };
     };
 };

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -58,6 +58,12 @@
 
 #define MOD(var1) GVARMAIN(var1)
 #define QMOD(var1) QUOTE(GVARMAIN(var1))
-#define PATHTO_FUNC(var1) QUOTE(PATHTO_SYS(PREFIX,COMPONENT,DOUBLES(fnc,var1)))
 #define RECOMPILE 1
 #define MODULE_AUTHOR QUOTE(ALiVE Mod Team)
+
+#define PATHTO_FUNC(var1) QUOTE(PATHTO_SYS(PREFIX,COMPONENT,DOUBLES(fnc,var1)))
+#define FUNC_FILEPATH(func,desc) class func {\
+  description = desc;\
+  file = QUOTE(PATHTO(DOUBLES(fnc,func)));\
+  recompile = RECOMPILE;\
+}

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -24,7 +24,7 @@
 */
 
 // Set a default debug mode for the component here (See documentation on how to default to each of the modes).
-//    #define DEBUG_ENABLED_MAIN
+    #define DEBUG_ENABLED_MAIN
 //    #define DEBUG_ENABLED_SYS_ADMINACTIONS
 //    #define DEBUG_ENABLED_FNC_STRATEGIC
 //    #define DEBUG_ENABLED_mil_cqb
@@ -36,7 +36,7 @@
 //    #define DEBUG_ENABLED_MIL_STRATEGIC
 //    #define DEBUG_ENABLED_SYS_PROFILE
 //    #define DEBUG_ENABLED_SYS_SIMULATION
-//    #define DEBUG_ENABLED_SYS_PLAYER
+    #define DEBUG_ENABLED_SYS_PLAYER
 //    #define DEBUG_ENABLED_SYS_playeroptions
 //    #define DEBUG_ENABLED_SYS_viewdistance
 //    #define DEBUG_ENABLED_SYS_playertags
@@ -58,5 +58,6 @@
 
 #define MOD(var1) GVARMAIN(var1)
 #define QMOD(var1) QUOTE(GVARMAIN(var1))
+#define PATHTO_FUNC(var1) QUOTE(PATHTO_SYS(PREFIX,COMPONENT,DOUBLES(fnc,var1)))
 #define RECOMPILE 1
 #define MODULE_AUTHOR QUOTE(ALiVE Mod Team)

--- a/addons/main/static/CQB.hpp
+++ b/addons/main/static/CQB.hpp
@@ -122,15 +122,15 @@ ALiVE_MIL_CQB_UNITBLACKLIST = ALiVE_MIL_CQB_CUSTOM_UNITBLACKLIST +
 
     "B_CTRG_Miller_F",
 
-    "O_T_helipilot_F",
-    "O_T_diver_F",
-    "O_T_diver_TL_F",
-    "O_T_diver_exp_F",
-    "O_T_crew_F",
+    "O_T_Helipilot_F",
+    "O_T_Diver_F",
+    "O_T_Diver_TL_F",
+    "O_T_Diver_Exp_F",
+    "O_T_Crew_F",
     "O_T_Pilot_F",
-    "O_T_helicrew_F",
+    "O_T_Helicrew_F",
 
-    "I_C_helipilot_F",
-    "I_C_pilot_F",
+    "I_C_Helipilot_F",
+    "I_C_Pilot_F",
     "I_C_Soldier_Camo_F"
 ];

--- a/addons/mil_c2istar/CfgFunctions.hpp
+++ b/addons/mil_c2istar/CfgFunctions.hpp
@@ -1,71 +1,19 @@
 class CfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class C2ISTAR {
-                description = "The main class";
-		            file = PATHTO_FUNC(C2ISTAR);
-                recompile = RECOMPILE;
-            };
-            class C2ISTARInit {
-                description = "The module initialisation function";
-		            file = PATHTO_FUNC(C2ISTARInit);
-                recompile = RECOMPILE;
-            };
-            class C2MenuDef {
-                description = "The module menu definition";
-		            file = PATHTO_FUNC(C2MenuDef);
-                recompile = RECOMPILE;
-            };
-            class C2TabletOnAction {
-                description = "The module Radio Action function";
-		            file = PATHTO_FUNC(C2TabletOnAction);
-                recompile = RECOMPILE;
-            };
-            class C2TabletOnLoad {
-                description = "The module tablet on load function";
-		            file = PATHTO_FUNC(C2TabletOnLoad);
-                recompile = RECOMPILE;
-            };
-            class C2TabletOnUnLoad {
-                description = "The module tablet on unload function";
-		            file = PATHTO_FUNC(C2TabletOnUnLoad);
-                recompile = RECOMPILE;
-            };
-            class C2TabletEventToClient {
-                description = "Call the tablet on the client from the server";
-		            file = PATHTO_FUNC(C2TabletEventToClient);
-                recompile = RECOMPILE;
-            };
-            class C2OnPlayerConnected {
-                description = "On player connected handler";
-		            file = PATHTO_FUNC(C2OnPlayerConnected);
-                recompile = RECOMPILE;
-            };
-            class taskHandler {
-                description = "Task Handler";
-		            file = PATHTO_FUNC(taskHandler);
-                recompile = RECOMPILE;
-            };
-            class taskHandlerClient {
-                description = "Task Handler Client";
-		            file = PATHTO_FUNC(taskHandlerClient);
-                recompile = RECOMPILE;
-            };
-            class taskHandlerEventToClient {
-                description = "Task Handler Event To Client";
-		            file = PATHTO_FUNC(taskHandlerEventToClient);
-                recompile = RECOMPILE;
-            };
-            class taskHandlerLoadData {
-                description = "Task Handler Load Data";
-		            file = PATHTO_FUNC(taskHandlerLoadData);
-                recompile = RECOMPILE;
-            };
-            class taskHandlerSaveData {
-                description = "Task Handler Save Data";
-		            file = PATHTO_FUNC(taskHandlerSaveData);
-                recompile = RECOMPILE;
-            };
+            FUNC_FILEPATH(C2ISTAR,"The main class");
+            FUNC_FILEPATH(C2ISTARInit,"The module initialisation function");
+            FUNC_FILEPATH(C2MenuDef,"The module menu definition");
+            FUNC_FILEPATH(C2TabletOnAction,"The module Radio Action function");
+            FUNC_FILEPATH(C2TabletOnLoad,"The module tablet on load function");
+            FUNC_FILEPATH(C2TabletOnUnLoad,"The module tablet on unload function");
+            FUNC_FILEPATH(C2TabletEventToClient,"Call the tablet on the client from the server");
+            FUNC_FILEPATH(C2OnPlayerConnected,"On player connected handler");
+            FUNC_FILEPATH(taskHandler,"Task Handler");
+            FUNC_FILEPATH(taskHandlerClient,"Task Handler Client");
+            FUNC_FILEPATH(taskHandlerEventToClient,"Task Handler Event To Client");
+            FUNC_FILEPATH(taskHandlerLoadData,"Task Handler Load Data");
+            FUNC_FILEPATH(taskHandlerSaveData,"Task Handler Save Data");
             class taskGetSideCluster {
                 description = "Utility get side cluster for tasks";
 		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetSideCluster.sqf";

--- a/addons/mil_c2istar/CfgFunctions.hpp
+++ b/addons/mil_c2istar/CfgFunctions.hpp
@@ -3,277 +3,277 @@ class CfgFunctions {
         class COMPONENT {
             class C2ISTAR {
                 description = "The main class";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_C2ISTAR.sqf";
+		            file = PATHTO_FUNC(C2ISTAR);
                 recompile = RECOMPILE;
             };
             class C2ISTARInit {
                 description = "The module initialisation function";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_C2ISTARInit.sqf";
+		            file = PATHTO_FUNC(C2ISTARInit);
                 recompile = RECOMPILE;
             };
             class C2MenuDef {
                 description = "The module menu definition";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_C2MenuDef.sqf";
+		            file = PATHTO_FUNC(C2MenuDef);
                 recompile = RECOMPILE;
             };
             class C2TabletOnAction {
                 description = "The module Radio Action function";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_C2TabletOnAction.sqf";
+		            file = PATHTO_FUNC(C2TabletOnAction);
                 recompile = RECOMPILE;
             };
             class C2TabletOnLoad {
                 description = "The module tablet on load function";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_C2TabletOnLoad.sqf";
+		            file = PATHTO_FUNC(C2TabletOnLoad);
                 recompile = RECOMPILE;
             };
             class C2TabletOnUnLoad {
                 description = "The module tablet on unload function";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_C2TabletOnUnLoad.sqf";
+		            file = PATHTO_FUNC(C2TabletOnUnLoad);
                 recompile = RECOMPILE;
             };
             class C2TabletEventToClient {
                 description = "Call the tablet on the client from the server";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_C2TabletEventToClient.sqf";
+		            file = PATHTO_FUNC(C2TabletEventToClient);
                 recompile = RECOMPILE;
             };
             class C2OnPlayerConnected {
                 description = "On player connected handler";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_C2OnPlayerConnected.sqf";
+		            file = PATHTO_FUNC(C2OnPlayerConnected);
                 recompile = RECOMPILE;
             };
             class taskHandler {
                 description = "Task Handler";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_taskHandler.sqf";
+		            file = PATHTO_FUNC(taskHandler);
                 recompile = RECOMPILE;
             };
             class taskHandlerClient {
                 description = "Task Handler Client";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_taskHandlerClient.sqf";
+		            file = PATHTO_FUNC(taskHandlerClient);
                 recompile = RECOMPILE;
             };
             class taskHandlerEventToClient {
                 description = "Task Handler Event To Client";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_taskHandlerEventToClient.sqf";
+		            file = PATHTO_FUNC(taskHandlerEventToClient);
                 recompile = RECOMPILE;
             };
             class taskHandlerLoadData {
                 description = "Task Handler Load Data";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_taskHandlerLoadData.sqf";
+		            file = PATHTO_FUNC(taskHandlerLoadData);
                 recompile = RECOMPILE;
             };
             class taskHandlerSaveData {
                 description = "Task Handler Save Data";
-                file = "\x\alive\addons\mil_C2ISTAR\fnc_taskHandlerSaveData.sqf";
+		            file = PATHTO_FUNC(taskHandlerSaveData);
                 recompile = RECOMPILE;
             };
             class taskGetSideCluster {
                 description = "Utility get side cluster for tasks";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetSideCluster.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetSideCluster.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetSideSectorCompositionPosition {
                 description = "Utility get side sector for tasks";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetSideSectorCompositionPosition.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetSideSectorCompositionPosition.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetSideSectorVehicles {
                 description = "Utility get side sector that contains vehicles";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetSideSectorVehicles.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetSideSectorVehicles.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetRandomSideVehicleFromSector {
                 description = "Utility get a random vehicle for a side from a sector";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetRandomSideVehicleFromSector.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetRandomSideVehicleFromSector.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetSideSectorEntities {
                 description = "Utility get side sector that contains entities";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetSideSectorEntities.sqf";
+		              file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetSideSectorEntities.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetRandomSideEntityFromSector {
                 description = "Utility get a random vehicle for a side from a sector";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetRandomSideEntityFromSector.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetRandomSideEntityFromSector.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetSectorPosition {
                 description = "Utility get position based on sector data";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetSectorPosition.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetSectorPosition.sqf";
                 recompile = RECOMPILE;
             };
             class taskHavePlayersReachedDestination {
                 description = "Utility check if players have reached the destination";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskHavePlayersReachedDestination.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskHavePlayersReachedDestination.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetClosestPlayerDistanceToDestination {
                 description = "Utility get the distance of the closest player to the destination";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetClosestPlayerDistanceToDestination.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetClosestPlayerDistanceToDestination.sqf";
                 recompile = RECOMPILE;
             };
             class taskIsAreaClearOfEnemies {
                 description = "Utility check if there are any enemies in the area";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskIsAreaClearOfEnemies.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskIsAreaClearOfEnemies.sqf";
                 recompile = RECOMPILE;
             };
             class taskCreateMarkersForPlayers {
                 description = "Utility mark target position on map";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskCreateMarkersForPlayers.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskCreateMarkersForPlayers.sqf";
                 recompile = RECOMPILE;
             };
             class taskCreateMarker {
                 description = "Utility create a local marker";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskCreateMarker.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskCreateMarker.sqf";
                 recompile = RECOMPILE;
             };
             class taskDeleteMarkersForPlayers {
                 description = "Utility delete any markers for players";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskDeleteMarkersForPlayers.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskDeleteMarkersForPlayers.sqf";
                 recompile = RECOMPILE;
             };
             class taskDeleteMarkers {
                 description = "Utility delete local markers";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskDeleteMarkers.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskDeleteMarkers.sqf";
                 recompile = RECOMPILE;
             };
             class taskCreateRadioBroadcastForPlayers {
                 description = "Utility broadcast radio message for players";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskCreateRadioBroadcastForPlayers.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskCreateRadioBroadcastForPlayers.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetNearestLocationName {
                 description = "Utility get the nearest location name";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetNearestLocationName.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetNearestLocationName.sqf";
                 recompile = RECOMPILE;
             };
             class taskCreateRandomMilLogisticsEvent {
                 description = "Utility call in a random mil logistics event";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskCreateRandomMilLogisticsEvent.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskCreateRandomMilLogisticsEvent.sqf";
                 recompile = RECOMPILE;
             };
             class taskCreateVehicleInsertionForUnits {
                 description = "Utility create an insertion vehicle for units";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskCreateVehicleInsertionForUnits.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskCreateVehicleInsertionForUnits.sqf";
                 recompile = RECOMPILE;
             };
             class taskCreateVehicleExtractionForUnits {
                 description = "Utility create an extraction vehicle for units";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskCreateVehicleExtractionForUnits.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskCreateVehicleExtractionForUnits.sqf";
                 recompile = RECOMPILE;
             };
             class taskCreateExplosiveProjectile {
                 description = "Utility create an explosive projectile orientate towards an object";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskCreateExplosiveProjectile.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskCreateExplosiveProjectile.sqf";
                 recompile = RECOMPILE;
             };
             class taskCreateBombardment {
                 description = "Utility create a bombardment of explosives";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskCreateBombardment.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskCreateBombardment.sqf";
                 recompile = RECOMPILE;
             };
             class taskSpawnOnTopOf {
                 description = "Utility spawn an object on top of another object";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskSpawnOnTopOf.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskSpawnOnTopOf.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetNearPlayerVehicles {
                 description = "Utility get near player vehicles";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetNearPlayerVehicles.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetNearPlayerVehicles.sqf";
                 recompile = RECOMPILE;
             };
             class taskDoVehiclesHaveRoomForGroup {
                 description = "Utility does any vehicle in an array of vehicles have room for a group";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskDoVehiclesHaveRoomForGroup.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskDoVehiclesHaveRoomForGroup.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetVehicleWithMaxRoom {
                 description = "Utility get the vehicle with the biggest amount of room for passengers";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetVehicleWithMaxRoom.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetVehicleWithMaxRoom.sqf";
                 recompile = RECOMPILE;
             };
             class taskHaveUnitsLoadedInVehicle {
                 description = "Utility have all the units loaded into the vehicle";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskHaveUnitsLoadedInVehicle.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskHaveUnitsLoadedInVehicle.sqf";
                 recompile = RECOMPILE;
             };
             class taskHaveUnitsUnloadedFromVehicle {
                 description = "Utility have all the units unloaded from the vehicle";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskHaveUnitsUnloadedFromVehicle.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskHaveUnitsUnloadedFromVehicle.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetStateOfVehicleProfiles {
                 description = "Utility have all the vehicle profiles been destroyed";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetStateOfVehicleProfiles.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetStateOfVehicleProfiles.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetStateOfEntityProfiles {
                 description = "Utility have all the entity profiles been destroyed";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetStateOfEntityProfiles.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetStateOfEntityProfiles.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetStateOfObjects {
                 description = "Utility have all the entity profiles been destroyed";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetStateOfObjects.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetStateOfObjects.sqf";
                 recompile = RECOMPILE;
             };
             class taskCreateReward {
                 description = "Utility create a reward for task completion";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskCreateReward.sqf";
+		            file = "\x\alive\addons\mil_c2istar\utils\fnc_taskCreateReward.sqf";
                 recompile = RECOMPILE;
             };
             class taskGetInsurgencyLocation {
                 description = "Utility to find insurgency location from asymetrical opcoms";
-                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetInsurgencyLocation.sqf";
+	              file = "\x\alive\addons\mil_c2istar\utils\fnc_taskGetInsurgencyLocation.sqf";
                 recompile = RECOMPILE;
             };
             class taskMilAssault {
                 description = "Task Mil Assault";
-                file = "\x\alive\addons\mil_C2ISTAR\tasks\fnc_taskMilAssault.sqf";
+		            file = "\x\alive\addons\mil_c2istar\tasks\fnc_taskMilAssault.sqf";
                 recompile = RECOMPILE;
             };
             class taskMilDefence {
                 description = "Task Mil Defence";
-                file = "\x\alive\addons\mil_C2ISTAR\tasks\fnc_taskMilDefence.sqf";
+		            file = "\x\alive\addons\mil_c2istar\tasks\fnc_taskMilDefence.sqf";
                 recompile = RECOMPILE;
             };
             class taskCivAssault {
                 description = "Task Civ Assault";
-                file = "\x\alive\addons\mil_C2ISTAR\tasks\fnc_taskCivAssault.sqf";
+		            file = "\x\alive\addons\mil_c2istar\tasks\fnc_taskCivAssault.sqf";
                 recompile = RECOMPILE;
             };
             class taskAssassination {
                 description = "Task Assassination";
-                file = "\x\alive\addons\mil_C2ISTAR\tasks\fnc_taskAssassination.sqf";
+		            file = "\x\alive\addons\mil_c2istar\tasks\fnc_taskAssassination.sqf";
                 recompile = RECOMPILE;
             };
             class taskTransportInsertion {
                 description = "Task Transport Insertion";
-                file = "\x\alive\addons\mil_C2ISTAR\tasks\fnc_taskTransportInsertion.sqf";
+		            file = "\x\alive\addons\mil_c2istar\tasks\fnc_taskTransportInsertion.sqf";
                 recompile = RECOMPILE;
             };
             class taskDestroyVehicles {
                 description = "Task Destroy Vehicles";
-                file = "\x\alive\addons\mil_C2ISTAR\tasks\fnc_taskDestroyVehicles.sqf";
+		            file = "\x\alive\addons\mil_c2istar\tasks\fnc_taskTransportInsertion.sqf";
                 recompile = RECOMPILE;
             };
             class taskDestroyInfantry {
                 description = "Task Destroy Infantry";
-                file = "\x\alive\addons\mil_C2ISTAR\tasks\fnc_taskDestroyInfantry.sqf";
+		            file = "\x\alive\addons\mil_c2istar\tasks\fnc_taskDestroyInfantry.sqf";
                 recompile = RECOMPILE;
             };
             class taskSabotageBuilding {
                 description = "Task Destroy Infantry";
-                file = "\x\alive\addons\mil_C2ISTAR\tasks\fnc_taskSabotageBuilding.sqf";
+		            file = "\x\alive\addons\mil_c2istar\tasks\fnc_taskSabotageBuilding.sqf";
                 recompile = RECOMPILE;
             };
             class taskInsurgencyPatrol {
                 description = "Task Insurgency Patrol";
-                file = "\x\alive\addons\mil_C2ISTAR\tasks\fnc_taskInsurgencyPatrol.sqf";
+		            file = "\x\alive\addons\mil_c2istar\tasks\fnc_taskInsurgencyPatrol.sqf";
                 recompile = RECOMPILE;
             };
             class taskInsurgencyDestroyAssets {
                 description = "Task Insurgency Destroy Assets";
-                file = "\x\alive\addons\mil_C2ISTAR\tasks\fnc_taskInsurgencyDestroyAssets.sqf";
+		            file = "\x\alive\addons\mil_c2istar\tasks\fnc_taskInsurgencyDestroyAssets.sqf";
                 recompile = RECOMPILE;
             };
         };

--- a/addons/mil_command/CfgFunctions.hpp
+++ b/addons/mil_command/CfgFunctions.hpp
@@ -1,61 +1,17 @@
 class cfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class commandRouter {
-                description = "commandRouter";
-								file = PATHTO_FUNC(commandRouter);
-                recompile = RECOMPILE;
-            };
-            class testCommand {
-                description = "testCommand";
-								file = PATHTO_FUNC(testCommand);
-                recompile = RECOMPILE;
-            };
-            class testManagedCommand {
-                description = "testManagedCommand";
-								file = PATHTO_FUNC(testManagedCommand);
-                recompile = RECOMPILE;
-            };
-            class buildingPatrol {
-                description = "buildingPatrol";
-								file = PATHTO_FUNC(buildingPatrol);
-                recompile = RECOMPILE;
-            };
-            class managedBuildingPatrol {
-                description = "managedBuildingPatrol";
-								file = PATHTO_FUNC(managedBuildingPatrol);
-                recompile = RECOMPILE;
-            };
-            class ambientMovement {
-                description = "Ambient movement within a given radius";
-								file = PATHTO_FUNC(ambientMovement);
-                recompile = RECOMPILE;
-            };
-            class seaPatrol {
-                description = "Ambient sea patrol within a given radius";
-								file = PATHTO_FUNC(SeaPatrol);
-                recompile = RECOMPILE;
-            };
-            class garrison {
-                description = "Places units in building positions";
-								file = PATHTO_FUNC(garrison);
-                recompile = RECOMPILE;
-            };
-            class managedGarrison {
-                description = "managedGarrison";
-								file = PATHTO_FUNC(managedGarrison);
-                recompile = RECOMPILE;
-            };
-            class insurgents {
-                description = "Basic insurgents behaviour";
-								file = PATHTO_FUNC(insurgents);
-                recompile = RECOMPILE;
-            };
-            class ambush {
-                description = "Ambush behaviour";
-								file = PATHTO_FUNC(ambush);
-                recompile = RECOMPILE;
-            };
-        };
-    };
+						FUNC_FILEPATH(commandRouter,"commandRouter");
+						FUNC_FILEPATH(testCommand,"testCommand");
+						FUNC_FILEPATH(testManagedCommand,"testManagedCommand");
+						FUNC_FILEPATH(buildingPatrol,"buildingPatrol");
+						FUNC_FILEPATH(managedBuildingPatrol,"managedBuildingPatrol");
+						FUNC_FILEPATH(ambientMovement,"Ambient movement within a given radius");
+						FUNC_FILEPATH(seaPatrol,"Ambient sea patrol within a given radius");
+						FUNC_FILEPATH(garrison,"Places units in building positions");
+						FUNC_FILEPATH(managedGarrison,"managedGarrison");
+						FUNC_FILEPATH(insurgents,"Basic insurgents behaviour");
+						FUNC_FILEPATH(ambush,"Ambush behaviour");
+				};
+		};
 };

--- a/addons/mil_command/CfgFunctions.hpp
+++ b/addons/mil_command/CfgFunctions.hpp
@@ -3,57 +3,57 @@ class cfgFunctions {
         class COMPONENT {
             class commandRouter {
                 description = "commandRouter";
-                file = "\x\alive\addons\mil_command\fnc_commandRouter.sqf";
+								file = PATHTO_FUNC(commandRouter);
                 recompile = RECOMPILE;
             };
             class testCommand {
                 description = "testCommand";
-                file = "\x\alive\addons\mil_command\fnc_testCommand.sqf";
+								file = PATHTO_FUNC(testCommand);
                 recompile = RECOMPILE;
             };
             class testManagedCommand {
                 description = "testManagedCommand";
-                file = "\x\alive\addons\mil_command\fnc_testManagedCommand.sqf";
+								file = PATHTO_FUNC(testManagedCommand);
                 recompile = RECOMPILE;
             };
             class buildingPatrol {
                 description = "buildingPatrol";
-                file = "\x\alive\addons\mil_command\fnc_buildingPatrol.sqf";
+								file = PATHTO_FUNC(buildingPatrol);
                 recompile = RECOMPILE;
             };
             class managedBuildingPatrol {
                 description = "managedBuildingPatrol";
-                file = "\x\alive\addons\mil_command\fnc_managedBuildingPatrol.sqf";
+								file = PATHTO_FUNC(managedBuildingPatrol);
                 recompile = RECOMPILE;
             };
             class ambientMovement {
                 description = "Ambient movement within a given radius";
-                file = "\x\alive\addons\mil_command\fnc_ambientMovement.sqf";
+								file = PATHTO_FUNC(ambientMovement);
                 recompile = RECOMPILE;
             };
             class seaPatrol {
                 description = "Ambient sea patrol within a given radius";
-                file = "\x\alive\addons\mil_command\fnc_SeaPatrol.sqf";
+								file = PATHTO_FUNC(SeaPatrol);
                 recompile = RECOMPILE;
             };
             class garrison {
                 description = "Places units in building positions";
-                file = "\x\alive\addons\mil_command\fnc_garrison.sqf";
+								file = PATHTO_FUNC(garrison);
                 recompile = RECOMPILE;
             };
             class managedGarrison {
                 description = "managedGarrison";
-                file = "\x\alive\addons\mil_command\fnc_managedGarrison.sqf";
+								file = PATHTO_FUNC(managedGarrison);
                 recompile = RECOMPILE;
             };
             class insurgents {
                 description = "Basic insurgents behaviour";
-                file = "\x\alive\addons\mil_command\fnc_insurgents.sqf";
+								file = PATHTO_FUNC(insurgents);
                 recompile = RECOMPILE;
             };
             class ambush {
                 description = "Ambush behaviour";
-                file = "\x\alive\addons\mil_command\fnc_ambush.sqf";
+								file = PATHTO_FUNC(ambush);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/mil_convoy/CfgFunctions.hpp
+++ b/addons/mil_convoy/CfgFunctions.hpp
@@ -1,36 +1,12 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class convoy {
-                                description = "The main class";
-																file = PATHTO_FUNC(convoy);
-                recompile = RECOMPILE;
-                        };
-                        class CONVOYInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(CONVOYInit);
-                recompile = RECOMPILE;
-                        };
-                        class addVehicle {
-                                description = "Add vehicles";
-																file = PATHTO_FUNC(addVehicle);
-                recompile = RECOMPILE;
-                        };
-                         class inTrigger {
-                                description = "Random Group by Type";
-																file = PATHTO_FUNC(inTrigger);
-                                recompile = RECOMPILE;
-                        };
-                        class findLocations {
-                                description = "Find Locations";
-																file = PATHTO_FUNC(findLocations);
-                                recompile = RECOMPILE;
-                        };
-                        class startConvoy {
-                                description = "Random Group by Type";
-																file = PATHTO_FUNC(startConvoy);
-                                recompile = RECOMPILE;
-                        };
-                   };
-        };
+												FUNC_FILEPATH(convoy,"The main class");
+												FUNC_FILEPATH(CONVOYInit,"The module initialisation function");
+												FUNC_FILEPATH(addVehicle,"Add vehicles");
+												FUNC_FILEPATH(inTrigger,"Random Group by Type");
+												FUNC_FILEPATH(findLocations,"Find Locations");
+												FUNC_FILEPATH(startConvoy,"Random Group by Type");
+								};
+				};
 };

--- a/addons/mil_convoy/CfgFunctions.hpp
+++ b/addons/mil_convoy/CfgFunctions.hpp
@@ -3,32 +3,32 @@ class cfgFunctions {
                 class COMPONENT {
                         class convoy {
                                 description = "The main class";
-                                file = "\x\alive\addons\mil_convoy\fnc_convoy.sqf";
+																file = PATHTO_FUNC(convoy);
                 recompile = RECOMPILE;
                         };
                         class CONVOYInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\mil_convoy\fnc_CONVOYInit.sqf";
+																file = PATHTO_FUNC(CONVOYInit);
                 recompile = RECOMPILE;
                         };
                         class addVehicle {
                                 description = "Add vehicles";
-                                file = "\x\alive\addons\mil_convoy\fnc_addVehicle.sqf";
+																file = PATHTO_FUNC(addVehicle);
                 recompile = RECOMPILE;
                         };
                          class inTrigger {
                                 description = "Random Group by Type";
-                                file = "\x\alive\addons\mil_convoy\fnc_inTrigger.sqf";
+																file = PATHTO_FUNC(inTrigger);
                                 recompile = RECOMPILE;
                         };
                         class findLocations {
                                 description = "Find Locations";
-                                file = "\x\alive\addons\mil_convoy\fnc_findLocations.sqf";
+																file = PATHTO_FUNC(findLocations);
                                 recompile = RECOMPILE;
                         };
                         class startConvoy {
                                 description = "Random Group by Type";
-                                file = "\x\alive\addons\mil_convoy\fnc_startConvoy.sqf";
+																file = PATHTO_FUNC(startConvoy);
                                 recompile = RECOMPILE;
                         };
                    };

--- a/addons/mil_cqb/CfgFunctions.hpp
+++ b/addons/mil_cqb/CfgFunctions.hpp
@@ -1,51 +1,15 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class CQB {
-                                description = "The main class";
-																file = PATHTO_FUNC(CQB);
-                                recompile = RECOMPILE;
-                        };
-                        class CQBInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(CQBInit);
-                                recompile = RECOMPILE;
-                        };
-                        class CQBsortStrategicHouses {
-                                description = "The CQB blacklist function";
-																file = PATHTO_FUNC(CQBsortStrategicHouses);
-                                recompile = RECOMPILE;
-                        };
-                        class CQBSaveData {
-                                description = "CQB save data to DB";
-																file = PATHTO_FUNC(CQBSaveData);
-                                recompile = RECOMPILE;
-                        };
-                        class CQBLoadData {
-                                description = "CQB load data to DB";
-																file = PATHTO_FUNC(CQBLoadData);
-                                recompile = RECOMPILE;
-                        };
-                        class CQBMenuDef {
-                                description = "CQB Menu Definition";
-																file = PATHTO_FUNC(CQBMenuDef);
-                                recompile = RECOMPILE;
-                        };
-                        class addCQBPositions {
-                                description = "Enables CQB positions within the given radius of a position";
-																file = PATHTO_FUNC(addCQBPositions);
-                                recompile = RECOMPILE;
-                        };
-                        class removeCQBPositions{
-                                description = "Disables CQB positions within the given radius of a position";
-																file = PATHTO_FUNC(removeCQBPositions);
-                                recompile = RECOMPILE;
-                        };
-                        class resetCQB {
-                                description = "Resets CQB to run in the background without houses";
-																file = PATHTO_FUNC(resetCQB);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(CQB,"The main class");
+												FUNC_FILEPATH(CQBInit,"The module initialisation function");
+												FUNC_FILEPATH(CQBsortStrategicHouses,"The CQB blacklist function");
+												FUNC_FILEPATH(CQBSaveData,"CQB save data to DB");
+												FUNC_FILEPATH(CQBLoadData,"CQB load data to DB");
+												FUNC_FILEPATH(CQBMenuDef,"CQB Menu Definition");
+												FUNC_FILEPATH(addCQBPositions,"Enables CQB positions within the given radius of a position");
+												FUNC_FILEPATH(removeCQBPositions,"Disables CQB positions within the given radius of a position");
+												FUNC_FILEPATH(resetCQB,"Resets CQB to run in the background without houses");
+								};
+				};
 };

--- a/addons/mil_cqb/CfgFunctions.hpp
+++ b/addons/mil_cqb/CfgFunctions.hpp
@@ -3,47 +3,47 @@ class cfgFunctions {
                 class COMPONENT {
                         class CQB {
                                 description = "The main class";
-                                file = "\x\alive\addons\mil_cqb\fnc_CQB.sqf";
+																file = PATHTO_FUNC(CQB);
                                 recompile = RECOMPILE;
                         };
                         class CQBInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\mil_cqb\fnc_CQBInit.sqf";
+																file = PATHTO_FUNC(CQBInit);
                                 recompile = RECOMPILE;
                         };
                         class CQBsortStrategicHouses {
                                 description = "The CQB blacklist function";
-                                file = "\x\alive\addons\mil_cqb\fnc_CQBsortStrategicHouses.sqf";
+																file = PATHTO_FUNC(CQBsortStrategicHouses);
                                 recompile = RECOMPILE;
                         };
                         class CQBSaveData {
                                 description = "CQB save data to DB";
-                                file = "\x\alive\addons\mil_cqb\fnc_CQBSaveData.sqf";
+																file = PATHTO_FUNC(CQBSaveData);
                                 recompile = RECOMPILE;
                         };
                         class CQBLoadData {
                                 description = "CQB load data to DB";
-                                file = "\x\alive\addons\mil_cqb\fnc_CQBLoadData.sqf";
+																file = PATHTO_FUNC(CQBLoadData);
                                 recompile = RECOMPILE;
                         };
                         class CQBMenuDef {
                                 description = "CQB Menu Definition";
-                                file = "\x\alive\addons\mil_cqb\fnc_CQBMenuDef.sqf";
-                                                                recompile = RECOMPILE;
+																file = PATHTO_FUNC(CQBMenuDef);
+                                recompile = RECOMPILE;
                         };
                         class addCQBPositions {
                                 description = "Enables CQB positions within the given radius of a position";
-                                file = "\x\alive\addons\mil_cqb\fnc_addCQBPositions.sqf";
+																file = PATHTO_FUNC(addCQBPositions);
                                 recompile = RECOMPILE;
                         };
                         class removeCQBPositions{
                                 description = "Disables CQB positions within the given radius of a position";
-                                file = "\x\alive\addons\mil_cqb\fnc_removeCQBPositions.sqf";
+																file = PATHTO_FUNC(removeCQBPositions);
                                 recompile = RECOMPILE;
                         };
                         class resetCQB {
                                 description = "Resets CQB to run in the background without houses";
-                                file = "\x\alive\addons\mil_cqb\fnc_resetCQB.sqf";
+																file = PATHTO_FUNC(resetCQB);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/mil_ied/CfgFunctions.hpp
+++ b/addons/mil_ied/CfgFunctions.hpp
@@ -3,77 +3,77 @@ class cfgFunctions {
                 class COMPONENT {
                         class IED {
                                 description = "The main class";
-                                file = "\x\alive\addons\mil_ied\fnc_ied.sqf";
+																file = PATHTO_FUNC(ied);
                                 recompile = RECOMPILE;
                         };
                         class IEDInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\mil_ied\fnc_iedInit.sqf";
+																file = PATHTO_FUNC(iedInit);
                                 recompile = RECOMPILE;
                         };
                         class IEDMenuDef {
                                 description = "The module menu definition";
-                                file = "\x\alive\addons\mil_ied\fnc_iedMenuDef.sqf";
+																file = PATHTO_FUNC(iedMenuDef);
                                 recompile = RECOMPILE;
                         };
                         class createBomber {
                                 description = "Create an ambient suicide bomber";
-                                file = "\x\alive\addons\mil_ied\fnc_createBomber.sqf";
+																file = PATHTO_FUNC(createBomber);
                                 recompile = RECOMPILE;
                         };
                         class RemoveBomber {
                                 description = "Remove a suicide bomber";
-                                file = "\x\alive\addons\mil_ied\fnc_removeBomber.sqf";
+																file = PATHTO_FUNC(removeBomber);
                                 recompile = RECOMPILE;
                         };
                         class RemoveIED {
                                 description = "Remove an IED";
-                                file = "\x\alive\addons\mil_ied\fnc_removeIED.sqf";
+																file = PATHTO_FUNC(removeIED);
                                 recompile = RECOMPILE;
                         };
                         class placeIED {
                                 description = "Find a suitable location for an IED";
-                                file = "\x\alive\addons\mil_ied\fnc_placeIED.sqf";
+																file = PATHTO_FUNC(placeIED);
                                 recompile = RECOMPILE;
                         };
                         class placeVBIED {
                                 description = "Find a suitable location for an IED";
-                                file = "\x\alive\addons\mil_ied\fnc_placeVBIED.sqf";
+																file = PATHTO_FUNC(placeVBIED);
                                                                 recompile = RECOMPILE;
                         };
                         class armIED {
                                 description = "Arm an IED";
-                                file = "\x\alive\addons\mil_ied\fnc_armIED.sqf";
+																file = PATHTO_FUNC(armIED);
                                 recompile = RECOMPILE;
                         };
                         class createVBIED {
                                 description = "Create a VB-IED";
-                                file = "\x\alive\addons\mil_ied\fnc_createVBIED.sqf";
+																file = PATHTO_FUNC(createVBIED);
                                 recompile = RECOMPILE;
                         };
                         class disarmIED {
                                 description = "Disarm a IED";
-                                file = "\x\alive\addons\mil_ied\fnc_disarmIED.sqf";
+																file = PATHTO_FUNC(disarmIED);
                                 recompile = RECOMPILE;
                         };
                         class detectIED {
                                 description = "Detect a IED";
-                                file = "\x\alive\addons\mil_ied\fnc_detectIED.sqf";
+																file = PATHTO_FUNC(detectIED);
                                 recompile = RECOMPILE;
                         };
                         class createIED {
                                 description = "Create an IED";
-                                file = "\x\alive\addons\mil_ied\fnc_createIED.sqf";
+																file = PATHTO_FUNC(createIED);
                                 recompile = RECOMPILE;
                         };
                         class addActionIED {
                                 description = "Add an action to an IED";
-                                file = "\x\alive\addons\mil_ied\fnc_addActionIED.sqf";
+																file = PATHTO_FUNC(addActionIED);
                                 recompile = RECOMPILE;
                         };
                         class removeActionIED {
                                 description = "Remove an action from an IED";
-                                file = "\x\alive\addons\mil_ied\fnc_removeActionIED.sqf";
+																file = PATHTO_FUNC(removeActionIED);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/mil_ied/CfgFunctions.hpp
+++ b/addons/mil_ied/CfgFunctions.hpp
@@ -1,81 +1,21 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class IED {
-                                description = "The main class";
-																file = PATHTO_FUNC(ied);
-                                recompile = RECOMPILE;
-                        };
-                        class IEDInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(iedInit);
-                                recompile = RECOMPILE;
-                        };
-                        class IEDMenuDef {
-                                description = "The module menu definition";
-																file = PATHTO_FUNC(iedMenuDef);
-                                recompile = RECOMPILE;
-                        };
-                        class createBomber {
-                                description = "Create an ambient suicide bomber";
-																file = PATHTO_FUNC(createBomber);
-                                recompile = RECOMPILE;
-                        };
-                        class RemoveBomber {
-                                description = "Remove a suicide bomber";
-																file = PATHTO_FUNC(removeBomber);
-                                recompile = RECOMPILE;
-                        };
-                        class RemoveIED {
-                                description = "Remove an IED";
-																file = PATHTO_FUNC(removeIED);
-                                recompile = RECOMPILE;
-                        };
-                        class placeIED {
-                                description = "Find a suitable location for an IED";
-																file = PATHTO_FUNC(placeIED);
-                                recompile = RECOMPILE;
-                        };
-                        class placeVBIED {
-                                description = "Find a suitable location for an IED";
-																file = PATHTO_FUNC(placeVBIED);
-                                                                recompile = RECOMPILE;
-                        };
-                        class armIED {
-                                description = "Arm an IED";
-																file = PATHTO_FUNC(armIED);
-                                recompile = RECOMPILE;
-                        };
-                        class createVBIED {
-                                description = "Create a VB-IED";
-																file = PATHTO_FUNC(createVBIED);
-                                recompile = RECOMPILE;
-                        };
-                        class disarmIED {
-                                description = "Disarm a IED";
-																file = PATHTO_FUNC(disarmIED);
-                                recompile = RECOMPILE;
-                        };
-                        class detectIED {
-                                description = "Detect a IED";
-																file = PATHTO_FUNC(detectIED);
-                                recompile = RECOMPILE;
-                        };
-                        class createIED {
-                                description = "Create an IED";
-																file = PATHTO_FUNC(createIED);
-                                recompile = RECOMPILE;
-                        };
-                        class addActionIED {
-                                description = "Add an action to an IED";
-																file = PATHTO_FUNC(addActionIED);
-                                recompile = RECOMPILE;
-                        };
-                        class removeActionIED {
-                                description = "Remove an action from an IED";
-																file = PATHTO_FUNC(removeActionIED);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(IED,"The main class");
+												FUNC_FILEPATH(IEDInit,"The module initialisation function");
+												FUNC_FILEPATH(IEDMenuDef,"The module menu definition");
+												FUNC_FILEPATH(createBomber,"Create an ambient suicide bomber");
+												FUNC_FILEPATH(RemoveBomber,"Remove a suicide bomber");
+												FUNC_FILEPATH(RemoveIED,"Remove an IED");
+												FUNC_FILEPATH(placeIED,"Find a suitable location for an IED");
+												FUNC_FILEPATH(placeVBIED,"Find a suitable location for an IED");
+												FUNC_FILEPATH(armIED,"Arm an IED");
+												FUNC_FILEPATH(createVBIED,"Create a VB-IED");
+												FUNC_FILEPATH(disarmIED,"Disarm a IED");
+												FUNC_FILEPATH(detectIED,"Detect a IED");
+												FUNC_FILEPATH(createIED,"Create an IED");
+												FUNC_FILEPATH(addActionIED,"Add an action to an IED");
+												FUNC_FILEPATH(removeActionIED,"Remove an action from an IED");
+								};
+				};
 };

--- a/addons/mil_intelligence/CfgFunctions.hpp
+++ b/addons/mil_intelligence/CfgFunctions.hpp
@@ -1,36 +1,12 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class MI {
-                                description = "The main class";
-																file = PATHTO_FUNC(MI);
-                                recompile = RECOMPILE;
-                        };
-                        class MIInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(MIInit);
-                                recompile = RECOMPILE;
-                        };
-                        class SD {
-                                description = "The main class";
-																file = PATHTO_FUNC(SD);
-                                recompile = RECOMPILE;
-                        };
-                        class SDInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(SDInit);
-                                recompile = RECOMPILE;
-                        };
-                        class PSD {
-                                description = "The main class";
-																file = PATHTO_FUNC(PSD);
-                                recompile = RECOMPILE;
-                        };
-                        class PSDInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(PSDInit);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(MI,"The main class");
+												FUNC_FILEPATH(MIInit,"The module initialisation function");
+												FUNC_FILEPATH(SD,"The main class");
+												FUNC_FILEPATH(SDInit,"The module initialisation function");
+												FUNC_FILEPATH(PSD,"The main class");
+												FUNC_FILEPATH(PSDInit,"The module initialisation function");
+								};
+				};
 };

--- a/addons/mil_intelligence/CfgFunctions.hpp
+++ b/addons/mil_intelligence/CfgFunctions.hpp
@@ -3,32 +3,32 @@ class cfgFunctions {
                 class COMPONENT {
                         class MI {
                                 description = "The main class";
-                                file = "\x\alive\addons\mil_intelligence\fnc_MI.sqf";
+																file = PATHTO_FUNC(MI);
                                 recompile = RECOMPILE;
                         };
                         class MIInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\mil_intelligence\fnc_MIInit.sqf";
+																file = PATHTO_FUNC(MIInit);
                                 recompile = RECOMPILE;
                         };
                         class SD {
                                 description = "The main class";
-                                file = "\x\alive\addons\mil_intelligence\fnc_SD.sqf";
+																file = PATHTO_FUNC(SD);
                                 recompile = RECOMPILE;
                         };
                         class SDInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\mil_intelligence\fnc_SDInit.sqf";
+																file = PATHTO_FUNC(SDInit);
                                 recompile = RECOMPILE;
                         };
                         class PSD {
                                 description = "The main class";
-                                file = "\x\alive\addons\mil_intelligence\fnc_PSD.sqf";
+																file = PATHTO_FUNC(PSD);
                                 recompile = RECOMPILE;
                         };
                         class PSDInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\mil_intelligence\fnc_PSDInit.sqf";
+																file = PATHTO_FUNC(PSDInit);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/mil_logistics/CfgFunctions.hpp
+++ b/addons/mil_logistics/CfgFunctions.hpp
@@ -1,31 +1,11 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class ML {
-                                description = "The main class";
-																file = PATHTO_FUNC(ML);
-                                recompile = RECOMPILE;
-                        };
-                        class MLInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(MLInit);
-                                recompile = RECOMPILE;
-                        };
-                        class MLGlobalRegistry {
-                                description = "Handles global module registry and forcepools";
-																file = PATHTO_FUNC(MLGlobalRegistry);
-                                recompile = RECOMPILE;
-                        };
-                        class MLLoadData {
-                                description = "Load persistent data";
-																file = PATHTO_FUNC(MLLoadData);
-                                recompile = RECOMPILE;
-                        };
-                        class MLSaveData {
-                                description = "Save persistent data";
-																file = PATHTO_FUNC(MLSaveData);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(ML,"The main class");
+												FUNC_FILEPATH(MLInit,"The module initialisation function");
+												FUNC_FILEPATH(MLGlobalRegistry,"Handles global module registry and forcepools");
+												FUNC_FILEPATH(MLLoadData,"Load persistent data");
+												FUNC_FILEPATH(MLSaveData,"Save persistent data");
+								};
+				};
 };

--- a/addons/mil_logistics/CfgFunctions.hpp
+++ b/addons/mil_logistics/CfgFunctions.hpp
@@ -3,27 +3,27 @@ class cfgFunctions {
                 class COMPONENT {
                         class ML {
                                 description = "The main class";
-                                file = "\x\alive\addons\mil_logistics\fnc_ML.sqf";
+																file = PATHTO_FUNC(ML);
                                 recompile = RECOMPILE;
                         };
                         class MLInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\mil_logistics\fnc_MLInit.sqf";
+																file = PATHTO_FUNC(MLInit);
                                 recompile = RECOMPILE;
                         };
                         class MLGlobalRegistry {
                                 description = "Handles global module registry and forcepools";
-                                file = "\x\alive\addons\mil_logistics\fnc_MLGlobalRegistry.sqf";
+																file = PATHTO_FUNC(MLGlobalRegistry);
                                 recompile = RECOMPILE;
                         };
                         class MLLoadData {
                                 description = "Load persistent data";
-                                file = "\x\alive\addons\mil_logistics\fnc_MLLoadData.sqf";
+																file = PATHTO_FUNC(MLLoadData);
                                 recompile = RECOMPILE;
                         };
                         class MLSaveData {
                                 description = "Save persistent data";
-                                file = "\x\alive\addons\mil_logistics\fnc_MLSaveData.sqf";
+																file = PATHTO_FUNC(MLSaveData);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/mil_opcom/CfgFunctions.hpp
+++ b/addons/mil_opcom/CfgFunctions.hpp
@@ -1,61 +1,17 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class OPCOM {
-                                description = "The main class";
-																file = PATHTO_FUNC(OPCOM);
-                                recompile = RECOMPILE;
-                        };
-                        class OPCOMInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(OPCOMInit);
-                                recompile = RECOMPILE;
-                        };
-                        class OPCOMpositions {
-                                description = "Selects OPCOM objective positions of given state";
-																file = PATHTO_FUNC(OPCOMpositions);
-                                recompile = RECOMPILE;
-                        };
-                        class OPCOMLoadData {
-                                description = "Loads OPCOM state from DB";
-																file = PATHTO_FUNC(OPCOMLoadData);
-                                recompile = RECOMPILE;
-                        };
-                        class OPCOMSaveData {
-                                description = "Saves OPCOM state from DB";
-																file = PATHTO_FUNC(OPCOMSaveData);
-                                recompile = RECOMPILE;
-                        };
-                        class OPCOMjoinNearestGroup {
-                                description = "Joins the given unit to the nearest group of given state (attacking/defending)";
-																file = PATHTO_FUNC(OPCOMjoinNearestGroup);
-                                recompile = RECOMPILE;
-                        };
-                        class OPCOMJoinObjective {
-                                description = "Joins the given unit to a group that is attacking/defending the selected objective!";
-																file = PATHTO_FUNC(OPCOMJoinObjective);
-                                recompile = RECOMPILE;
-                        };
-                        class OPCOMToggleInstallations {
-                                description = "Toggles Installation markers on / off";
-																file = PATHTO_FUNC(OPCOMToggleInstallations);
-                                recompile = RECOMPILE;
-                        };
-                        class updateSectorHostility {
-                                description = "Updates the current sector of position with given value";
-																file = PATHTO_FUNC(updateSectorHostility);
-                                recompile = RECOMPILE;
-                        };
-                        class INS_helpers {
-                                description = "Loads the parent function for the Insurgency helper functions";
-																file = PATHTO_FUNC(INS_helpers);
-                                recompile = RECOMPILE;
-                        };
-                        class OPCOMDropIntel {
-                                description = "Drops Intel by chance";
-																file = PATHTO_FUNC(OPCOMDropIntel);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(OPCOM,"The main class");
+												FUNC_FILEPATH(OPCOMInit,"The module initialisation function");
+												FUNC_FILEPATH(OPCOMpositions,"Selects OPCOM objective positions of given state");
+												FUNC_FILEPATH(OPCOMLoadData,"Loads OPCOM state from DB");
+												FUNC_FILEPATH(OPCOMSaveData,"Saves OPCOM state from DB");
+												FUNC_FILEPATH(OPCOMjoinNearestGroup,"Joins the given unit to the nearest group of given state (attacking/defending)");
+												FUNC_FILEPATH(OPCOMJoinObjective,"Joins the given unit to a group that is attacking/defending the selected objective!");
+												FUNC_FILEPATH(OPCOMToggleInstallations,"Toggles Installation markers on / off");
+												FUNC_FILEPATH(updateSectorHostility,"Updates the current sector of position with given value");
+												FUNC_FILEPATH(INS_helpers,"Loads the parent function for the Insurgency helper functions");
+												FUNC_FILEPATH(OPCOMDropIntel,"Drops Intel by chance");
+								};
+				};
 };

--- a/addons/mil_opcom/CfgFunctions.hpp
+++ b/addons/mil_opcom/CfgFunctions.hpp
@@ -3,57 +3,57 @@ class cfgFunctions {
                 class COMPONENT {
                         class OPCOM {
                                 description = "The main class";
-                                file = "\x\alive\addons\mil_opcom\fnc_OPCOM.sqf";
+																file = PATHTO_FUNC(OPCOM);
                                 recompile = RECOMPILE;
                         };
                         class OPCOMInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\mil_opcom\fnc_OPCOMInit.sqf";
+																file = PATHTO_FUNC(OPCOMInit);
                                 recompile = RECOMPILE;
                         };
                         class OPCOMpositions {
                                 description = "Selects OPCOM objective positions of given state";
-                                file = "\x\alive\addons\mil_opcom\fnc_OPCOMpositions.sqf";
+																file = PATHTO_FUNC(OPCOMpositions);
                                 recompile = RECOMPILE;
                         };
                         class OPCOMLoadData {
                                 description = "Loads OPCOM state from DB";
-                                file = "\x\alive\addons\mil_opcom\fnc_OPCOMLoadData.sqf";
+																file = PATHTO_FUNC(OPCOMLoadData);
                                 recompile = RECOMPILE;
                         };
                         class OPCOMSaveData {
                                 description = "Saves OPCOM state from DB";
-                                file = "\x\alive\addons\mil_opcom\fnc_OPCOMSaveData.sqf";
+																file = PATHTO_FUNC(OPCOMSaveData);
                                 recompile = RECOMPILE;
                         };
                         class OPCOMjoinNearestGroup {
                                 description = "Joins the given unit to the nearest group of given state (attacking/defending)";
-                                file = "\x\alive\addons\mil_opcom\fnc_OPCOMjoinNearestGroup.sqf";
+																file = PATHTO_FUNC(OPCOMjoinNearestGroup);
                                 recompile = RECOMPILE;
                         };
                         class OPCOMJoinObjective {
                                 description = "Joins the given unit to a group that is attacking/defending the selected objective!";
-                                file = "\x\alive\addons\mil_opcom\fnc_OPCOMJoinObjective.sqf";
+																file = PATHTO_FUNC(OPCOMJoinObjective);
                                 recompile = RECOMPILE;
                         };
                         class OPCOMToggleInstallations {
                                 description = "Toggles Installation markers on / off";
-                                file = "\x\alive\addons\mil_opcom\fnc_OPCOMToggleInstallations.sqf";
+																file = PATHTO_FUNC(OPCOMToggleInstallations);
                                 recompile = RECOMPILE;
                         };
                         class updateSectorHostility {
                                 description = "Updates the current sector of position with given value";
-                                file = "\x\alive\addons\mil_opcom\fnc_updateSectorHostility.sqf";
+																file = PATHTO_FUNC(updateSectorHostility);
                                 recompile = RECOMPILE;
                         };
                         class INS_helpers {
                                 description = "Loads the parent function for the Insurgency helper functions";
-                                file = "\x\alive\addons\mil_opcom\fnc_INS_helpers.sqf";
+																file = PATHTO_FUNC(INS_helpers);
                                 recompile = RECOMPILE;
                         };
                         class OPCOMDropIntel {
                                 description = "Drops Intel by chance";
-                                file = "\x\alive\addons\mil_opcom\fnc_OPCOMDropIntel.sqf";
+																file = PATHTO_FUNC(OPCOMDropIntel);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/mil_placement/CfgFunctions.hpp
+++ b/addons/mil_placement/CfgFunctions.hpp
@@ -3,22 +3,22 @@ class cfgFunctions {
                 class COMPONENT {
                         class MP {
                                 description = "The main class";
-                                file = "\x\alive\addons\mil_placement\fnc_MP.sqf";
+																file = PATHTO_FUNC(MP);
                                 recompile = RECOMPILE;
                         };
                         class MPInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\mil_placement\fnc_MPInit.sqf";
+																file = PATHTO_FUNC(MPInit);
                                 recompile = RECOMPILE;
                         };
             class milClusterGeneration {
                                 description = "Generates static cluster output";
-                                file = "\x\alive\addons\mil_placement\fnc_milClusterGeneration.sqf";
+																file = PATHTO_FUNC(milClusterGeneration);
                                 recompile = RECOMPILE;
                         };
                         class auto_milClusterGeneration {
                                 description = "Auto generates static cluster output";
-                                file = "\x\alive\addons\mil_placement\fnc_auto_milClusterGeneration.sqf";
+																file = PATHTO_FUNC(auto_milClusterGeneration);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/mil_placement/CfgFunctions.hpp
+++ b/addons/mil_placement/CfgFunctions.hpp
@@ -1,26 +1,10 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class MP {
-                                description = "The main class";
-																file = PATHTO_FUNC(MP);
-                                recompile = RECOMPILE;
-                        };
-                        class MPInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(MPInit);
-                                recompile = RECOMPILE;
-                        };
-            class milClusterGeneration {
-                                description = "Generates static cluster output";
-																file = PATHTO_FUNC(milClusterGeneration);
-                                recompile = RECOMPILE;
-                        };
-                        class auto_milClusterGeneration {
-                                description = "Auto generates static cluster output";
-																file = PATHTO_FUNC(auto_milClusterGeneration);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(MP,"The main class");
+												FUNC_FILEPATH(MPInit,"The module initialisation function");
+						            FUNC_FILEPATH(milClusterGeneration,"Generates static cluster output");
+												FUNC_FILEPATH(auto_milClusterGeneration,"Auto generates static cluster output");
+								};
+				};
 };

--- a/addons/mil_placement_custom/CfgFunctions.hpp
+++ b/addons/mil_placement_custom/CfgFunctions.hpp
@@ -3,12 +3,12 @@ class cfgFunctions {
                 class COMPONENT {
                         class CMP {
                                 description = "The main class";
-                                file = "\x\alive\addons\mil_placement_custom\fnc_CMP.sqf";
+																file = PATHTO_FUNC(CMP);
                                 recompile = RECOMPILE;
                         };
                         class CMPInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\mil_placement_custom\fnc_CMPInit.sqf";
+																file = PATHTO_FUNC(CMPInit);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/mil_placement_custom/CfgFunctions.hpp
+++ b/addons/mil_placement_custom/CfgFunctions.hpp
@@ -1,16 +1,8 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class CMP {
-                                description = "The main class";
-																file = PATHTO_FUNC(CMP);
-                                recompile = RECOMPILE;
-                        };
-                        class CMPInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(CMPInit);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(CMP,"The main class");
+												FUNC_FILEPATH(CMPInit,"The module initialisation function");
+								};
+				};
 };

--- a/addons/sup_artillery/CfgFunctions.hpp
+++ b/addons/sup_artillery/CfgFunctions.hpp
@@ -3,12 +3,12 @@ class cfgFunctions {
                 class COMPONENT {
                         class ARTILLERY {
                                 description = "The main class";
-                                file = "\x\alive\addons\sup_artillery\fnc_artillery.sqf";
+																file = PATHTO_FUNC(artillery);
                 recompile = RECOMPILE;
                         };
                         class artilleryInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sup_artillery\fnc_artilleryInit.sqf";
+																file = PATHTO_FUNC(artilleryInit);
                 recompile = RECOMPILE;
                         };
                    };

--- a/addons/sup_artillery/CfgFunctions.hpp
+++ b/addons/sup_artillery/CfgFunctions.hpp
@@ -1,16 +1,8 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class ARTILLERY {
-                                description = "The main class";
-																file = PATHTO_FUNC(artillery);
-                recompile = RECOMPILE;
-                        };
-                        class artilleryInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(artilleryInit);
-                recompile = RECOMPILE;
-                        };
-                   };
-        };
+												FUNC_FILEPATH(ARTILLERY,"The main class");
+												FUNC_FILEPATH(artilleryInit,"The module initialisation function");
+								};
+				};
 };

--- a/addons/sup_cas/CfgFunctions.hpp
+++ b/addons/sup_cas/CfgFunctions.hpp
@@ -1,16 +1,8 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class CAS {
-                                description = "The main class";
-																file = PATHTO_FUNC(CAS);
-                recompile = RECOMPILE;
-                        };
-                        class CASInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(CASInit);
-                recompile = RECOMPILE;
-                        };
-                   };
-        };
+												FUNC_FILEPATH(CAS,"The main class");
+												FUNC_FILEPATH(CASInit,"The module initialisation function");
+								};
+				};
 };

--- a/addons/sup_cas/CfgFunctions.hpp
+++ b/addons/sup_cas/CfgFunctions.hpp
@@ -3,12 +3,12 @@ class cfgFunctions {
                 class COMPONENT {
                         class CAS {
                                 description = "The main class";
-                                file = "\x\alive\addons\sup_cas\fnc_CAS.sqf";
+																file = PATHTO_FUNC(CAS);
                 recompile = RECOMPILE;
                         };
                         class CASInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sup_cas\fnc_CASInit.sqf";
+																file = PATHTO_FUNC(CASInit);
                 recompile = RECOMPILE;
                         };
                    };

--- a/addons/sup_combatsupport/CfgFunctions.hpp
+++ b/addons/sup_combatsupport/CfgFunctions.hpp
@@ -1,50 +1,22 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class combatSupportFncInit {
-                                description = "The main class";
-																file = PATHTO_FUNC(combatSupportFncInit);
-                                recompile = RECOMPILE;
+												FUNC_FILEPATH(combatSupportFncInit,"The main class");
+												FUNC_FILEPATH(combatSupport,"The main class");
+												FUNC_FILEPATH(combatSupportInit,"The module initialisation function");
+												FUNC_FILEPATH(radioAction,"The module Radio Action function");
+												FUNC_FILEPATH(combatSupportMenuDef,"The module menu definition");
+												FUNC_FILEPATH(packMortar,"Enables a group to pack a mortar");
+												FUNC_FILEPATH(unpackMortar,"Enables a group to unpack a mortar");
+                        class combatSupportAdd {
+                          description = "Adds Combat Support unit via script";
+                          file = "\x\alive\addons\sup_combatsupport\scripts\NEO_radio\functions\misc\fn_supportAdd.sqf";
+                          recompile = RECOMPILE;
                         };
-                        class combatSupport {
-                                description = "The main class";
-																file = PATHTO_FUNC(combatSupport);
-                                recompile = RECOMPILE;
-                        };
-                        class combatSupportInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(combatSupportInit);
-                                recompile = RECOMPILE;
-                        };
-                          class radioAction {
-                                description = "The module Radio Action function";
-																file = PATHTO_FUNC(radioAction);
-                                recompile = RECOMPILE;
-                        };
-                        class combatSupportMenuDef {
-                                description = "The module menu definition";
-																file = PATHTO_FUNC(combatSupportMenuDef);
-                                recompile = RECOMPILE;
-                        };
-                        class packMortar {
-                                description = "Enables a group to pack a mortar";
-																file = PATHTO_FUNC(packMortar);
-                                recompile = RECOMPILE;
-                        };
-                        class unpackMortar {
-                                description = "Enables a group to unpack a mortar";
-																file = PATHTO_FUNC(unpackMortar);
-                                recompile = RECOMPILE;
-                        };
-                          class combatSupportAdd {
-                                description = "Adds Combat Support unit via script";
-                                file = "\x\alive\addons\sup_combatsupport\scripts\NEO_radio\functions\misc\fn_supportAdd.sqf";
-                                recompile = RECOMPILE;
-                        };
-                           class combatSupportRemove{
-                                description = "Removes Combat Support unit via script";
-                                file = "\x\alive\addons\sup_combatsupport\scripts\NEO_radio\functions\misc\fn_supportRemove.sqf";
-                                recompile = RECOMPILE;
+                        class combatSupportRemove {
+                          description = "Removes Combat Support unit via script";
+                          file = "\x\alive\addons\sup_combatsupport\scripts\NEO_radio\functions\misc\fn_supportRemove.sqf";
+                          recompile = RECOMPILE;
                         };
                 };
         };

--- a/addons/sup_combatsupport/CfgFunctions.hpp
+++ b/addons/sup_combatsupport/CfgFunctions.hpp
@@ -3,37 +3,37 @@ class cfgFunctions {
                 class COMPONENT {
                         class combatSupportFncInit {
                                 description = "The main class";
-                                file = "\x\alive\addons\sup_combatsupport\fnc_combatSupportFncInit.sqf";
+																file = PATHTO_FUNC(combatSupportFncInit);
                                 recompile = RECOMPILE;
                         };
                         class combatSupport {
                                 description = "The main class";
-                                file = "\x\alive\addons\sup_combatsupport\fnc_combatSupport.sqf";
+																file = PATHTO_FUNC(combatSupport);
                                 recompile = RECOMPILE;
                         };
                         class combatSupportInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sup_combatsupport\fnc_combatSupportInit.sqf";
+																file = PATHTO_FUNC(combatSupportInit);
                                 recompile = RECOMPILE;
                         };
                           class radioAction {
                                 description = "The module Radio Action function";
-                                file = "\x\alive\addons\sup_combatsupport\fnc_radioAction.sqf";
+																file = PATHTO_FUNC(radioAction);
                                 recompile = RECOMPILE;
                         };
                         class combatSupportMenuDef {
                                 description = "The module menu definition";
-                                file = "\x\alive\addons\sup_combatsupport\fnc_combatSupportMenuDef.sqf";
+																file = PATHTO_FUNC(combatSupportMenuDef);
                                 recompile = RECOMPILE;
                         };
                         class packMortar {
                                 description = "Enables a group to pack a mortar";
-                                file = "\x\alive\addons\sup_combatsupport\fnc_packMortar.sqf";
+																file = PATHTO_FUNC(packMortar);
                                 recompile = RECOMPILE;
                         };
                         class unpackMortar {
                                 description = "Enables a group to unpack a mortar";
-                                file = "\x\alive\addons\sup_combatsupport\fnc_unpackMortar.sqf";
+																file = PATHTO_FUNC(unpackMortar);
                                 recompile = RECOMPILE;
                         };
                           class combatSupportAdd {
@@ -49,4 +49,3 @@ class cfgFunctions {
                 };
         };
 };
-

--- a/addons/sup_command/CfgFunctions.hpp
+++ b/addons/sup_command/CfgFunctions.hpp
@@ -3,37 +3,37 @@ class CfgFunctions {
         class COMPONENT {
             class SCOM {
                 description = "The main class";
-                file = "\x\alive\addons\sup_command\fnc_SCOM.sqf";
+								file = PATHTO_FUNC(SCOM);
                 recompile = RECOMPILE;
             };
             class SCOMInit {
                 description = "The module initialisation function";
-                file = "\x\alive\addons\sup_command\fnc_SCOMInit.sqf";
+								file = PATHTO_FUNC(SCOMInit);
                 recompile = RECOMPILE;
             };
             class SCOMTabletOnAction {
                 description = "The module Radio Action function";
-                file = "\x\alive\addons\sup_command\fnc_SCOMTabletOnAction.sqf";
+								file = PATHTO_FUNC(SCOMTabletOnAction);
                 recompile = RECOMPILE;
             };
             class SCOMTabletOnLoad {
                 description = "The module tablet on load function";
-                file = "\x\alive\addons\sup_command\fnc_SCOMTabletOnLoad.sqf";
+								file = PATHTO_FUNC(SCOMTabletOnLoad);
                 recompile = RECOMPILE;
             };
             class SCOMTabletOnUnLoad {
                 description = "The module tablet on unload function";
-                file = "\x\alive\addons\sup_command\fnc_SCOMTabletOnUnLoad.sqf";
+								file = PATHTO_FUNC(SCOMTabletOnUnload);
                 recompile = RECOMPILE;
             };
             class SCOMTabletEventToClient {
                 description = "Call the tablet on the client from the server";
-                file = "\x\alive\addons\sup_command\fnc_SCOMTabletEventToClient.sqf";
+								file = PATHTO_FUNC(SCOMTabletEventToClient);
                 recompile = RECOMPILE;
             };
             class commandHandler {
                 description = "Command Handler";
-                file = "\x\alive\addons\sup_command\fnc_commandHandler.sqf";
+								file = PATHTO_FUNC(commandHandler);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/sup_command/CfgFunctions.hpp
+++ b/addons/sup_command/CfgFunctions.hpp
@@ -1,41 +1,13 @@
 class CfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class SCOM {
-                description = "The main class";
-								file = PATHTO_FUNC(SCOM);
-                recompile = RECOMPILE;
-            };
-            class SCOMInit {
-                description = "The module initialisation function";
-								file = PATHTO_FUNC(SCOMInit);
-                recompile = RECOMPILE;
-            };
-            class SCOMTabletOnAction {
-                description = "The module Radio Action function";
-								file = PATHTO_FUNC(SCOMTabletOnAction);
-                recompile = RECOMPILE;
-            };
-            class SCOMTabletOnLoad {
-                description = "The module tablet on load function";
-								file = PATHTO_FUNC(SCOMTabletOnLoad);
-                recompile = RECOMPILE;
-            };
-            class SCOMTabletOnUnLoad {
-                description = "The module tablet on unload function";
-								file = PATHTO_FUNC(SCOMTabletOnUnload);
-                recompile = RECOMPILE;
-            };
-            class SCOMTabletEventToClient {
-                description = "Call the tablet on the client from the server";
-								file = PATHTO_FUNC(SCOMTabletEventToClient);
-                recompile = RECOMPILE;
-            };
-            class commandHandler {
-                description = "Command Handler";
-								file = PATHTO_FUNC(commandHandler);
-                recompile = RECOMPILE;
-            };
-        };
-    };
+						FUNC_FILEPATH(SCOM,"The main class");
+						FUNC_FILEPATH(SCOMInit,"The module initialisation function");
+						FUNC_FILEPATH(SCOMTabletOnAction,"The module Radio Action function");
+						FUNC_FILEPATH(SCOMTabletOnLoad,"The module tablet on load function");
+						FUNC_FILEPATH(SCOMTabletOnUnLoad,"The module tablet on unload function");
+						FUNC_FILEPATH(SCOMTabletEventToClient,"Call the tablet on the client from the server");
+						FUNC_FILEPATH(commandHandler,"Command Handler");
+				};
+		};
 };

--- a/addons/sup_group_manager/CfgFunctions.hpp
+++ b/addons/sup_group_manager/CfgFunctions.hpp
@@ -3,37 +3,37 @@ class CfgFunctions {
         class COMPONENT {
             class GM {
                 description = "The main class";
-                file = "\x\alive\addons\sup_group_manager\fnc_GM.sqf";
+								file = PATHTO_FUNC(GM);
                 recompile = RECOMPILE;
             };
             class GMInit {
                 description = "The module initialisation function";
-                file = "\x\alive\addons\sup_group_manager\fnc_GMInit.sqf";
+								file = PATHTO_FUNC(GMInit);
                 recompile = RECOMPILE;
             };
             class GMTabletOnAction {
                 description = "The module Radio Action function";
-                file = "\x\alive\addons\sup_group_manager\fnc_GMTabletOnAction.sqf";
+								file = PATHTO_FUNC(GMTabletOnAction);
                 recompile = RECOMPILE;
             };
             class GMTabletOnLoad {
                 description = "The module tablet on load function";
-                file = "\x\alive\addons\sup_group_manager\fnc_GMTabletOnLoad.sqf";
+								file = PATHTO_FUNC(GMTabletOnLoad);
                 recompile = RECOMPILE;
             };
             class GMTabletOnUnLoad {
                 description = "The module tablet on unload function";
-                file = "\x\alive\addons\sup_group_manager\fnc_GMTabletOnUnLoad.sqf";
+								file = PATHTO_FUNC(GMTabletOnUnLoad);
                 recompile = RECOMPILE;
             };
             class GMTabletEventToClient {
                 description = "Call the tablet on the client from the server";
-                file = "\x\alive\addons\sup_group_manager\fnc_GMTabletEventToClient.sqf";
+								file = PATHTO_FUNC(GMTabletEventToClient);
                 recompile = RECOMPILE;
             };
             class groupHandler {
                 description = "Group Handler";
-                file = "\x\alive\addons\sup_group_manager\fnc_groupHandler.sqf";
+								file = PATHTO_FUNC(groupHandler);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/sup_group_manager/CfgFunctions.hpp
+++ b/addons/sup_group_manager/CfgFunctions.hpp
@@ -1,41 +1,13 @@
 class CfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class GM {
-                description = "The main class";
-								file = PATHTO_FUNC(GM);
-                recompile = RECOMPILE;
-            };
-            class GMInit {
-                description = "The module initialisation function";
-								file = PATHTO_FUNC(GMInit);
-                recompile = RECOMPILE;
-            };
-            class GMTabletOnAction {
-                description = "The module Radio Action function";
-								file = PATHTO_FUNC(GMTabletOnAction);
-                recompile = RECOMPILE;
-            };
-            class GMTabletOnLoad {
-                description = "The module tablet on load function";
-								file = PATHTO_FUNC(GMTabletOnLoad);
-                recompile = RECOMPILE;
-            };
-            class GMTabletOnUnLoad {
-                description = "The module tablet on unload function";
-								file = PATHTO_FUNC(GMTabletOnUnLoad);
-                recompile = RECOMPILE;
-            };
-            class GMTabletEventToClient {
-                description = "Call the tablet on the client from the server";
-								file = PATHTO_FUNC(GMTabletEventToClient);
-                recompile = RECOMPILE;
-            };
-            class groupHandler {
-                description = "Group Handler";
-								file = PATHTO_FUNC(groupHandler);
-                recompile = RECOMPILE;
-            };
-        };
-    };
+						FUNC_FILEPATH(GM,"The main class");
+						FUNC_FILEPATH(GMInit,"The module initialisation function");
+						FUNC_FILEPATH(GMTabletOnAction,"The module Radio Action function");
+						FUNC_FILEPATH(GMTabletOnLoad,"The module tablet on load function");
+						FUNC_FILEPATH(GMTabletOnUnLoad,"The module tablet on unload function");
+						FUNC_FILEPATH(GMTabletEventToClient,"Call the tablet on the client from the server");
+						FUNC_FILEPATH(groupHandler,"Group Handler");
+				};
+		};
 };

--- a/addons/sup_multispawn/CfgFunctions.hpp
+++ b/addons/sup_multispawn/CfgFunctions.hpp
@@ -1,31 +1,11 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class multispawn {
-                                description = "The main class";
-																file = PATHTO_FUNC(multispawn);
-                                recompile = RECOMPILE;
-                        };
-                        class multispawnInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(multispawnInit);
-                                recompile = RECOMPILE;
-                        };
-                        class multispawnMenuDef {
-                                description = "The module menu definition";
-																file = PATHTO_FUNC(multispawnMenuDef);
-                                recompile = RECOMPILE;
-                        };
-                        class forwardSpawn {
-                                description = "The spawn function that lets you selects a group unit and spawn near it";
-																file = PATHTO_FUNC(forwardSpawn);
-                                recompile = RECOMPILE;
-                        };
-                        class establishingShotCustom {
-                                description = "Camera waiting scene for insertion";
-																file = PATHTO_FUNC(establishingShotCustom);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(multispawn,"The main class");
+												FUNC_FILEPATH(multispawnInit,"The module initialisation function");
+												FUNC_FILEPATH(multispawnMenuDef,"The module menu definition");
+												FUNC_FILEPATH(forwardSpawn,"The spawn function that lets you selects a group unit and spawn near it");
+												FUNC_FILEPATH(establishingShotCustom,"Camera waiting scene for insertion");
+								};
+				};
 };

--- a/addons/sup_multispawn/CfgFunctions.hpp
+++ b/addons/sup_multispawn/CfgFunctions.hpp
@@ -3,27 +3,27 @@ class cfgFunctions {
                 class COMPONENT {
                         class multispawn {
                                 description = "The main class";
-                                file = "\x\alive\addons\sup_multispawn\fnc_multispawn.sqf";
+																file = PATHTO_FUNC(multispawn);
                                 recompile = RECOMPILE;
                         };
                         class multispawnInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sup_multispawn\fnc_multispawnInit.sqf";
+																file = PATHTO_FUNC(multispawnInit);
                                 recompile = RECOMPILE;
                         };
                         class multispawnMenuDef {
                                 description = "The module menu definition";
-                                file = "\x\alive\addons\sup_multispawn\fnc_multispawnMenuDef.sqf";
+																file = PATHTO_FUNC(multispawnMenuDef);
                                 recompile = RECOMPILE;
                         };
                         class forwardSpawn {
                                 description = "The spawn function that lets you selects a group unit and spawn near it";
-                                file = "\x\alive\addons\sup_multispawn\fnc_forwardSpawn.sqf";
+																file = PATHTO_FUNC(forwardSpawn);
                                 recompile = RECOMPILE;
                         };
                         class establishingShotCustom {
                                 description = "Camera waiting scene for insertion";
-                                file = "\x\alive\addons\sup_multispawn\fnc_establishingShotCustom.sqf";
+																file = PATHTO_FUNC(establishingShotCustom);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/sup_player_resupply/CfgFunctions.hpp
+++ b/addons/sup_player_resupply/CfgFunctions.hpp
@@ -3,37 +3,37 @@ class CfgFunctions {
         class COMPONENT {
             class PR {
                 description = "The main class";
-                file = "\x\alive\addons\sup_player_resupply\fnc_PR.sqf";
+								file = PATHTO_FUNC(PR);
                 recompile = RECOMPILE;
             };
             class PRInit {
                 description = "The module initialisation function";
-                file = "\x\alive\addons\sup_player_resupply\fnc_PRInit.sqf";
+								file = PATHTO_FUNC(PRInit);
                 recompile = RECOMPILE;
             };
             class PRMenuDef {
                 description = "The module menu definition";
-                file = "\x\alive\addons\sup_player_resupply\fnc_PRMenuDef.sqf";
+								file = PATHTO_FUNC(PRMenuDef);
                 recompile = RECOMPILE;
             };
             class PRTabletOnAction {
                 description = "The module Radio Action function";
-                file = "\x\alive\addons\sup_player_resupply\fnc_PRTabletOnAction.sqf";
+								file = PATHTO_FUNC(PRTabletOnAction);
                 recompile = RECOMPILE;
             };
             class PRTabletOnLoad {
                 description = "The module tablet on load function";
-                file = "\x\alive\addons\sup_player_resupply\fnc_PRTabletOnLoad.sqf";
+								file = PATHTO_FUNC(PRTabletOnLoad);
                 recompile = RECOMPILE;
             };
             class PRTabletOnUnLoad {
                 description = "The module tablet on unload function";
-                file = "\x\alive\addons\sup_player_resupply\fnc_PRTabletOnUnLoad.sqf";
+								file = PATHTO_FUNC(PRTabletOnUnLoad);
                 recompile = RECOMPILE;
             };
             class PRTabletEventToClient {
                 description = "Call the tablet on the client from the server";
-                file = "\x\alive\addons\sup_player_resupply\fnc_PRTabletEventToClient.sqf";
+								file = PATHTO_FUNC(PRTabletEventToClient);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/sup_player_resupply/CfgFunctions.hpp
+++ b/addons/sup_player_resupply/CfgFunctions.hpp
@@ -1,41 +1,13 @@
 class CfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class PR {
-                description = "The main class";
-								file = PATHTO_FUNC(PR);
-                recompile = RECOMPILE;
-            };
-            class PRInit {
-                description = "The module initialisation function";
-								file = PATHTO_FUNC(PRInit);
-                recompile = RECOMPILE;
-            };
-            class PRMenuDef {
-                description = "The module menu definition";
-								file = PATHTO_FUNC(PRMenuDef);
-                recompile = RECOMPILE;
-            };
-            class PRTabletOnAction {
-                description = "The module Radio Action function";
-								file = PATHTO_FUNC(PRTabletOnAction);
-                recompile = RECOMPILE;
-            };
-            class PRTabletOnLoad {
-                description = "The module tablet on load function";
-								file = PATHTO_FUNC(PRTabletOnLoad);
-                recompile = RECOMPILE;
-            };
-            class PRTabletOnUnLoad {
-                description = "The module tablet on unload function";
-								file = PATHTO_FUNC(PRTabletOnUnLoad);
-                recompile = RECOMPILE;
-            };
-            class PRTabletEventToClient {
-                description = "Call the tablet on the client from the server";
-								file = PATHTO_FUNC(PRTabletEventToClient);
-                recompile = RECOMPILE;
-            };
-        };
-    };
+						FUNC_FILEPATH(PR,"The main class");
+						FUNC_FILEPATH(PRInit,"The module initialisation function");
+						FUNC_FILEPATH(PRMenuDef,"The module menu definition");
+						FUNC_FILEPATH(PRTabletOnAction,"The module Radio Action function");
+						FUNC_FILEPATH(PRTabletOnLoad,"The module tablet on load function");
+						FUNC_FILEPATH(PRTabletOnUnLoad,"The module tablet on unload function");
+						FUNC_FILEPATH(PRTabletEventToClient,"Call the tablet on the client from the server");
+				};
+		};
 };

--- a/addons/sup_transport/CfgFunctions.hpp
+++ b/addons/sup_transport/CfgFunctions.hpp
@@ -1,16 +1,8 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class TRANSPORT {
-                                description = "The main class";
-																file = PATHTO_FUNC(TRANSPORT);
-                recompile = RECOMPILE;
-                        };
-                        class TRANSPORTInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(TRANSPORTInit);
-                recompile = RECOMPILE;
-                        };
-                   };
-        };
+												FUNC_FILEPATH(TRANSPORT,"The main class");
+												FUNC_FILEPATH(TRANSPORTInit,"The module initialisation function");
+								};
+				};
 };

--- a/addons/sup_transport/CfgFunctions.hpp
+++ b/addons/sup_transport/CfgFunctions.hpp
@@ -3,12 +3,12 @@ class cfgFunctions {
                 class COMPONENT {
                         class TRANSPORT {
                                 description = "The main class";
-                                file = "\x\alive\addons\sup_transport\fnc_TRANSPORT.sqf";
+																file = PATHTO_FUNC(TRANSPORT);
                 recompile = RECOMPILE;
                         };
                         class TRANSPORTInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sup_transport\fnc_TRANSPORTInit.sqf";
+																file = PATHTO_FUNC(TRANSPORTInit);
                 recompile = RECOMPILE;
                         };
                    };

--- a/addons/sys_adminactions/CfgFunctions.hpp
+++ b/addons/sys_adminactions/CfgFunctions.hpp
@@ -3,47 +3,47 @@ class cfgFunctions {
                 class COMPONENT {
                         class adminActions {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_adminactions\fnc_adminActions.sqf";
+																file = PATHTO_FUNC(adminActions);
                                 recompile = RECOMPILE;
                         };
                         class adminActionsInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_adminactions\fnc_adminActionsInit.sqf";
+																file = PATHTO_FUNC(adminActionsInit);
                                 recompile = RECOMPILE;
                         };
                         class adminActionsMenuDef {
                                 description = "The module menu definition";
-                                file = "\x\alive\addons\sys_adminactions\fnc_adminActionsMenuDef.sqf";
+																file = PATHTO_FUNC(adminActionsMenuDef);
                                 recompile = RECOMPILE;
                         };
                         class markUnits {
                                 description = "Mark units active and profiled";
-                                file = "\x\alive\addons\sys_adminactions\fnc_markUnits.sqf";
+																file = PATHTO_FUNC(markUnits);
                                 recompile = RECOMPILE;
                         };
                         class adminGhost {
                                 description = "Set admin to ghost mode";
-                                file = "\x\alive\addons\sys_adminactions\fnc_adminGhost.sqf";
+																file = PATHTO_FUNC(adminGhost);
                                 recompile = RECOMPILE;
                         };
                         class profileSystemDebug {
                                 description = "Turn on profile system debug";
-                                file = "\x\alive\addons\sys_adminactions\fnc_profileSystemDebug.sqf";
+																file = PATHTO_FUNC(profileSystemDebug);
                                 recompile = RECOMPILE;
                         };
                         class adminCreateProfiles {
                                 description = "Profile non profiled units";
-                                file = "\x\alive\addons\sys_adminactions\fnc_adminCreateProfiles.sqf";
+																file = PATHTO_FUNC(adminCreateProfiles);
                                 recompile = RECOMPILE;
                         };
                         class agentSystemDebug {
                                 description = "Turn on agent system debug";
-                                file = "\x\alive\addons\sys_adminactions\fnc_agentSystemDebug.sqf";
+																file = PATHTO_FUNC(agentSystemDebug);
                                 recompile = RECOMPILE;
                         };
                         class adminActionsTeleportUnits {
                                 description = "Teleports the nearest given unit to the desired spot";
-                                file = "\x\alive\addons\sys_adminactions\fnc_adminActionsTeleportUnits.sqf";
+																file = PATHTO_FUNC(adminActionsTeleportUnits);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/sys_adminactions/CfgFunctions.hpp
+++ b/addons/sys_adminactions/CfgFunctions.hpp
@@ -1,51 +1,15 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class adminActions {
-                                description = "The main class";
-																file = PATHTO_FUNC(adminActions);
-                                recompile = RECOMPILE;
-                        };
-                        class adminActionsInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(adminActionsInit);
-                                recompile = RECOMPILE;
-                        };
-                        class adminActionsMenuDef {
-                                description = "The module menu definition";
-																file = PATHTO_FUNC(adminActionsMenuDef);
-                                recompile = RECOMPILE;
-                        };
-                        class markUnits {
-                                description = "Mark units active and profiled";
-																file = PATHTO_FUNC(markUnits);
-                                recompile = RECOMPILE;
-                        };
-                        class adminGhost {
-                                description = "Set admin to ghost mode";
-																file = PATHTO_FUNC(adminGhost);
-                                recompile = RECOMPILE;
-                        };
-                        class profileSystemDebug {
-                                description = "Turn on profile system debug";
-																file = PATHTO_FUNC(profileSystemDebug);
-                                recompile = RECOMPILE;
-                        };
-                        class adminCreateProfiles {
-                                description = "Profile non profiled units";
-																file = PATHTO_FUNC(adminCreateProfiles);
-                                recompile = RECOMPILE;
-                        };
-                        class agentSystemDebug {
-                                description = "Turn on agent system debug";
-																file = PATHTO_FUNC(agentSystemDebug);
-                                recompile = RECOMPILE;
-                        };
-                        class adminActionsTeleportUnits {
-                                description = "Teleports the nearest given unit to the desired spot";
-																file = PATHTO_FUNC(adminActionsTeleportUnits);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(adminActions,"The main class");
+												FUNC_FILEPATH(adminActionsInit,"The module initialisation function");
+												FUNC_FILEPATH(adminActionsMenuDef,"The module menu definition");
+												FUNC_FILEPATH(markUnits,"Mark units active and profiled");
+												FUNC_FILEPATH(adminGhost,"Set admin to ghost mode");
+												FUNC_FILEPATH(profileSystemDebug,"Turn on profile system debug");
+												FUNC_FILEPATH(adminCreateProfiles,"Profile non profiled units");
+												FUNC_FILEPATH(agentSystemDebug,"Turn on agent system debug");
+												FUNC_FILEPATH(adminActionsTeleportUnits,"Teleports the nearest given unit to the desired spot");
+								};
+				};
 };

--- a/addons/sys_aiskill/CfgFunctions.hpp
+++ b/addons/sys_aiskill/CfgFunctions.hpp
@@ -3,17 +3,17 @@ class CfgFunctions {
         class COMPONENT {
             class aiSkill {
                 description = "The main class";
-                file = "\x\alive\addons\sys_aiskill\fnc_AISkill.sqf";
+								file = PATHTO_FUNC(AISkill);
                 recompile = RECOMPILE;
             };
             class aiSkillInit {
                 description = "The module initialisation function";
-                file = "\x\alive\addons\sys_aiskill\fnc_AISkillInit.sqf";
+								file = PATHTO_FUNC(AISkillInit);
                 recompile = RECOMPILE;
             };
             class AIskillSetter {
                 description = "The init EH function";
-                file = "\x\alive\addons\sys_aiskill\fnc_AISkillSetter.sqf";
+								file = PATHTO_FUNC(AISkillSetter);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/sys_aiskill/CfgFunctions.hpp
+++ b/addons/sys_aiskill/CfgFunctions.hpp
@@ -1,21 +1,9 @@
 class CfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class aiSkill {
-                description = "The main class";
-								file = PATHTO_FUNC(AISkill);
-                recompile = RECOMPILE;
-            };
-            class aiSkillInit {
-                description = "The module initialisation function";
-								file = PATHTO_FUNC(AISkillInit);
-                recompile = RECOMPILE;
-            };
-            class AIskillSetter {
-                description = "The init EH function";
-								file = PATHTO_FUNC(AISkillSetter);
-                recompile = RECOMPILE;
-            };
-        };
-    };
+						FUNC_FILEPATH(aiSkill,"The main class");
+						FUNC_FILEPATH(aiSkillInit,"The module initialisation function");
+						FUNC_FILEPATH(AIskillSetter,"The init EH function");
+				};
+		};
 };

--- a/addons/sys_crewinfo/CfgFunctions.hpp
+++ b/addons/sys_crewinfo/CfgFunctions.hpp
@@ -1,21 +1,9 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class crewinfo {
-                                description = "The main class";
-																file = PATHTO_FUNC(crewinfo);
-                                                                recompile = RECOMPILE;
-                        };
-                        class crewinfoInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(crewinfoInit);
-                                                                recompile = RECOMPILE;
-                        };
-                                              class crewinfoClient {
-                               description = "The module script";
-																file = PATHTO_FUNC(crewinfoClient);
-                                                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(crewinfo,"The main class");
+												FUNC_FILEPATH(crewinfoInit,"The module initialisation function");
+												FUNC_FILEPATH(crewinfoClient,"The module script");
+								};
+				};
 };

--- a/addons/sys_crewinfo/CfgFunctions.hpp
+++ b/addons/sys_crewinfo/CfgFunctions.hpp
@@ -1,19 +1,19 @@
-﻿class cfgFunctions {
+class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
                         class crewinfo {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_crewinfo\fnc_crewinfo.sqf";
+																file = PATHTO_FUNC(crewinfo);
                                                                 recompile = RECOMPILE;
                         };
                         class crewinfoInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_crewinfo\fnc_crewinfoInit.sqf";
+																file = PATHTO_FUNC(crewinfoInit);
                                                                 recompile = RECOMPILE;
                         };
                                               class crewinfoClient {
                                description = "The module script";
-                                file = "\x\alive\addons\sys_crewinfo\fnc_crewinfoClient.sqf";
+																file = PATHTO_FUNC(crewinfoClient);
                                                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/sys_data/CfgFunctions.hpp
+++ b/addons/sys_data/CfgFunctions.hpp
@@ -3,62 +3,62 @@ class cfgFunctions {
             class COMPONENT {
                 class data {
                     description = "Data Handler";
-                    file = "\x\alive\addons\sys_data\fnc_data.sqf";
+										file = PATHTO_FUNC(data);
                     recompile = RECOMPILE;
                 };
                 class dataInit {
                     description = "The module initialisation function";
-                    file = "\x\alive\addons\sys_data\fnc_dataInit.sqf";
+										file = PATHTO_FUNC(dataInit);
                     recompile = RECOMPILE;
                 };
                 class sendToPlugIn {
                     description = "Sends data to an external plugin via arma2net";
-                    file = "\x\alive\addons\sys_data\fnc_sendToPlugIn.sqf";
+										file = PATHTO_FUNC(sendToPlugIn);
                     recompile = RECOMPILE;
                 };
                 class sendToPlugInAsync {
                     description = "Sends data to an external plugin via arma2net using an Async function";
-                    file = "\x\alive\addons\sys_data\fnc_sendToPlugInAsync.sqf";
+										file = PATHTO_FUNC(sendToPlugInAsync);
                     recompile = RECOMPILE;
                 };
                 class getServerIP {
                     description = "Gets the servers IP address via arma2net";
-                    file = "\x\alive\addons\sys_data\fnc_getServerIP.sqf";
+										file = PATHTO_FUNC(getServerIP);
                     recompile = RECOMPILE;
                 };
                 class getServerName {
                     description = "Gets the server hostname via arma2net";
-                    file = "\x\alive\addons\sys_data\fnc_getServerName.sqf";
+										file = PATHTO_FUNC(getServerName);
                     recompile = RECOMPILE;
                 };
                 class getServerTime {
                     description = "Gets the current local time from the server via arma2net";
-                    file = "\x\alive\addons\sys_data\fnc_getServerTime.sqf";
+										file = PATHTO_FUNC(getServerTime);
                     recompile = RECOMPILE;
                 };
                 class getGroupID {
                     description = "Gets the group ID via arma2net";
-                    file = "\x\alive\addons\sys_data\fnc_getGroupID.sqf";
+										file = PATHTO_FUNC(getGroupID);
                     recompile = RECOMPILE;
                 };
                 class getData {
                     description = "Gets custom data";
-                    file = "\x\alive\addons\sys_data\fnc_getData.sqf";
+										file = PATHTO_FUNC(getData);
                     recompile = RECOMPILE;
                 };
                 class setData {
                     description = "Sets custom data";
-                    file = "\x\alive\addons\sys_data\fnc_setData.sqf";
+										file = PATHTO_FUNC(setData);
                     recompile = RECOMPILE;
                 };
                 class startALiVEPLugIn {
                     description = "Starts the ALiVE Plugin for arma2net";
-                    file = "\x\alive\addons\sys_data\fnc_startALiVEPlugIn.sqf";
+										file = PATHTO_FUNC(startALiVEPlugin);
                     recompile = RECOMPILE;
                 };
                 class data_OnPlayerDisconnected {
                         description = "The module onPlayerDisconnected handler";
-                        file = "\x\alive\addons\sys_data\fnc_data_onPlayerDisconnected.sqf";
+												file = PATHTO_FUNC(data_onPlayerDisconnected);
                         recompile = RECOMPILE;
                 };
             };

--- a/addons/sys_data/CfgFunctions.hpp
+++ b/addons/sys_data/CfgFunctions.hpp
@@ -1,66 +1,18 @@
 class cfgFunctions {
         class PREFIX {
             class COMPONENT {
-                class data {
-                    description = "Data Handler";
-										file = PATHTO_FUNC(data);
-                    recompile = RECOMPILE;
-                };
-                class dataInit {
-                    description = "The module initialisation function";
-										file = PATHTO_FUNC(dataInit);
-                    recompile = RECOMPILE;
-                };
-                class sendToPlugIn {
-                    description = "Sends data to an external plugin via arma2net";
-										file = PATHTO_FUNC(sendToPlugIn);
-                    recompile = RECOMPILE;
-                };
-                class sendToPlugInAsync {
-                    description = "Sends data to an external plugin via arma2net using an Async function";
-										file = PATHTO_FUNC(sendToPlugInAsync);
-                    recompile = RECOMPILE;
-                };
-                class getServerIP {
-                    description = "Gets the servers IP address via arma2net";
-										file = PATHTO_FUNC(getServerIP);
-                    recompile = RECOMPILE;
-                };
-                class getServerName {
-                    description = "Gets the server hostname via arma2net";
-										file = PATHTO_FUNC(getServerName);
-                    recompile = RECOMPILE;
-                };
-                class getServerTime {
-                    description = "Gets the current local time from the server via arma2net";
-										file = PATHTO_FUNC(getServerTime);
-                    recompile = RECOMPILE;
-                };
-                class getGroupID {
-                    description = "Gets the group ID via arma2net";
-										file = PATHTO_FUNC(getGroupID);
-                    recompile = RECOMPILE;
-                };
-                class getData {
-                    description = "Gets custom data";
-										file = PATHTO_FUNC(getData);
-                    recompile = RECOMPILE;
-                };
-                class setData {
-                    description = "Sets custom data";
-										file = PATHTO_FUNC(setData);
-                    recompile = RECOMPILE;
-                };
-                class startALiVEPLugIn {
-                    description = "Starts the ALiVE Plugin for arma2net";
-										file = PATHTO_FUNC(startALiVEPlugin);
-                    recompile = RECOMPILE;
-                };
-                class data_OnPlayerDisconnected {
-                        description = "The module onPlayerDisconnected handler";
-												file = PATHTO_FUNC(data_onPlayerDisconnected);
-                        recompile = RECOMPILE;
-                };
-            };
-        };
+								FUNC_FILEPATH(data,"Data Handler");
+								FUNC_FILEPATH(dataInit,"The module initialisation function");
+								FUNC_FILEPATH(sendToPlugIn,"Sends data to an external plugin via arma2net");
+								FUNC_FILEPATH(sendToPlugInAsync,"Sends data to an external plugin via arma2net using an Async function");
+								FUNC_FILEPATH(getServerIP,"Gets the servers IP address via arma2net");
+								FUNC_FILEPATH(getServerName,"Gets the server hostname via arma2net");
+								FUNC_FILEPATH(getServerTime,"Gets the current local time from the server via arma2net");
+								FUNC_FILEPATH(getGroupID,"Gets the group ID via arma2net");
+								FUNC_FILEPATH(getData,"Gets custom data");
+								FUNC_FILEPATH(setData,"Sets custom data");
+								FUNC_FILEPATH(startALiVEPLugIn,"Starts the ALiVE Plugin for arma2net");
+								FUNC_FILEPATH(data_OnPlayerDisconnected,"The module onPlayerDisconnected handler");
+						};
+				};
 };

--- a/addons/sys_data_couchdb/CfgFunctions.hpp
+++ b/addons/sys_data_couchdb/CfgFunctions.hpp
@@ -3,62 +3,62 @@ class cfgFunctions {
             class COMPONENT {
                 class writeData_couchdb {
                     description = "Writes a record/document to a data source";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_writeData.sqf";
+										file = PATHTO_FUNC(writeData);
                     recompile = RECOMPILE;
                 };
                 class bulkWriteData_couchdb {
                     description = "Writes a record/document to a data source";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_bulkWriteData.sqf";
+										file = PATHTO_FUNC(bulkWriteData);
                     recompile = RECOMPILE;
                 };
                 class updateData_couchdb {
                     description = "Updates a record stored in a data source";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_updateData.sqf";
+										file = PATHTO_FUNC(updateData);
                     recompile = RECOMPILE;
                 };
                 class readData_couchdb {
                     description = "Reads a record/document from a data source";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_readData.sqf";
+										file = PATHTO_FUNC(readData);
                     recompile = RECOMPILE;
                 };
                 class bulkReadData_couchdb {
                     description = "Bulk Reads a set of records/documents from a data source";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_bulkReadData.sqf";
+										file = PATHTO_FUNC(bulkReadData);
                     recompile = RECOMPILE;
                 };
                 class convertData_couchdb {
                     description = "Decomposes objects/data to a suitable formatted text string for couchdb";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_convertData.sqf";
+										file = PATHTO_FUNC(convertData);
                     recompile = RECOMPILE;
                 };
                 class restoreData_couchdb {
                     description = "Composes objects/data from a couchdb formatted text string";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_restoreData.sqf";
+										file = PATHTO_FUNC(restoreData);
                     recompile = RECOMPILE;
                 };
                 class saveData_couchdb {
                     description = "Saves all records/documents to a data source";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_saveData.sqf";
+										file = PATHTO_FUNC(saveData);
                     recompile = RECOMPILE;
                 };
                 class bulkSaveData_couchdb {
                     description = "Saves all records/documents to a data source";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_bulkSaveData.sqf";
+										file = PATHTO_FUNC(bulkSaveData);
                     recompile = RECOMPILE;
                 };
                 class loadData_couchdb {
                     description = "Loads all records/documents from a table/document set stored in a data source";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_loadData.sqf";
+										file = PATHTO_FUNC(loadData);
                     recompile = RECOMPILE;
                 };
                 class bulkLoadData_couchdb {
                     description = "Bulk Loads all records/documents from a table/document set stored in a data source";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_bulkLoadData.sqf";
+										file = PATHTO_FUNC(bulkLoadData);
                     recompile = RECOMPILE;
                 };
                 class deleteData_couchdb {
                     description = "Deletes a record stored in a data source";
-                    file = "\x\alive\addons\sys_data_couchdb\fnc_deleteData.sqf";
+										file = PATHTO_FUNC(deleteData);
                     recompile = RECOMPILE;
                 };
 

--- a/addons/sys_gc/CfgFunctions.hpp
+++ b/addons/sys_gc/CfgFunctions.hpp
@@ -3,12 +3,12 @@ class cfgFunctions {
                 class COMPONENT {
                         class GC {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_GC\fnc_GC.sqf";
+																file = PATHTO_FUNC(GC);
                                 recompile = RECOMPILE;
                         };
                         class GCInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_GC\fnc_GCInit.sqf";
+																file = PATHTO_FUNC(GCInit);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/sys_gc/CfgFunctions.hpp
+++ b/addons/sys_gc/CfgFunctions.hpp
@@ -1,16 +1,8 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class GC {
-                                description = "The main class";
-																file = PATHTO_FUNC(GC);
-                                recompile = RECOMPILE;
-                        };
-                        class GCInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(GCInit);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(GC,"The main class");
+												FUNC_FILEPATH(GCInit,"The module initialisation function");
+								};
+				};
 };

--- a/addons/sys_indexer/CfgFunctions.hpp
+++ b/addons/sys_indexer/CfgFunctions.hpp
@@ -1,37 +1,16 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                    class indexer {
-                        description = "The main class";
-												file = PATHTO_FUNC(indexer);
-                        recompile = RECOMPILE;
-                    };
-                    class indexerInit {
-                        description = "The module initialisation function";
-												file = PATHTO_FUNC(indexerInit);
-                        recompile = RECOMPILE;
-                    };
-                    class indexerMenuDef {
-                        description = "The module menu definition";
-												file = PATHTO_FUNC(indexerMenuDef);
-                        recompile = RECOMPILE;
-                    };
-                    class indexMap
-                    {
+										FUNC_FILEPATH(indexer,"The main class");
+										FUNC_FILEPATH(indexerInit,"The module initialisation function");
+										FUNC_FILEPATH(indexerMenuDef,"The module menu definition");
+                    class indexMap {
 												file = PATHTO_FUNC(indexMap);
                         ext = ".sqf";
                         recompile = RECOMPILE;
                     };
-                    class auto_staticObjects {
-                        description = "ALiVE object viewer";
-												file = PATHTO_FUNC(auto_staticObjects);
-                        recompile = RECOMPILE;
-                    };
-                    class autoUpdateStaticData {
-                        description = "ALiVE index static data update UI";
-												file = PATHTO_FUNC(autoUpdateStaticData);
-                        recompile = RECOMPILE;
-                    };
+                    FUNC_FILEPATH(auto_staticObjects,"ALiVE object viewer");
+                    FUNC_FILEPATH(autoUpdateStaticData,"ALiVE index static data update UI")
                 };
         };
 };

--- a/addons/sys_indexer/CfgFunctions.hpp
+++ b/addons/sys_indexer/CfgFunctions.hpp
@@ -3,36 +3,35 @@ class cfgFunctions {
                 class COMPONENT {
                     class indexer {
                         description = "The main class";
-                        file = "\x\alive\addons\sys_indexer\fnc_indexer.sqf";
+												file = PATHTO_FUNC(indexer);
                         recompile = RECOMPILE;
                     };
                     class indexerInit {
                         description = "The module initialisation function";
-                        file = "\x\alive\addons\sys_indexer\fnc_indexerInit.sqf";
+												file = PATHTO_FUNC(indexerInit);
                         recompile = RECOMPILE;
                     };
                     class indexerMenuDef {
                         description = "The module menu definition";
-                        file = "\x\alive\addons\sys_indexer\fnc_indexerMenuDef.sqf";
+												file = PATHTO_FUNC(indexerMenuDef);
                         recompile = RECOMPILE;
                     };
                     class indexMap
                     {
-                        file = "\x\alive\addons\sys_indexer\fnc_indexMap.sqf";
+												file = PATHTO_FUNC(indexMap);
                         ext = ".sqf";
                         recompile = RECOMPILE;
                     };
                     class auto_staticObjects {
                         description = "ALiVE object viewer";
-                        file = "\x\alive\addons\sys_indexer\fnc_auto_staticObjects.sqf";
+												file = PATHTO_FUNC(auto_staticObjects);
                         recompile = RECOMPILE;
                     };
                     class autoUpdateStaticData {
                         description = "ALiVE index static data update UI";
-                        file = "\x\alive\addons\sys_indexer\fnc_autoUpdateStaticData.sqf";
+												file = PATHTO_FUNC(autoUpdateStaticData);
                         recompile = RECOMPILE;
                     };
                 };
         };
 };
-

--- a/addons/sys_logistics/CfgFunctions.hpp
+++ b/addons/sys_logistics/CfgFunctions.hpp
@@ -3,112 +3,112 @@ class cfgFunctions {
                 class COMPONENT {
                         class logistics {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_logistics\fnc_logistics.sqf";
+																file = PATHTO_FUNC(logistics);
                                 recompile = RECOMPILE;
                         };
                         class logisticsInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_logistics\fnc_logisticsInit.sqf";
+																file = PATHTO_FUNC(logisticsInit);
                                 recompile = RECOMPILE;
                         };
                         class logisticsDisable {
                                 description = "Logistics load data to DB";
-                                file = "\x\alive\addons\sys_logistics\fnc_logisticsDisable.sqf";
+																file = PATHTO_FUNC(logisticsDisable);
                                 recompile = RECOMPILE;
                         };
                         class logisticsMenuDef {
                                 description = "The module menu definition";
-                                file = "\x\alive\addons\sys_logistics\fnc_logisticsMenuDef.sqf";
+																file = PATHTO_FUNC(logisticsMenuDef);
                                 recompile = RECOMPILE;
                         };
                         class getObjectWeight {
                                 description = "Gets the approximate weight (sum) of the given objects";
-                                file = "\x\alive\addons\sys_logistics\fnc_getObjectWeight.sqf";
+																file = PATHTO_FUNC(getObjectWeight);
                                 recompile = RECOMPILE;
                         };
                         class getObjectSize {
                                 description = "Gets the approximate volume (sum) of the given objects";
-                                file = "\x\alive\addons\sys_logistics\fnc_getObjectSize.sqf";
+																file = PATHTO_FUNC(getObjectSize);
                                 recompile = RECOMPILE;
                         };
                         class availableWeight {
                                 description = "Gets the available weight capacity (sum) of the given objects in kg";
-                                file = "\x\alive\addons\sys_logistics\fnc_availableWeight.sqf";
+																file = PATHTO_FUNC(availableWeight);
                                 recompile = RECOMPILE;
                         };
                         class availableCargo {
                                 description = "Gets the available cargo volume (sum) of the given objects in m^3";
-                                file = "\x\alive\addons\sys_logistics\fnc_availableCargo.sqf";
+																file = PATHTO_FUNC(availableCargo);
                                 recompile = RECOMPILE;
                         };
                         class canCarry {
                                 description = "Checks if an object can be carried by another given object";
-                                file = "\x\alive\addons\sys_logistics\fnc_canCarry.sqf";
+																file = PATHTO_FUNC(canCarry);
                                 recompile = RECOMPILE;
                         };
                         class canStow {
                                 description = "Checks if an object can be stowed the given container";
-                                file = "\x\alive\addons\sys_logistics\fnc_canStow.sqf";
+																file = PATHTO_FUNC(canStow);
                                 recompile = RECOMPILE;
                         };
                         class canTow {
                                 description = "Checks if an object can be towed by the given vehicle";
-                                file = "\x\alive\addons\sys_logistics\fnc_canTow.sqf";
+																file = PATHTO_FUNC(canTow);
                                 recompile = RECOMPILE;
                         };
                         class canLift {
                                 description = "Checks if an object can be lifted by given vehicle";
-                                file = "\x\alive\addons\sys_logistics\fnc_canLift.sqf";
+																file = PATHTO_FUNC(canLift);
                                 recompile = RECOMPILE;
                         };
                         class getObjectCargo {
                                 description = "Gets the cargo list of an object";
-                                file = "\x\alive\addons\sys_logistics\fnc_getObjectCargo.sqf";
+																file = PATHTO_FUNC(getObjectCargo);
                                 recompile = RECOMPILE;
                         };
                         class setObjectCargo {
                                 description = "Sets the cargo back on an object";
-                                file = "\x\alive\addons\sys_logistics\fnc_setObjectCargo.sqf";
+																file = PATHTO_FUNC(setObjectCargo);
                                 recompile = RECOMPILE;
                         };
                         class setObjectState {
                                 description = "Sets the given state of on an object";
-                                file = "\x\alive\addons\sys_logistics\fnc_setObjectState.sqf";
+																file = PATHTO_FUNC(setObjectState);
                                 recompile = RECOMPILE;
                         };
                         class getObjectState {
                                 description = "Gets the given state of an object";
-                                file = "\x\alive\addons\sys_logistics\fnc_getObjectState.sqf";
+																file = PATHTO_FUNC(getObjectState);
                                 recompile = RECOMPILE;
                         };
                         class getObjectFuel {
                                 description = "Gets the fuel of an object";
-                                file = "\x\alive\addons\sys_logistics\fnc_getObjectFuel.sqf";
+																file = PATHTO_FUNC(getObjectFuel);
                                 recompile = RECOMPILE;
                         };
                         class setObjectFuel {
                                 description = "Sets the given fuel oo an object";
-                                file = "\x\alive\addons\sys_logistics\fnc_setObjectFuel.sqf";
+																file = PATHTO_FUNC(setObjectFuel);
                                 recompile = RECOMPILE;
                         };
                         class getObjectDamage {
                                 description = "Gets the damage of an object";
-                                file = "\x\alive\addons\sys_logistics\fnc_getObjectDamage.sqf";
+																file = PATHTO_FUNC(getObjectDamage);
                                 recompile = RECOMPILE;
                         };
                         class setObjectDamage {
                                 description = "Sets the given damage on an object";
-                                file = "\x\alive\addons\sys_logistics\fnc_setObjectDamage.sqf";
+																file = PATHTO_FUNC(setObjectDamage);
                                 recompile = RECOMPILE;
                         };
                         class logisticsSaveData {
                                 description = "Logistics save data to DB";
-                                file = "\x\alive\addons\sys_logistics\fnc_logisticsSaveData.sqf";
+																file = PATHTO_FUNC(logisticsSaveData);
                                 recompile = RECOMPILE;
                         };
                         class logisticsLoadData {
                                 description = "Logistics load data to DB";
-                                file = "\x\alive\addons\sys_logistics\fnc_logisticsLoadData.sqf";
+																file = PATHTO_FUNC(logisticsLoadData);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/sys_logistics/CfgFunctions.hpp
+++ b/addons/sys_logistics/CfgFunctions.hpp
@@ -1,116 +1,28 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class logistics {
-                                description = "The main class";
-																file = PATHTO_FUNC(logistics);
-                                recompile = RECOMPILE;
-                        };
-                        class logisticsInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(logisticsInit);
-                                recompile = RECOMPILE;
-                        };
-                        class logisticsDisable {
-                                description = "Logistics load data to DB";
-																file = PATHTO_FUNC(logisticsDisable);
-                                recompile = RECOMPILE;
-                        };
-                        class logisticsMenuDef {
-                                description = "The module menu definition";
-																file = PATHTO_FUNC(logisticsMenuDef);
-                                recompile = RECOMPILE;
-                        };
-                        class getObjectWeight {
-                                description = "Gets the approximate weight (sum) of the given objects";
-																file = PATHTO_FUNC(getObjectWeight);
-                                recompile = RECOMPILE;
-                        };
-                        class getObjectSize {
-                                description = "Gets the approximate volume (sum) of the given objects";
-																file = PATHTO_FUNC(getObjectSize);
-                                recompile = RECOMPILE;
-                        };
-                        class availableWeight {
-                                description = "Gets the available weight capacity (sum) of the given objects in kg";
-																file = PATHTO_FUNC(availableWeight);
-                                recompile = RECOMPILE;
-                        };
-                        class availableCargo {
-                                description = "Gets the available cargo volume (sum) of the given objects in m^3";
-																file = PATHTO_FUNC(availableCargo);
-                                recompile = RECOMPILE;
-                        };
-                        class canCarry {
-                                description = "Checks if an object can be carried by another given object";
-																file = PATHTO_FUNC(canCarry);
-                                recompile = RECOMPILE;
-                        };
-                        class canStow {
-                                description = "Checks if an object can be stowed the given container";
-																file = PATHTO_FUNC(canStow);
-                                recompile = RECOMPILE;
-                        };
-                        class canTow {
-                                description = "Checks if an object can be towed by the given vehicle";
-																file = PATHTO_FUNC(canTow);
-                                recompile = RECOMPILE;
-                        };
-                        class canLift {
-                                description = "Checks if an object can be lifted by given vehicle";
-																file = PATHTO_FUNC(canLift);
-                                recompile = RECOMPILE;
-                        };
-                        class getObjectCargo {
-                                description = "Gets the cargo list of an object";
-																file = PATHTO_FUNC(getObjectCargo);
-                                recompile = RECOMPILE;
-                        };
-                        class setObjectCargo {
-                                description = "Sets the cargo back on an object";
-																file = PATHTO_FUNC(setObjectCargo);
-                                recompile = RECOMPILE;
-                        };
-                        class setObjectState {
-                                description = "Sets the given state of on an object";
-																file = PATHTO_FUNC(setObjectState);
-                                recompile = RECOMPILE;
-                        };
-                        class getObjectState {
-                                description = "Gets the given state of an object";
-																file = PATHTO_FUNC(getObjectState);
-                                recompile = RECOMPILE;
-                        };
-                        class getObjectFuel {
-                                description = "Gets the fuel of an object";
-																file = PATHTO_FUNC(getObjectFuel);
-                                recompile = RECOMPILE;
-                        };
-                        class setObjectFuel {
-                                description = "Sets the given fuel oo an object";
-																file = PATHTO_FUNC(setObjectFuel);
-                                recompile = RECOMPILE;
-                        };
-                        class getObjectDamage {
-                                description = "Gets the damage of an object";
-																file = PATHTO_FUNC(getObjectDamage);
-                                recompile = RECOMPILE;
-                        };
-                        class setObjectDamage {
-                                description = "Sets the given damage on an object";
-																file = PATHTO_FUNC(setObjectDamage);
-                                recompile = RECOMPILE;
-                        };
-                        class logisticsSaveData {
-                                description = "Logistics save data to DB";
-																file = PATHTO_FUNC(logisticsSaveData);
-                                recompile = RECOMPILE;
-                        };
-                        class logisticsLoadData {
-                                description = "Logistics load data to DB";
-																file = PATHTO_FUNC(logisticsLoadData);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(logistics,"The main class");
+												FUNC_FILEPATH(logisticsInit,"The module initialisation function");
+												FUNC_FILEPATH(logisticsDisable,"Logistics load data to DB");
+												FUNC_FILEPATH(logisticsMenuDef,"The module menu definition");
+												FUNC_FILEPATH(getObjectWeight,"Gets the approximate weight (sum) of the given objects");
+												FUNC_FILEPATH(getObjectSize,"Gets the approximate volume (sum) of the given objects");
+												FUNC_FILEPATH(availableWeight,"Gets the available weight capacity (sum) of the given objects in kg");
+												FUNC_FILEPATH(availableCargo,"Gets the available cargo volume (sum) of the given objects in m^3");
+												FUNC_FILEPATH(canCarry,"Checks if an object can be carried by another given object");
+												FUNC_FILEPATH(canStow,"Checks if an object can be stowed the given container");
+												FUNC_FILEPATH(canTow,"Checks if an object can be towed by the given vehicle");
+												FUNC_FILEPATH(canLift,"Checks if an object can be lifted by given vehicle");
+												FUNC_FILEPATH(getObjectCargo,"Gets the cargo list of an object");
+												FUNC_FILEPATH(setObjectCargo,"Sets the cargo back on an object");
+												FUNC_FILEPATH(setObjectState,"Sets the given state of on an object");
+												FUNC_FILEPATH(getObjectState,"Gets the given state of an object");
+												FUNC_FILEPATH(getObjectFuel,"Gets the fuel of an object");
+												FUNC_FILEPATH(setObjectFuel,"Sets the given fuel oo an object");
+												FUNC_FILEPATH(getObjectDamage,"Gets the damage of an object");
+												FUNC_FILEPATH(setObjectDamage,"Sets the given damage on an object");
+												FUNC_FILEPATH(logisticsSaveData,"Logistics save data to DB");
+												FUNC_FILEPATH(logisticsLoadData,"Logistics load data to DB");
+								};
+				};
 };

--- a/addons/sys_marker/CfgFunctions.hpp
+++ b/addons/sys_marker/CfgFunctions.hpp
@@ -3,57 +3,57 @@ class cfgFunctions {
                 class COMPONENT {
                         class marker {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_marker\fnc_marker.sqf";
+																file = PATHTO_FUNC(marker);
                                 recompile = RECOMPILE;
                         };
                         class markerInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_marker\fnc_markerInit.sqf";
+																file = PATHTO_FUNC(markerInit);
                                 recompile = RECOMPILE;
                         };
                         class markerParams {
                                 description = "Marker parameters";
-                                file = "\x\alive\addons\sys_marker\fnc_markerParams.sqf";
+																file = PATHTO_FUNC(markerParams);
                                 recompile = RECOMPILE;
                         };
                         class markerSaveData {
                                 description = "marker save data to DB";
-                                file = "\x\alive\addons\sys_marker\fnc_markerSaveData.sqf";
+																file = PATHTO_FUNC(markerSaveData);
                                                                 recompile = RECOMPILE;
                         };
                         class markerLoadData {
                                 description = "marker load data to DB";
-                                file = "\x\alive\addons\sys_marker\fnc_markerLoadData.sqf";
+																file = PATHTO_FUNC(markerLoadData);
                                                                 recompile = RECOMPILE;
                         };
                         class markerDeleteData {
                                 description = "marker delete data from DB";
-                                file = "\x\alive\addons\sys_marker\fnc_markerDeleteData.sqf";
+																file = PATHTO_FUNC(markerDeleteData);
                                                                 recompile = RECOMPILE;
                         };
                         class markerOnLoad{
                                 description = "Onload for Dialog";
-                                file = "\x\alive\addons\sys_marker\fnc_markerOnLoad.sqf";
+																file = PATHTO_FUNC(markerOnLoad);
                                                                 recompile = RECOMPILE;
                         };
                         class markerOnPlayerConnected{
                                 description = "Handles on player connected event";
-                                file = "\x\alive\addons\sys_marker\fnc_markerOnPlayerConnected.sqf";
+																file = PATHTO_FUNC(markerOnPlayerConnected);
                                                                 recompile = RECOMPILE;
                         };
                         class markerLBSelChanged{
                                 description = "LBSelChanged for Dialog";
-                                file = "\x\alive\addons\sys_marker\fnc_markerLBSelChanged.sqf";
+																file = PATHTO_FUNC(markerLBSelChanged);
                                                                 recompile = RECOMPILE;
                         };
                         class markerCheckedChanged{
                                 description = "CheckedChanged for Dialog";
-                                file = "\x\alive\addons\sys_marker\fnc_markerCheckedChanged.sqf";
+																file = PATHTO_FUNC(markerCheckedChanged);
                                                                 recompile = RECOMPILE;
                         };
                         class markerButtonAction{
                                 description = "Button Action for Dialog";
-                                file = "\x\alive\addons\sys_marker\fnc_markerButtonAction.sqf";
+																file = PATHTO_FUNC(markerButtonAction);
                                                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/sys_marker/CfgFunctions.hpp
+++ b/addons/sys_marker/CfgFunctions.hpp
@@ -1,61 +1,17 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class marker {
-                                description = "The main class";
-																file = PATHTO_FUNC(marker);
-                                recompile = RECOMPILE;
-                        };
-                        class markerInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(markerInit);
-                                recompile = RECOMPILE;
-                        };
-                        class markerParams {
-                                description = "Marker parameters";
-																file = PATHTO_FUNC(markerParams);
-                                recompile = RECOMPILE;
-                        };
-                        class markerSaveData {
-                                description = "marker save data to DB";
-																file = PATHTO_FUNC(markerSaveData);
-                                                                recompile = RECOMPILE;
-                        };
-                        class markerLoadData {
-                                description = "marker load data to DB";
-																file = PATHTO_FUNC(markerLoadData);
-                                                                recompile = RECOMPILE;
-                        };
-                        class markerDeleteData {
-                                description = "marker delete data from DB";
-																file = PATHTO_FUNC(markerDeleteData);
-                                                                recompile = RECOMPILE;
-                        };
-                        class markerOnLoad{
-                                description = "Onload for Dialog";
-																file = PATHTO_FUNC(markerOnLoad);
-                                                                recompile = RECOMPILE;
-                        };
-                        class markerOnPlayerConnected{
-                                description = "Handles on player connected event";
-																file = PATHTO_FUNC(markerOnPlayerConnected);
-                                                                recompile = RECOMPILE;
-                        };
-                        class markerLBSelChanged{
-                                description = "LBSelChanged for Dialog";
-																file = PATHTO_FUNC(markerLBSelChanged);
-                                                                recompile = RECOMPILE;
-                        };
-                        class markerCheckedChanged{
-                                description = "CheckedChanged for Dialog";
-																file = PATHTO_FUNC(markerCheckedChanged);
-                                                                recompile = RECOMPILE;
-                        };
-                        class markerButtonAction{
-                                description = "Button Action for Dialog";
-																file = PATHTO_FUNC(markerButtonAction);
-                                                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(marker,"The main class");
+												FUNC_FILEPATH(markerInit,"The module initialisation function");
+												FUNC_FILEPATH(markerParams,"Marker parameters");
+												FUNC_FILEPATH(markerSaveData,"marker save data to DB");
+												FUNC_FILEPATH(markerLoadData,"marker load data to DB");
+												FUNC_FILEPATH(markerDeleteData,"marker delete data from DB");
+												FUNC_FILEPATH(markerOnLoad,"Onload for Dialog");
+												FUNC_FILEPATH(markerOnPlayerConnected,"Handles on player connected event");
+												FUNC_FILEPATH(markerLBSelChanged,"LBSelChanged for Dialog");
+												FUNC_FILEPATH(markerCheckedChanged,"CheckedChanged for Dialog");
+												FUNC_FILEPATH(markerButtonAction,"Button Action for Dialog");
+								};
+				};
 };

--- a/addons/sys_newsfeed/CfgFunctions.hpp
+++ b/addons/sys_newsfeed/CfgFunctions.hpp
@@ -3,18 +3,18 @@ class cfgFunctions {
                 class COMPONENT {
                         class newsFeed {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_newsfeed\fnc_newsFeed.sqf";
-                recompile = RECOMPILE;
+																file = PATHTO_FUNC(newsFeed);
+                                recompile = RECOMPILE;
                         };
                         class newsFeedInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_newsfeed\fnc_newsFeedInit.sqf";
-                recompile = RECOMPILE;
+																file = PATHTO_FUNC(newsFeedInit);
+                                recompile = RECOMPILE;
                         };
                         class newsFeedMenuDef {
                                 description = "The module menu definition";
-                                file = "\x\alive\addons\sys_newsfeed\fnc_newsFeedMenuDef.sqf";
-                recompile = RECOMPILE;
+																file = PATHTO_FUNC(newsFeedMenuDef);
+                                recompile = RECOMPILE;
                         };
                          class newsFeedMenuInit {
                                 description = "The module menu definition";
@@ -24,4 +24,3 @@ class cfgFunctions {
                 };
         };
 };
-

--- a/addons/sys_newsfeed/CfgFunctions.hpp
+++ b/addons/sys_newsfeed/CfgFunctions.hpp
@@ -1,21 +1,9 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class newsFeed {
-                                description = "The main class";
-																file = PATHTO_FUNC(newsFeed);
-                                recompile = RECOMPILE;
-                        };
-                        class newsFeedInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(newsFeedInit);
-                                recompile = RECOMPILE;
-                        };
-                        class newsFeedMenuDef {
-                                description = "The module menu definition";
-																file = PATHTO_FUNC(newsFeedMenuDef);
-                                recompile = RECOMPILE;
-                        };
+												FUNC_FILEPATH(newsFeed,"The main class");
+												FUNC_FILEPATH(newsFeedInit,"The module initialisation function");
+												FUNC_FILEPATH(newsFeedMenuDef,"The module menu definition");
                          class newsFeedMenuInit {
                                 description = "The module menu definition";
                                 file = "\x\alive\addons\sys_newsfeed\newsfeed\newsfeed_init.sqf";

--- a/addons/sys_patrolrep/CfgFunctions.hpp
+++ b/addons/sys_patrolrep/CfgFunctions.hpp
@@ -3,57 +3,57 @@ class cfgFunctions {
                 class COMPONENT {
                         class patrolrep {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_patrolrep\fnc_patrolrep.sqf";
+																file = PATHTO_FUNC(patrolrep);
                                 recompile = RECOMPILE;
                         };
                         class patrolrepInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_patrolrep\fnc_patrolrepInit.sqf";
+																file = PATHTO_FUNC(patrolrepInit);
                                 recompile = RECOMPILE;
                         };
                         class patrolrepParams {
                                 description = "patrolrep parameters";
-                                file = "\x\alive\addons\sys_patrolrep\fnc_patrolrepParams.sqf";
+																file = PATHTO_FUNC(patrolrepParams);
                                 recompile = RECOMPILE;
                         };
                         class patrolrepSaveData {
                                 description = "patrolrep save data to DB";
-                                file = "\x\alive\addons\sys_patrolrep\fnc_patrolrepSaveData.sqf";
+																file = PATHTO_FUNC(patrolrepSaveData);
                                                                 recompile = RECOMPILE;
                         };
                         class patrolrepLoadData {
                                 description = "patrolrep load data to DB";
-                                file = "\x\alive\addons\sys_patrolrep\fnc_patrolrepLoadData.sqf";
+																file = PATHTO_FUNC(patrolrepLoadData);
                                                                 recompile = RECOMPILE;
                         };
                         class patrolrepDeleteData {
                                 description = "patrolrep delete data from DB";
-                                file = "\x\alive\addons\sys_patrolrep\fnc_patrolrepDeleteData.sqf";
+																file = PATHTO_FUNC(patrolrepDeleteData);
                                                                 recompile = RECOMPILE;
                         };
                         class patrolrepOnPlayerConnected {
                                 description = "Handles on player connected event";
-                                file = "\x\alive\addons\sys_patrolrep\fnc_patrolrepOnPlayerConnected.sqf";
+																file = PATHTO_FUNC(patrolrepOnPlayerConnected);
                                                                 recompile = RECOMPILE;
                         };
                         class patrolrepCreateDiaryRecord {
                                 description = "Adds a patrolrep to a diary record";
-                                file = "\x\alive\addons\sys_patrolrep\fnc_patrolrepCreateDiaryRecord.sqf";
+																file = PATHTO_FUNC(patrolrepCreateDiaryRecord);
                                                                 recompile = RECOMPILE;
                         };
                         class patrolrepOnLoad {
                                 description = "patrolrep on load for dialog";
-                                file = "\x\alive\addons\sys_patrolrep\fnc_patrolrepOnLoad.sqf";
+																file = PATHTO_FUNC(patrolrepOnLoad);
                                                                 recompile = RECOMPILE;
                         };
                         class patrolrepButtonAction {
                                 description = "patrolrep button action for dialog";
-                                file = "\x\alive\addons\sys_patrolrep\fnc_patrolrepButtonAction.sqf";
+																file = PATHTO_FUNC(patrolrepButtonAction);
                                                                 recompile = RECOMPILE;
                         };
                         class patrolrepOnMapEvent {
                                 description = "patrolrep on map event for dialog";
-                                file = "\x\alive\addons\sys_patrolrep\fnc_patrolrepOnMapEvent.sqf";
+																file = PATHTO_FUNC(patrolrepOnMapEvent);
                                                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/sys_patrolrep/CfgFunctions.hpp
+++ b/addons/sys_patrolrep/CfgFunctions.hpp
@@ -1,61 +1,17 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class patrolrep {
-                                description = "The main class";
-																file = PATHTO_FUNC(patrolrep);
-                                recompile = RECOMPILE;
-                        };
-                        class patrolrepInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(patrolrepInit);
-                                recompile = RECOMPILE;
-                        };
-                        class patrolrepParams {
-                                description = "patrolrep parameters";
-																file = PATHTO_FUNC(patrolrepParams);
-                                recompile = RECOMPILE;
-                        };
-                        class patrolrepSaveData {
-                                description = "patrolrep save data to DB";
-																file = PATHTO_FUNC(patrolrepSaveData);
-                                                                recompile = RECOMPILE;
-                        };
-                        class patrolrepLoadData {
-                                description = "patrolrep load data to DB";
-																file = PATHTO_FUNC(patrolrepLoadData);
-                                                                recompile = RECOMPILE;
-                        };
-                        class patrolrepDeleteData {
-                                description = "patrolrep delete data from DB";
-																file = PATHTO_FUNC(patrolrepDeleteData);
-                                                                recompile = RECOMPILE;
-                        };
-                        class patrolrepOnPlayerConnected {
-                                description = "Handles on player connected event";
-																file = PATHTO_FUNC(patrolrepOnPlayerConnected);
-                                                                recompile = RECOMPILE;
-                        };
-                        class patrolrepCreateDiaryRecord {
-                                description = "Adds a patrolrep to a diary record";
-																file = PATHTO_FUNC(patrolrepCreateDiaryRecord);
-                                                                recompile = RECOMPILE;
-                        };
-                        class patrolrepOnLoad {
-                                description = "patrolrep on load for dialog";
-																file = PATHTO_FUNC(patrolrepOnLoad);
-                                                                recompile = RECOMPILE;
-                        };
-                        class patrolrepButtonAction {
-                                description = "patrolrep button action for dialog";
-																file = PATHTO_FUNC(patrolrepButtonAction);
-                                                                recompile = RECOMPILE;
-                        };
-                        class patrolrepOnMapEvent {
-                                description = "patrolrep on map event for dialog";
-																file = PATHTO_FUNC(patrolrepOnMapEvent);
-                                                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(patrolrep,"The main class");
+												FUNC_FILEPATH(patrolrepInit,"The module initialisation function");
+												FUNC_FILEPATH(patrolrepParams,"patrolrep parameters");
+												FUNC_FILEPATH(patrolrepSaveData,"patrolrep save data to DB");
+												FUNC_FILEPATH(patrolrepLoadData,"patrolrep load data to DB");
+												FUNC_FILEPATH(patrolrepDeleteData,"patrolrep delete data from DB");
+												FUNC_FILEPATH(patrolrepOnPlayerConnected,"Handles on player connected event");
+												FUNC_FILEPATH(patrolrepCreateDiaryRecord,"Adds a patrolrep to a diary record");
+												FUNC_FILEPATH(patrolrepOnLoad,"patrolrep on load for dialog");
+												FUNC_FILEPATH(patrolrepButtonAction,"patrolrep button action for dialog");
+												FUNC_FILEPATH(patrolrepOnMapEvent,"patrolrep on map event for dialog");
+								};
+				};
 };

--- a/addons/sys_perf/CfgFunctions.hpp
+++ b/addons/sys_perf/CfgFunctions.hpp
@@ -3,27 +3,27 @@ class cfgFunctions {
                 class COMPONENT {
                         class perfInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_perf\fnc_perfInit.sqf";
+																file = PATHTO_FUNC(perfInit);
                                 recompile = RECOMPILE;
                         };
                         class perfMenuDef {
                                 description = "The module menu definition";
-                                file = "\x\alive\addons\sys_perf\fnc_perfMenuDef.sqf";
+																file = PATHTO_FUNC(perfMenuDef);
                                 recompile = RECOMPILE;
                         };
                         class perfDisable {
                                 description = "The module disable function";
-                                file = "\x\alive\addons\sys_perf\fnc_perfDisable.sqf";
+																file = PATHTO_FUNC(perfDisable);
                                 recompile = RECOMPILE;
                         };
                         class perfModuleFunction {
                                 description = "The module function definition";
-                                file = "\x\alive\addons\sys_perf\fnc_perfModuleFunction.sqf";
+																file = PATHTO_FUNC(perfModuleFunction);
                                 recompile = RECOMPILE;
                         };
                         class perf_OnPlayerDisconnected {
                                 description = "The module onPlayerDisconnected handler";
-                                file = "\x\alive\addons\sys_perf\fnc_perf_onPlayerDisconnected.sqf";
+																file = PATHTO_FUNC(perf_onPlayerDisconnected);
                                 recompile = RECOMPILE;
                         };
                         class perfMonitor {

--- a/addons/sys_perf/CfgFunctions.hpp
+++ b/addons/sys_perf/CfgFunctions.hpp
@@ -1,31 +1,11 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class perfInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(perfInit);
-                                recompile = RECOMPILE;
-                        };
-                        class perfMenuDef {
-                                description = "The module menu definition";
-																file = PATHTO_FUNC(perfMenuDef);
-                                recompile = RECOMPILE;
-                        };
-                        class perfDisable {
-                                description = "The module disable function";
-																file = PATHTO_FUNC(perfDisable);
-                                recompile = RECOMPILE;
-                        };
-                        class perfModuleFunction {
-                                description = "The module function definition";
-																file = PATHTO_FUNC(perfModuleFunction);
-                                recompile = RECOMPILE;
-                        };
-                        class perf_OnPlayerDisconnected {
-                                description = "The module onPlayerDisconnected handler";
-																file = PATHTO_FUNC(perf_onPlayerDisconnected);
-                                recompile = RECOMPILE;
-                        };
+												FUNC_FILEPATH(perfInit,"The module initialisation function");
+												FUNC_FILEPATH(perfMenuDef,"The module menu definition");
+												FUNC_FILEPATH(perfDisable,"The module disable function");
+												FUNC_FILEPATH(perfModuleFunction,"The module function definition");
+												FUNC_FILEPATH(perf_OnPlayerDisconnected,"The module onPlayerDisconnected handler");
                         class perfMonitor {
                             file = "\x\alive\addons\sys_perf\fnc_perfMonitor.fsm";
                             ext = ".fsm";

--- a/addons/sys_player/CfgFunctions.hpp
+++ b/addons/sys_player/CfgFunctions.hpp
@@ -2,54 +2,54 @@ class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
                         class player {
-                                description = "The main class";
-                                file = "\x\alive\addons\sys_player\fnc_player.sqf";
-                recompile = RECOMPILE;
+                          description = "The main class";
+                          file = PATHTO_FUNC(player);
+                          recompile = RECOMPILE;
                         };
                         class playerInit {
-                                description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_player\fnc_playerInit.sqf";
-                recompile = RECOMPILE;
+                          description = "The module initialisation function";
+                          file = PATHTO_FUNC(playerInit);
+                          recompile = RECOMPILE;
                         };
                         class playerMenuDef {
-                                description = "The module menu definition";
-                                file = "\x\alive\addons\sys_player\fnc_playerMenuDef.sqf";
-                recompile = RECOMPILE;
+                          description = "The module menu definition";
+                          file = PATHTO_FUNC(playerMenuDef);
+                          recompile = RECOMPILE;
                         };
                         class getPlayer {
-                                description = "Gets player data from the store and applies it to the player object";
-                                file = "\x\alive\addons\sys_player\fnc_getPlayer.sqf";
-                recompile = RECOMPILE;
+                          description = "Gets player data from the store and applies it to the player object";
+                          file = PATHTO_FUNC(getPlayer);
+                          recompile = RECOMPILE;
                         };
                         class setPlayer {
-                                description = "Sets player data to the store";
-                                file = "\x\alive\addons\sys_player\fnc_setPlayer.sqf";
-                                recompile = RECOMPILE;
+                          description = "Sets player data to the store";
+                          file = PATHTO_FUNC(setPlayer);
+                          recompile = RECOMPILE;
                         };
                         class getGear {
-                                description = "Gets loadout data from a store and applies it to the player object";
-                                file = "\x\alive\addons\sys_player\fnc_getGear.sqf";
-                                recompile = RECOMPILE;
+                          description = "Gets loadout data from a store and applies it to the player object";
+                          file = PATHTO_FUNC(getGear);
+                          recompile = RECOMPILE;
                         };
                         class setGear {
-                                description = "Sets loadout data to a store";
-                                file = "\x\alive\addons\sys_player\fnc_setGear.sqf";
-                recompile = RECOMPILE;
+                          description = "Sets loadout data to a store";
+                          file = PATHTO_FUNC(setGear);
+                          recompile = RECOMPILE;
                         };
                         class player_OnPlayerDisconnected {
-                                        description = "The module onPlayerDisconnected handler";
-                                        file = "\x\alive\addons\sys_player\fnc_player_onPlayerDisconnected.sqf";
-                                        recompile = RECOMPILE;
+                          description = "The module onPlayerDisconnected handler";
+                          file = PATHTO_FUNC(player_onPlayerDisconnected);
+                          recompile = RECOMPILE;
                         };
                         class player_OnPlayerConnected {
-                                        description = "The module onPlayerConnected handler";
-                                        file = "\x\alive\addons\sys_player\fnc_player_onPlayerConnected.sqf";
-                                        recompile = RECOMPILE;
+                          description = "The module onPlayerConnected handler";
+                          file = PATHTO_FUNC(player_onPlayerConnected);
+                          recompile = RECOMPILE;
                         };
                         class autoStorePlayer {
-                                        description = "Checks to see if the player data should be saved to server or DB";
-                                        file = "\x\alive\addons\sys_player\fnc_autoStorePlayer.sqf";
-                                        recompile = RECOMPILE;
+                          description = "Checks to see if the player data should be saved to server or DB";
+                          file = PATHTO_FUNC(autoStorePlayer);
+                          recompile = RECOMPILE;
                         };
                 };
         };

--- a/addons/sys_player/CfgFunctions.hpp
+++ b/addons/sys_player/CfgFunctions.hpp
@@ -1,56 +1,16 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class player {
-                          description = "The main class";
-                          file = PATHTO_FUNC(player);
-                          recompile = RECOMPILE;
-                        };
-                        class playerInit {
-                          description = "The module initialisation function";
-                          file = PATHTO_FUNC(playerInit);
-                          recompile = RECOMPILE;
-                        };
-                        class playerMenuDef {
-                          description = "The module menu definition";
-                          file = PATHTO_FUNC(playerMenuDef);
-                          recompile = RECOMPILE;
-                        };
-                        class getPlayer {
-                          description = "Gets player data from the store and applies it to the player object";
-                          file = PATHTO_FUNC(getPlayer);
-                          recompile = RECOMPILE;
-                        };
-                        class setPlayer {
-                          description = "Sets player data to the store";
-                          file = PATHTO_FUNC(setPlayer);
-                          recompile = RECOMPILE;
-                        };
-                        class getGear {
-                          description = "Gets loadout data from a store and applies it to the player object";
-                          file = PATHTO_FUNC(getGear);
-                          recompile = RECOMPILE;
-                        };
-                        class setGear {
-                          description = "Sets loadout data to a store";
-                          file = PATHTO_FUNC(setGear);
-                          recompile = RECOMPILE;
-                        };
-                        class player_OnPlayerDisconnected {
-                          description = "The module onPlayerDisconnected handler";
-                          file = PATHTO_FUNC(player_onPlayerDisconnected);
-                          recompile = RECOMPILE;
-                        };
-                        class player_OnPlayerConnected {
-                          description = "The module onPlayerConnected handler";
-                          file = PATHTO_FUNC(player_onPlayerConnected);
-                          recompile = RECOMPILE;
-                        };
-                        class autoStorePlayer {
-                          description = "Checks to see if the player data should be saved to server or DB";
-                          file = PATHTO_FUNC(autoStorePlayer);
-                          recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(player,"The main class");
+												FUNC_FILEPATH(playerInit,"The module initialisation function");
+												FUNC_FILEPATH(playerMenuDef,"The module menu definition");
+												FUNC_FILEPATH(getPlayer,"Gets player data from the store and applies it to the player object");
+												FUNC_FILEPATH(setPlayer,"Sets player data to the store");
+												FUNC_FILEPATH(getGear,"Gets loadout data from a store and applies it to the player object");
+												FUNC_FILEPATH(setGear,"Sets loadout data to a store");
+												FUNC_FILEPATH(player_OnPlayerDisconnected,"The module onPlayerDisconnected handler");
+												FUNC_FILEPATH(player_OnPlayerConnected,"The module onPlayerConnected handler");
+												FUNC_FILEPATH(autoStorePlayer,"Checks to see if the player data should be saved to server or DB");
+								};
+				};
 };

--- a/addons/sys_playeroptions/CfgFunctions.hpp
+++ b/addons/sys_playeroptions/CfgFunctions.hpp
@@ -3,17 +3,17 @@ class cfgFunctions {
                 class COMPONENT {
                         class playeroptions {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_playeroptions\fnc_playeroptions.sqf";
+																file = PATHTO_FUNC(playeroptions);
                                 recompile = RECOMPILE;
                         };
                         class playeroptionsInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_playeroptions\fnc_playeroptionsInit.sqf";
+																file = PATHTO_FUNC(playeroptionsInit);
                                 recompile = RECOMPILE;
                         };
                         class playeroptionsMenuDef {
                                 description = "The menu definition function";
-                                file = "\x\alive\addons\sys_playeroptions\fnc_playeroptionsMenuDef.sqf";
+																file = PATHTO_FUNC(playeroptionsMenuDef);
                                                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/sys_playeroptions/CfgFunctions.hpp
+++ b/addons/sys_playeroptions/CfgFunctions.hpp
@@ -1,21 +1,9 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class playeroptions {
-                                description = "The main class";
-																file = PATHTO_FUNC(playeroptions);
-                                recompile = RECOMPILE;
-                        };
-                        class playeroptionsInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(playeroptionsInit);
-                                recompile = RECOMPILE;
-                        };
-                        class playeroptionsMenuDef {
-                                description = "The menu definition function";
-																file = PATHTO_FUNC(playeroptionsMenuDef);
-                                                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(playeroptions,"The main class");
+												FUNC_FILEPATH(playeroptionsInit,"The module initialisation function");
+												FUNC_FILEPATH(playeroptionsMenuDef,"The menu definition function");
+								};
+				};
 };

--- a/addons/sys_playertags/CfgFunctions.hpp
+++ b/addons/sys_playertags/CfgFunctions.hpp
@@ -1,40 +1,28 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class playertags {
-                                description = "The main class";
-																file = PATHTO_FUNC(playertags);
-                                                                recompile = RECOMPILE;
-                        };
-                        class playertagsInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(playertagsInit);
-                                                                recompile = RECOMPILE;
-                        };
-                        class playertagsMenuDef {
-                                description = "The module menu definition";
-																file = PATHTO_FUNC(playertagsMenuDef);
-                                                                recompile = RECOMPILE;
-                        };
-                                                class playertagsRecognise {
+												FUNC_FILEPATH(playertags,"The main class");
+												FUNC_FILEPATH(playertagsInit,"The module initialisation function");
+												FUNC_FILEPATH(playertagsMenuDef,"The module menu definition");
+                        class playertagsRecognise {
                                 description = "The condition script";
                                 file = "\x\alive\addons\sys_playertags\playertags_recognise.sqf";
-                                                                recompile = RECOMPILE;
+                                recompile = RECOMPILE;
                         };
-                                                class playertagsRecogniseHandler {
+                        class playertagsRecogniseHandler {
                                 description = "The handler script";
                                 file = "\x\alive\addons\sys_playertags\playertags_recogniseHandler.sqf";
-                                                                recompile = RECOMPILE;
+                                recompile = RECOMPILE;
                         };
-                                                class playertagsRecogniseOverlayCtrl {
+                        class playertagsRecogniseOverlayCtrl {
                                 description = "The overlay control";
                                 file = "\x\alive\addons\sys_playertags\playertags_recogniseOverlayCtrl.sqf";
-                                                                recompile = RECOMPILE;
+                                recompile = RECOMPILE;
                         };
-                                                class playertagsGenerateLabelText {
+                        class playertagsGenerateLabelText {
                                 description = "The label control";
                                 file = "\x\alive\addons\sys_playertags\playertags_generateLabelText.sqf";
-                                                                recompile = RECOMPILE;
+                                recompile = RECOMPILE;
                         };
                 };
         };

--- a/addons/sys_playertags/CfgFunctions.hpp
+++ b/addons/sys_playertags/CfgFunctions.hpp
@@ -3,17 +3,17 @@ class cfgFunctions {
                 class COMPONENT {
                         class playertags {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_playertags\fnc_playertags.sqf";
+																file = PATHTO_FUNC(playertags);
                                                                 recompile = RECOMPILE;
                         };
                         class playertagsInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_playertags\fnc_playertagsInit.sqf";
+																file = PATHTO_FUNC(playertagsInit);
                                                                 recompile = RECOMPILE;
                         };
                         class playertagsMenuDef {
                                 description = "The module menu definition";
-                                file = "\x\alive\addons\sys_playertags\fnc_playertagsMenuDef.sqf";
+																file = PATHTO_FUNC(playertagsMenuDef);
                                                                 recompile = RECOMPILE;
                         };
                                                 class playertagsRecognise {

--- a/addons/sys_profile/CfgFunctions.hpp
+++ b/addons/sys_profile/CfgFunctions.hpp
@@ -3,262 +3,262 @@ class cfgFunctions {
         class COMPONENT {
             class profileSystemInit {
                 description = "profileSystemInit";
-                file = "\x\alive\addons\sys_profile\fnc_profileSystemInit.sqf";
+								file = PATHTO_FUNC(profileSystemInit);
                 recompile = RECOMPILE;
             };
             class profileSystem {
                 description = "profileSystem";
-                file = "\x\alive\addons\sys_profile\fnc_profileSystem.sqf";
+								file = PATHTO_FUNC(profileSystem);
                 recompile = RECOMPILE;
             };
             class profileHandler {
                 description = "profileHandler";
-                file = "\x\alive\addons\sys_profile\fnc_profileHandler.sqf";
+								file = PATHTO_FUNC(profileHandler);
                 recompile = RECOMPILE;
             };
             class profile {
                 description = "profile";
-                file = "\x\alive\addons\sys_profile\fnc_profile.sqf";
+								file = PATHTO_FUNC(profile);
                 recompile = RECOMPILE;
             };
             class profileEntity {
                 description = "profileEntity";
-                file = "\x\alive\addons\sys_profile\fnc_profileEntity.sqf";
+								file = PATHTO_FUNC(profileEntity);
                 recompile = RECOMPILE;
             };
             class profileMenuDef {
                 description = "profileMenuDef";
-                file = "\x\alive\addons\sys_profile\fnc_profileMenuDef.sqf";
+								file = PATHTO_FUNC(profileMenuDef);
                 recompile = RECOMPILE;
             };
             class profileVehicle {
                 description = "profileVehicle";
-                file = "\x\alive\addons\sys_profile\fnc_profileVehicle.sqf";
+								file = PATHTO_FUNC(profileVehicle);
                 recompile = RECOMPILE;
             };
             class createProfilesFromGroupConfig {
                 description = "createProfilesFromGroupConfig";
-                file = "\x\alive\addons\sys_profile\fnc_createProfilesFromGroupConfig.sqf";
+								file = PATHTO_FUNC(createProfilesFromGroupConfig);
                 recompile = RECOMPILE;
             };
             class createProfilesCrewedVehicle {
                 description = "createProfilesCrewedVehicle";
-                file = "\x\alive\addons\sys_profile\fnc_createProfilesCrewedVehicle.sqf";
+								file = PATHTO_FUNC(createProfilesCrewedVehicle);
                 recompile = RECOMPILE;
             };
             class createProfileVehicle {
                 description = "createProfileVehicle";
-                file = "\x\alive\addons\sys_profile\fnc_createProfileVehicle.sqf";
+								file = PATHTO_FUNC(createProfileVehicle);
                 recompile = RECOMPILE;
             };
             class createProfileEntity {
                 description = "createProfileEntity";
-                file = "\x\alive\addons\sys_profile\fnc_createProfileEntity.sqf";
+								file = PATHTO_FUNC(createProfileEntity);
                 recompile = RECOMPILE;
             };
             class createProfilesFromUnits {
                 description = "createProfilesFromUnits";
-                file = "\x\alive\addons\sys_profile\fnc_createProfilesFromUnits.sqf";
+								file = PATHTO_FUNC(createProfilesFromUnits);
                 recompile = RECOMPILE;
             };
             class createProfilesFromUnitsRuntime {
                 description = "createProfilesFromUnitsRuntime";
-                file = "\x\alive\addons\sys_profile\fnc_createProfilesFromUnitsRuntime.sqf";
+								file = PATHTO_FUNC(createProfilesFromUnitsRuntime);
                 recompile = RECOMPILE;
             };
             class createProfilesFromPlayers {
                 description = "createProfilesFromPlayers";
-                file = "\x\alive\addons\sys_profile\fnc_createProfilesFromPlayers.sqf";
+								file = PATHTO_FUNC(createProfilesFromPlayers);
                 recompile = RECOMPILE;
             };
             class profileKilledEventHandler {
                 description = "profileKilledEventHandler";
-                file = "\x\alive\addons\sys_profile\fnc_profileKilledEventHandler.sqf";
+								file = PATHTO_FUNC(profileKilledEventHandler);
                 recompile = RECOMPILE;
             };
             class profileGetInEventHandler {
                 description = "profileGetInEventHandler";
-                file = "\x\alive\addons\sys_profile\fnc_profileGetInEventHandler.sqf";
+								file = PATHTO_FUNC(profileGetInEventHandler);
                 recompile = RECOMPILE;
             };
             class createProfileWaypoint {
                 description = "createProfileWaypoint";
-                file = "\x\alive\addons\sys_profile\fnc_createProfileWaypoint.sqf";
+								file = PATHTO_FUNC(createProfileWaypoint);
                 recompile = RECOMPILE;
             };
             class profileWaypointsToWaypoints {
                 description = "profileWaypointsToWaypoints";
-                file = "\x\alive\addons\sys_profile\fnc_profileWaypointsToWaypoints.sqf";
+								file = PATHTO_FUNC(profileWaypointsToWaypoints);
                 recompile = RECOMPILE;
             };
             class profileWaypointToWaypoint {
                 description = "profileWaypointToWaypoint";
-                file = "\x\alive\addons\sys_profile\fnc_profileWaypointToWaypoint.sqf";
+								file = PATHTO_FUNC(profileWaypointToWaypoint);
                 recompile = RECOMPILE;
             };
             class waypointsToProfileWaypoints {
                 description = "waypointsToProfileWaypoints";
-                file = "\x\alive\addons\sys_profile\fnc_waypointsToProfileWaypoints.sqf";
+								file = PATHTO_FUNC(waypointsToProfileWaypoints);
                 recompile = RECOMPILE;
             };
             class waypointToProfileWaypoint {
                 description = "waypointToProfileWaypoint";
-                file = "\x\alive\addons\sys_profile\fnc_waypointToProfileWaypoint.sqf";
+								file = PATHTO_FUNC(waypointToProfileWaypoint);
                 recompile = RECOMPILE;
             };
             class createProfileVehicleAssignment {
                 description = "createProfileVehicleAssignment";
-                file = "\x\alive\addons\sys_profile\fnc_createProfileVehicleAssignment.sqf";
+								file = PATHTO_FUNC(createProfileVehicleAssignment);
                 recompile = RECOMPILE;
             };
             class removeProfileVehicleAssignments {
                 description = "removeProfileVehicleAssignments";
-                file = "\x\alive\addons\sys_profile\fnc_removeProfileVehicleAssignments.sqf";
+								file = PATHTO_FUNC(removeProfileVehicleAssignments);
                 recompile = RECOMPILE;
             };
             class removeProfileVehicleAssignment {
                 description = "removeProfileVehicleAssignment";
-                file = "\x\alive\addons\sys_profile\fnc_removeProfileVehicleAssignment.sqf";
+								file = PATHTO_FUNC(removeProfileVehicleAssignment);
                 recompile = RECOMPILE;
             };
             class profileVehicleAssignmentGetUsedIndexes {
                 description = "profileVehicleAssignmentGetUsedIndexes";
-                file = "\x\alive\addons\sys_profile\fnc_profileVehicleAssignmentGetUsedIndexes.sqf";
+								file = PATHTO_FUNC(profileVehicleAssignmentGetUsedIndexes);
                 recompile = RECOMPILE;
             };
             class profileVehicleAssignmentGetEmptyPositions {
                 description = "profileVehicleAssignmentGetEmptyPositions";
-                file = "\x\alive\addons\sys_profile\fnc_profileVehicleAssignmentGetEmptyPositions.sqf";
+								file = PATHTO_FUNC(profileVehicleAssignmentGetEmptyPositions);
                 recompile = RECOMPILE;
             };
             class profileVehicleAssignmentsToVehicleAssignments {
                 description = "profileVehicleAssignmentsToVehicleAssignments";
-                file = "\x\alive\addons\sys_profile\fnc_profileVehicleAssignmentsToVehicleAssignments.sqf";
+								file = PATHTO_FUNC(profileVehicleAssignmentsToVehicleAssignments);
                 recompile = RECOMPILE;
             };
             class profileVehicleAssignmentToVehicleAssignment {
                 description = "profileVehicleAssignmentToVehicleAssignment";
-                file = "\x\alive\addons\sys_profile\fnc_profileVehicleAssignmentToVehicleAssignment.sqf";
+								file = PATHTO_FUNC(profileVehicleAssignmentToVehicleAssignment);
                 recompile = RECOMPILE;
             };
             class profileVehicleAssignmentIndexesToUnits {
                 description = "profileVehicleAssignmentIndexesToUnits";
-                file = "\x\alive\addons\sys_profile\fnc_profileVehicleAssignmentIndexesToUnits.sqf";
+								file = PATHTO_FUNC(profileVehicleAssignmentIndexesToUnits);
                 recompile = RECOMPILE;
             };
             class profileVehicleAssignmentsGetInCommand {
                 description = "profileVehicleAssignmentsGetInCommand";
-                file = "\x\alive\addons\sys_profile\fnc_profileVehicleAssignmentsGetInCommand.sqf";
+								file = PATHTO_FUNC(profileVehicleAssignmentsGetInCommand);
                 recompile = RECOMPILE;
             };
             class profileVehicleAssignmentsGetInCargo {
                 description = "profileVehicleAssignmentsGetInCargo";
-                file = "\x\alive\addons\sys_profile\fnc_profileVehicleAssignmentsGetInCargo.sqf";
+								file = PATHTO_FUNC(profileVehicleAssignmentsGetInCargo);
                 recompile = RECOMPILE;
             };
             class profileVehicleAssignmentsSetAllPositions {
                 description = "profileVehicleAssignmentsSetAllPositions";
-                file = "\x\alive\addons\sys_profile\fnc_profileVehicleAssignmentsSetAllPositions.sqf";
+								file = PATHTO_FUNC(profileVehicleAssignmentsSetAllPositions);
                 recompile = RECOMPILE;
             };
             class profileVehicleAssignmentsGetSpeedPerSecond {
                 description = "profileVehicleAssignmentsGetSpeedPerSecond";
-                file = "\x\alive\addons\sys_profile\fnc_profileVehicleAssignmentsGetSpeedPerSecond.sqf";
+								file = PATHTO_FUNC(profileVehicleAssignmentsGetSpeedPerSecond);
                 recompile = RECOMPILE;
             };
             class profileVehicleAssignmentsGetCount {
                 description = "profileVehicleAssignmentsGetCount";
-                file = "\x\alive\addons\sys_profile\fnc_profileVehicleAssignmentsGetCount.sqf";
+								file = PATHTO_FUNC(profileVehicleAssignmentsGetCount);
                 recompile = RECOMPILE;
             };
             class profileGetGoodSpawnPosition {
                 description = "profileGetGoodSpawnPosition";
-                file = "\x\alive\addons\sys_profile\fnc_profileGetGoodSpawnPosition.sqf";
+								file = PATHTO_FUNC(profileGetGoodSpawnPosition);
                 recompile = RECOMPILE;
             };
             class profileGetAnyLinkedInRange {
                 description = "profileGetAnyLinkedInRange";
-                file = "\x\alive\addons\sys_profile\fnc_profileGetAnyLinkedInRange.sqf";
+								file = PATHTO_FUNC(profileGetAnyLinkedInRange);
                 recompile = RECOMPILE;
             };
             class profileSimulator {
                 description = "profileSimulator";
-                file = "\x\alive\addons\sys_profile\fnc_profileSimulator.sqf";
+								file = PATHTO_FUNC(profileSimulator);
                 recompile = RECOMPILE;
             };
             class profileSpawner {
                 description = "profileSpawner";
-                file = "\x\alive\addons\sys_profile\fnc_profileSpawner.sqf";
+								file = PATHTO_FUNC(profileSpawner);
                 recompile = RECOMPILE;
             };
             class profileDespawner {
                 description = "profileDespawner";
-                file = "\x\alive\addons\sys_profile\fnc_profileDespawner.sqf";
+								file = PATHTO_FUNC(profileDespawner);
                 recompile = RECOMPILE;
             };
             class getNearProfiles {
                 description = "getNearProfiles";
-                file = "\x\alive\addons\sys_profile\fnc_getNearProfiles.sqf";
+								file = PATHTO_FUNC(getNearProfiles);
                 recompile = RECOMPILE;
             };
             class vehicleAssignmentsGetLinkedProfiles {
                 description = "vehicleAssignmentsGetLinkedProfiles";
-                file = "\x\alive\addons\sys_profile\fnc_vehicleAssignmentsGetLinkedProfiles.sqf";
+								file = PATHTO_FUNC(vehicleAssignmentsGetLinkedProfiles);
                 recompile = RECOMPILE;
             };
             class vehicleAssignmentsToProfileVehicleAssignments {
                 description = "vehicleAssignmentsToProfileVehicleAssignments";
-                file = "\x\alive\addons\sys_profile\fnc_vehicleAssignmentsToProfileVehicleAssignments.sqf";
+								file = PATHTO_FUNC(vehicleAssignmentsToProfileVehicleAssignments);
                 recompile = RECOMPILE;
             };
             class vehicleAssignmentToProfileVehicleAssignment {
                 description = "vehicleAssignmentToProfileVehicleAssignment";
-                file = "\x\alive\addons\sys_profile\fnc_vehicleAssignmentToProfileVehicleAssignment.sqf";
+								file = PATHTO_FUNC(vehicleAssignmentToProfileVehicleAssignment);
                 recompile = RECOMPILE;
             };
             class getInActiveEntitiesForMarking {
                 description = "getInActiveEntitiesForMarking";
-                file = "\x\alive\addons\sys_profile\fnc_getInActiveEntitiesForMarking.sqf";
+								file = PATHTO_FUNC(getInActiveEntitiesForMarking);
                 recompile = RECOMPILE;
             };
             class profile_onPlayerConnected {
                 description = "profile_onPlayerConnected";
-                file = "\x\alive\addons\sys_profile\fnc_profile_onPlayerConnected.sqf";
+								file = PATHTO_FUNC(profile_onPlayerConnected);
                 recompile = RECOMPILE;
             };
             class profile_onPlayerDisconnected {
                 description = "profile_onPlayerDisconnected";
-                file = "\x\alive\addons\sys_profile\fnc_profile_onPlayerDisconnected.sqf";
+								file = PATHTO_FUNC(profile_onPlayerDisconnected);
                 recompile = RECOMPILE;
             };
             class profilesSaveData {
                 description = "profilesSaveData";
-                file = "\x\alive\addons\sys_profile\fnc_profilesSaveData.sqf";
+								file = PATHTO_FUNC(profilesSaveData);
                 recompile = RECOMPILE;
             };
             class profilesLoadData {
                 description = "profilesLoadData";
-                file = "\x\alive\addons\sys_profile\fnc_profilesLoadData.sqf";
+								file = PATHTO_FUNC(profilesLoadData);
                 recompile = RECOMPILE;
             };
             class profileAttack {
                 description = "profileAttack";
-                file = "\x\alive\addons\sys_profile\fnc_profileAttack.sqf";
+								file = PATHTO_FUNC(profileAttack);
                 recompile = RECOMPILE;
             };
             class profileBattle {
                 description = "profileBattle";
-                file = "\x\alive\addons\sys_profile\fnc_profileBattle.sqf";
+								file = PATHTO_FUNC(profileBattle);
                 recompile = RECOMPILE;
             };
             class profileCombatHandler {
                 description = "profileCombatHandler";
-                file = "\x\alive\addons\sys_profile\fnc_profileCombatHandler.sqf";
+								file = PATHTO_FUNC(profileCombatHandler);
                 recompile = RECOMPILE;
             };
             class profileGetDamageOutput {
                 description = "profileGetDamageOutput";
-                file = "\x\alive\addons\sys_profile\fnc_profileGetDamageOutput.sqf";
+								file = PATHTO_FUNC(profileGetDamageOutput);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/sys_profile/CfgFunctions.hpp
+++ b/addons/sys_profile/CfgFunctions.hpp
@@ -1,266 +1,58 @@
 class cfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class profileSystemInit {
-                description = "profileSystemInit";
-								file = PATHTO_FUNC(profileSystemInit);
-                recompile = RECOMPILE;
-            };
-            class profileSystem {
-                description = "profileSystem";
-								file = PATHTO_FUNC(profileSystem);
-                recompile = RECOMPILE;
-            };
-            class profileHandler {
-                description = "profileHandler";
-								file = PATHTO_FUNC(profileHandler);
-                recompile = RECOMPILE;
-            };
-            class profile {
-                description = "profile";
-								file = PATHTO_FUNC(profile);
-                recompile = RECOMPILE;
-            };
-            class profileEntity {
-                description = "profileEntity";
-								file = PATHTO_FUNC(profileEntity);
-                recompile = RECOMPILE;
-            };
-            class profileMenuDef {
-                description = "profileMenuDef";
-								file = PATHTO_FUNC(profileMenuDef);
-                recompile = RECOMPILE;
-            };
-            class profileVehicle {
-                description = "profileVehicle";
-								file = PATHTO_FUNC(profileVehicle);
-                recompile = RECOMPILE;
-            };
-            class createProfilesFromGroupConfig {
-                description = "createProfilesFromGroupConfig";
-								file = PATHTO_FUNC(createProfilesFromGroupConfig);
-                recompile = RECOMPILE;
-            };
-            class createProfilesCrewedVehicle {
-                description = "createProfilesCrewedVehicle";
-								file = PATHTO_FUNC(createProfilesCrewedVehicle);
-                recompile = RECOMPILE;
-            };
-            class createProfileVehicle {
-                description = "createProfileVehicle";
-								file = PATHTO_FUNC(createProfileVehicle);
-                recompile = RECOMPILE;
-            };
-            class createProfileEntity {
-                description = "createProfileEntity";
-								file = PATHTO_FUNC(createProfileEntity);
-                recompile = RECOMPILE;
-            };
-            class createProfilesFromUnits {
-                description = "createProfilesFromUnits";
-								file = PATHTO_FUNC(createProfilesFromUnits);
-                recompile = RECOMPILE;
-            };
-            class createProfilesFromUnitsRuntime {
-                description = "createProfilesFromUnitsRuntime";
-								file = PATHTO_FUNC(createProfilesFromUnitsRuntime);
-                recompile = RECOMPILE;
-            };
-            class createProfilesFromPlayers {
-                description = "createProfilesFromPlayers";
-								file = PATHTO_FUNC(createProfilesFromPlayers);
-                recompile = RECOMPILE;
-            };
-            class profileKilledEventHandler {
-                description = "profileKilledEventHandler";
-								file = PATHTO_FUNC(profileKilledEventHandler);
-                recompile = RECOMPILE;
-            };
-            class profileGetInEventHandler {
-                description = "profileGetInEventHandler";
-								file = PATHTO_FUNC(profileGetInEventHandler);
-                recompile = RECOMPILE;
-            };
-            class createProfileWaypoint {
-                description = "createProfileWaypoint";
-								file = PATHTO_FUNC(createProfileWaypoint);
-                recompile = RECOMPILE;
-            };
-            class profileWaypointsToWaypoints {
-                description = "profileWaypointsToWaypoints";
-								file = PATHTO_FUNC(profileWaypointsToWaypoints);
-                recompile = RECOMPILE;
-            };
-            class profileWaypointToWaypoint {
-                description = "profileWaypointToWaypoint";
-								file = PATHTO_FUNC(profileWaypointToWaypoint);
-                recompile = RECOMPILE;
-            };
-            class waypointsToProfileWaypoints {
-                description = "waypointsToProfileWaypoints";
-								file = PATHTO_FUNC(waypointsToProfileWaypoints);
-                recompile = RECOMPILE;
-            };
-            class waypointToProfileWaypoint {
-                description = "waypointToProfileWaypoint";
-								file = PATHTO_FUNC(waypointToProfileWaypoint);
-                recompile = RECOMPILE;
-            };
-            class createProfileVehicleAssignment {
-                description = "createProfileVehicleAssignment";
-								file = PATHTO_FUNC(createProfileVehicleAssignment);
-                recompile = RECOMPILE;
-            };
-            class removeProfileVehicleAssignments {
-                description = "removeProfileVehicleAssignments";
-								file = PATHTO_FUNC(removeProfileVehicleAssignments);
-                recompile = RECOMPILE;
-            };
-            class removeProfileVehicleAssignment {
-                description = "removeProfileVehicleAssignment";
-								file = PATHTO_FUNC(removeProfileVehicleAssignment);
-                recompile = RECOMPILE;
-            };
-            class profileVehicleAssignmentGetUsedIndexes {
-                description = "profileVehicleAssignmentGetUsedIndexes";
-								file = PATHTO_FUNC(profileVehicleAssignmentGetUsedIndexes);
-                recompile = RECOMPILE;
-            };
-            class profileVehicleAssignmentGetEmptyPositions {
-                description = "profileVehicleAssignmentGetEmptyPositions";
-								file = PATHTO_FUNC(profileVehicleAssignmentGetEmptyPositions);
-                recompile = RECOMPILE;
-            };
-            class profileVehicleAssignmentsToVehicleAssignments {
-                description = "profileVehicleAssignmentsToVehicleAssignments";
-								file = PATHTO_FUNC(profileVehicleAssignmentsToVehicleAssignments);
-                recompile = RECOMPILE;
-            };
-            class profileVehicleAssignmentToVehicleAssignment {
-                description = "profileVehicleAssignmentToVehicleAssignment";
-								file = PATHTO_FUNC(profileVehicleAssignmentToVehicleAssignment);
-                recompile = RECOMPILE;
-            };
-            class profileVehicleAssignmentIndexesToUnits {
-                description = "profileVehicleAssignmentIndexesToUnits";
-								file = PATHTO_FUNC(profileVehicleAssignmentIndexesToUnits);
-                recompile = RECOMPILE;
-            };
-            class profileVehicleAssignmentsGetInCommand {
-                description = "profileVehicleAssignmentsGetInCommand";
-								file = PATHTO_FUNC(profileVehicleAssignmentsGetInCommand);
-                recompile = RECOMPILE;
-            };
-            class profileVehicleAssignmentsGetInCargo {
-                description = "profileVehicleAssignmentsGetInCargo";
-								file = PATHTO_FUNC(profileVehicleAssignmentsGetInCargo);
-                recompile = RECOMPILE;
-            };
-            class profileVehicleAssignmentsSetAllPositions {
-                description = "profileVehicleAssignmentsSetAllPositions";
-								file = PATHTO_FUNC(profileVehicleAssignmentsSetAllPositions);
-                recompile = RECOMPILE;
-            };
-            class profileVehicleAssignmentsGetSpeedPerSecond {
-                description = "profileVehicleAssignmentsGetSpeedPerSecond";
-								file = PATHTO_FUNC(profileVehicleAssignmentsGetSpeedPerSecond);
-                recompile = RECOMPILE;
-            };
-            class profileVehicleAssignmentsGetCount {
-                description = "profileVehicleAssignmentsGetCount";
-								file = PATHTO_FUNC(profileVehicleAssignmentsGetCount);
-                recompile = RECOMPILE;
-            };
-            class profileGetGoodSpawnPosition {
-                description = "profileGetGoodSpawnPosition";
-								file = PATHTO_FUNC(profileGetGoodSpawnPosition);
-                recompile = RECOMPILE;
-            };
-            class profileGetAnyLinkedInRange {
-                description = "profileGetAnyLinkedInRange";
-								file = PATHTO_FUNC(profileGetAnyLinkedInRange);
-                recompile = RECOMPILE;
-            };
-            class profileSimulator {
-                description = "profileSimulator";
-								file = PATHTO_FUNC(profileSimulator);
-                recompile = RECOMPILE;
-            };
-            class profileSpawner {
-                description = "profileSpawner";
-								file = PATHTO_FUNC(profileSpawner);
-                recompile = RECOMPILE;
-            };
-            class profileDespawner {
-                description = "profileDespawner";
-								file = PATHTO_FUNC(profileDespawner);
-                recompile = RECOMPILE;
-            };
-            class getNearProfiles {
-                description = "getNearProfiles";
-								file = PATHTO_FUNC(getNearProfiles);
-                recompile = RECOMPILE;
-            };
-            class vehicleAssignmentsGetLinkedProfiles {
-                description = "vehicleAssignmentsGetLinkedProfiles";
-								file = PATHTO_FUNC(vehicleAssignmentsGetLinkedProfiles);
-                recompile = RECOMPILE;
-            };
-            class vehicleAssignmentsToProfileVehicleAssignments {
-                description = "vehicleAssignmentsToProfileVehicleAssignments";
-								file = PATHTO_FUNC(vehicleAssignmentsToProfileVehicleAssignments);
-                recompile = RECOMPILE;
-            };
-            class vehicleAssignmentToProfileVehicleAssignment {
-                description = "vehicleAssignmentToProfileVehicleAssignment";
-								file = PATHTO_FUNC(vehicleAssignmentToProfileVehicleAssignment);
-                recompile = RECOMPILE;
-            };
-            class getInActiveEntitiesForMarking {
-                description = "getInActiveEntitiesForMarking";
-								file = PATHTO_FUNC(getInActiveEntitiesForMarking);
-                recompile = RECOMPILE;
-            };
-            class profile_onPlayerConnected {
-                description = "profile_onPlayerConnected";
-								file = PATHTO_FUNC(profile_onPlayerConnected);
-                recompile = RECOMPILE;
-            };
-            class profile_onPlayerDisconnected {
-                description = "profile_onPlayerDisconnected";
-								file = PATHTO_FUNC(profile_onPlayerDisconnected);
-                recompile = RECOMPILE;
-            };
-            class profilesSaveData {
-                description = "profilesSaveData";
-								file = PATHTO_FUNC(profilesSaveData);
-                recompile = RECOMPILE;
-            };
-            class profilesLoadData {
-                description = "profilesLoadData";
-								file = PATHTO_FUNC(profilesLoadData);
-                recompile = RECOMPILE;
-            };
-            class profileAttack {
-                description = "profileAttack";
-								file = PATHTO_FUNC(profileAttack);
-                recompile = RECOMPILE;
-            };
-            class profileBattle {
-                description = "profileBattle";
-								file = PATHTO_FUNC(profileBattle);
-                recompile = RECOMPILE;
-            };
-            class profileCombatHandler {
-                description = "profileCombatHandler";
-								file = PATHTO_FUNC(profileCombatHandler);
-                recompile = RECOMPILE;
-            };
-            class profileGetDamageOutput {
-                description = "profileGetDamageOutput";
-								file = PATHTO_FUNC(profileGetDamageOutput);
-                recompile = RECOMPILE;
-            };
-        };
-    };
+						FUNC_FILEPATH(profileSystemInit,"profileSystemInit");
+						FUNC_FILEPATH(profileSystem,"profileSystem");
+						FUNC_FILEPATH(profileHandler,"profileHandler");
+						FUNC_FILEPATH(profile,"profile");
+						FUNC_FILEPATH(profileEntity,"profileEntity");
+						FUNC_FILEPATH(profileMenuDef,"profileMenuDef");
+						FUNC_FILEPATH(profileVehicle,"profileVehicle");
+						FUNC_FILEPATH(createProfilesFromGroupConfig,"createProfilesFromGroupConfig");
+						FUNC_FILEPATH(createProfilesCrewedVehicle,"createProfilesCrewedVehicle");
+						FUNC_FILEPATH(createProfileVehicle,"createProfileVehicle");
+						FUNC_FILEPATH(createProfileEntity,"createProfileEntity");
+						FUNC_FILEPATH(createProfilesFromUnits,"createProfilesFromUnits");
+						FUNC_FILEPATH(createProfilesFromUnitsRuntime,"createProfilesFromUnitsRuntime");
+						FUNC_FILEPATH(createProfilesFromPlayers,"createProfilesFromPlayers");
+						FUNC_FILEPATH(profileKilledEventHandler,"profileKilledEventHandler");
+						FUNC_FILEPATH(profileGetInEventHandler,"profileGetInEventHandler");
+						FUNC_FILEPATH(createProfileWaypoint,"createProfileWaypoint");
+						FUNC_FILEPATH(profileWaypointsToWaypoints,"profileWaypointsToWaypoints");
+						FUNC_FILEPATH(profileWaypointToWaypoint,"profileWaypointToWaypoint");
+						FUNC_FILEPATH(waypointsToProfileWaypoints,"waypointsToProfileWaypoints");
+						FUNC_FILEPATH(waypointToProfileWaypoint,"waypointToProfileWaypoint");
+						FUNC_FILEPATH(createProfileVehicleAssignment,"createProfileVehicleAssignment");
+						FUNC_FILEPATH(removeProfileVehicleAssignments,"removeProfileVehicleAssignments");
+						FUNC_FILEPATH(removeProfileVehicleAssignment,"removeProfileVehicleAssignment");
+						FUNC_FILEPATH(profileVehicleAssignmentGetUsedIndexes,"profileVehicleAssignmentGetUsedIndexes");
+						FUNC_FILEPATH(profileVehicleAssignmentGetEmptyPositions,"profileVehicleAssignmentGetEmptyPositions");
+						FUNC_FILEPATH(profileVehicleAssignmentsToVehicleAssignments,"profileVehicleAssignmentsToVehicleAssignments");
+						FUNC_FILEPATH(profileVehicleAssignmentToVehicleAssignment,"profileVehicleAssignmentToVehicleAssignment");
+						FUNC_FILEPATH(profileVehicleAssignmentIndexesToUnits,"profileVehicleAssignmentIndexesToUnits");
+						FUNC_FILEPATH(profileVehicleAssignmentsGetInCommand,"profileVehicleAssignmentsGetInCommand");
+						FUNC_FILEPATH(profileVehicleAssignmentsGetInCargo,"profileVehicleAssignmentsGetInCargo");
+						FUNC_FILEPATH(profileVehicleAssignmentsSetAllPositions,"profileVehicleAssignmentsSetAllPositions");
+						FUNC_FILEPATH(profileVehicleAssignmentsGetSpeedPerSecond,"profileVehicleAssignmentsGetSpeedPerSecond");
+						FUNC_FILEPATH(profileVehicleAssignmentsGetCount,"profileVehicleAssignmentsGetCount");
+						FUNC_FILEPATH(profileGetGoodSpawnPosition,"profileGetGoodSpawnPosition");
+						FUNC_FILEPATH(profileGetAnyLinkedInRange,"profileGetAnyLinkedInRange");
+						FUNC_FILEPATH(profileSimulator,"profileSimulator");
+						FUNC_FILEPATH(profileSpawner,"profileSpawner");
+						FUNC_FILEPATH(profileDespawner,"profileDespawner");
+						FUNC_FILEPATH(getNearProfiles,"getNearProfiles");
+						FUNC_FILEPATH(vehicleAssignmentsGetLinkedProfiles,"vehicleAssignmentsGetLinkedProfiles");
+						FUNC_FILEPATH(vehicleAssignmentsToProfileVehicleAssignments,"vehicleAssignmentsToProfileVehicleAssignments");
+						FUNC_FILEPATH(vehicleAssignmentToProfileVehicleAssignment,"vehicleAssignmentToProfileVehicleAssignment");
+						FUNC_FILEPATH(getInActiveEntitiesForMarking,"getInActiveEntitiesForMarking");
+						FUNC_FILEPATH(profile_onPlayerConnected,"profile_onPlayerConnected");
+						FUNC_FILEPATH(profile_onPlayerDisconnected,"profile_onPlayerDisconnected");
+						FUNC_FILEPATH(profilesSaveData,"profilesSaveData");
+						FUNC_FILEPATH(profilesLoadData,"profilesLoadData");
+						FUNC_FILEPATH(profileAttack,"profileAttack");
+						FUNC_FILEPATH(profileBattle,"profileBattle");
+						FUNC_FILEPATH(profileCombatHandler,"profileCombatHandler");
+						FUNC_FILEPATH(profileGetDamageOutput,"profileGetDamageOutput");
+				};
+		};
 };

--- a/addons/sys_quickstart/CfgFunctions.hpp
+++ b/addons/sys_quickstart/CfgFunctions.hpp
@@ -3,12 +3,12 @@ class cfgFunctions {
                 class COMPONENT {
                         class quickstart {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_quickstart\fnc_quickstart.sqf";
+																file = PATHTO_FUNC(quickstart);
                                 recompile = RECOMPILE;
                         };
                         class quickstartInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_quickstart\fnc_quickstartInit.sqf";
+																file = PATHTO_FUNC(quickstartInit);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/sys_quickstart/CfgFunctions.hpp
+++ b/addons/sys_quickstart/CfgFunctions.hpp
@@ -1,16 +1,8 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class quickstart {
-                                description = "The main class";
-																file = PATHTO_FUNC(quickstart);
-                                recompile = RECOMPILE;
-                        };
-                        class quickstartInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(quickstartInit);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(quickstart,"The main class");
+												FUNC_FILEPATH(quickstartInit,"The module initialisation function");
+								};
+				};
 };

--- a/addons/sys_sitrep/CfgFunctions.hpp
+++ b/addons/sys_sitrep/CfgFunctions.hpp
@@ -1,61 +1,17 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class sitrep {
-                                description = "The main class";
-																file = PATHTO_FUNC(sitrep);
-                                recompile = RECOMPILE;
-                        };
-                        class sitrepInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(sitrepInit);
-                                recompile = RECOMPILE;
-                        };
-                        class sitrepParams {
-                                description = "sitrep parameters";
-																file = PATHTO_FUNC(sitrepParams);
-                                recompile = RECOMPILE;
-                        };
-                        class sitrepSaveData {
-                                description = "sitrep save data to DB";
-																file = PATHTO_FUNC(sitrepSaveData);
-                                                                recompile = RECOMPILE;
-                        };
-                        class sitrepLoadData {
-                                description = "sitrep load data to DB";
-																file = PATHTO_FUNC(sitrepLoadData);
-                                                                recompile = RECOMPILE;
-                        };
-                        class sitrepDeleteData {
-                                description = "sitrep delete data from DB";
-																file = PATHTO_FUNC(sitrepDeleteData);
-                                                                recompile = RECOMPILE;
-                        };
-                        class sitrepOnPlayerConnected {
-                                description = "Handles on player connected event";
-																file = PATHTO_FUNC(sitrepOnPlayerConnected);
-                                                                recompile = RECOMPILE;
-                        };
-                        class sitrepCreateDiaryRecord {
-                                description = "Adds a sitrep to a diary record";
-																file = PATHTO_FUNC(sitrepCreateDiaryRecord);
-                                                                recompile = RECOMPILE;
-                        };
-                        class sitrepOnLoad {
-                                description = "sitrep on load for dialog";
-																file = PATHTO_FUNC(sitrepOnLoad);
-                                                                recompile = RECOMPILE;
-                        };
-                        class sitrepButtonAction {
-                                description = "sitrep button action for dialog";
-																file = PATHTO_FUNC(sitrepButtonAction);
-                                                                recompile = RECOMPILE;
-                        };
-                        class sitrepOnMapEvent {
-                                description = "sitrep on map event for dialog";
-																file = PATHTO_FUNC(sitrepOnMapEvent);
-                                                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(sitrep,"The main class");
+												FUNC_FILEPATH(sitrepInit,"The module initialisation function");
+												FUNC_FILEPATH(sitrepParams,"sitrep parameters");
+												FUNC_FILEPATH(sitrepSaveData,"sitrep save data to DB");
+												FUNC_FILEPATH(sitrepLoadData,"sitrep load data to DB");
+												FUNC_FILEPATH(sitrepDeleteData,"sitrep delete data from DB");
+												FUNC_FILEPATH(sitrepOnPlayerConnected,"Handles on player connected event");
+												FUNC_FILEPATH(sitrepCreateDiaryRecord,"Adds a sitrep to a diary record");
+												FUNC_FILEPATH(sitrepOnLoad,"sitrep on load for dialog");
+												FUNC_FILEPATH(sitrepButtonAction,"sitrep button action for dialog");
+												FUNC_FILEPATH(sitrepOnMapEvent,"sitrep on map event for dialog");
+								};
+				};
 };

--- a/addons/sys_sitrep/CfgFunctions.hpp
+++ b/addons/sys_sitrep/CfgFunctions.hpp
@@ -3,57 +3,57 @@ class cfgFunctions {
                 class COMPONENT {
                         class sitrep {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_sitrep\fnc_sitrep.sqf";
+																file = PATHTO_FUNC(sitrep);
                                 recompile = RECOMPILE;
                         };
                         class sitrepInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_sitrep\fnc_sitrepInit.sqf";
+																file = PATHTO_FUNC(sitrepInit);
                                 recompile = RECOMPILE;
                         };
                         class sitrepParams {
                                 description = "sitrep parameters";
-                                file = "\x\alive\addons\sys_sitrep\fnc_sitrepParams.sqf";
+																file = PATHTO_FUNC(sitrepParams);
                                 recompile = RECOMPILE;
                         };
                         class sitrepSaveData {
                                 description = "sitrep save data to DB";
-                                file = "\x\alive\addons\sys_sitrep\fnc_sitrepSaveData.sqf";
+																file = PATHTO_FUNC(sitrepSaveData);
                                                                 recompile = RECOMPILE;
                         };
                         class sitrepLoadData {
                                 description = "sitrep load data to DB";
-                                file = "\x\alive\addons\sys_sitrep\fnc_sitrepLoadData.sqf";
+																file = PATHTO_FUNC(sitrepLoadData);
                                                                 recompile = RECOMPILE;
                         };
                         class sitrepDeleteData {
                                 description = "sitrep delete data from DB";
-                                file = "\x\alive\addons\sys_sitrep\fnc_sitrepDeleteData.sqf";
+																file = PATHTO_FUNC(sitrepDeleteData);
                                                                 recompile = RECOMPILE;
                         };
                         class sitrepOnPlayerConnected {
                                 description = "Handles on player connected event";
-                                file = "\x\alive\addons\sys_sitrep\fnc_sitrepOnPlayerConnected.sqf";
+																file = PATHTO_FUNC(sitrepOnPlayerConnected);
                                                                 recompile = RECOMPILE;
                         };
                         class sitrepCreateDiaryRecord {
                                 description = "Adds a sitrep to a diary record";
-                                file = "\x\alive\addons\sys_sitrep\fnc_sitrepCreateDiaryRecord.sqf";
+																file = PATHTO_FUNC(sitrepCreateDiaryRecord);
                                                                 recompile = RECOMPILE;
                         };
                         class sitrepOnLoad {
                                 description = "sitrep on load for dialog";
-                                file = "\x\alive\addons\sys_sitrep\fnc_sitrepOnLoad.sqf";
+																file = PATHTO_FUNC(sitrepOnLoad);
                                                                 recompile = RECOMPILE;
                         };
                         class sitrepButtonAction {
                                 description = "sitrep button action for dialog";
-                                file = "\x\alive\addons\sys_sitrep\fnc_sitrepButtonAction.sqf";
+																file = PATHTO_FUNC(sitrepButtonAction);
                                                                 recompile = RECOMPILE;
                         };
                         class sitrepOnMapEvent {
                                 description = "sitrep on map event for dialog";
-                                file = "\x\alive\addons\sys_sitrep\fnc_sitrepOnMapEvent.sqf";
+																file = PATHTO_FUNC(sitrepOnMapEvent);
                                                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/sys_spotrep/CfgFunctions.hpp
+++ b/addons/sys_spotrep/CfgFunctions.hpp
@@ -1,46 +1,14 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class spotrep {
-                                description = "The main class";
-																file = PATHTO_FUNC(spotrep);
-                                recompile = RECOMPILE;
-                        };
-                        class spotrepInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(spotrepInit);
-                                recompile = RECOMPILE;
-                        };
-                        class spotrepParams {
-                                description = "spotrep parameters";
-																file = PATHTO_FUNC(spotrepParams);
-                                recompile = RECOMPILE;
-                        };
-                        class spotrepSaveData {
-                                description = "spotrep save data to DB";
-																file = PATHTO_FUNC(spotrepSaveData);
-                                recompile = RECOMPILE;
-                        };
-                        class spotrepLoadData {
-                                description = "spotrep load data to DB";
-																file = PATHTO_FUNC(spotrepLoadData);
-                                recompile = RECOMPILE;
-                        };
-                        class spotrepDeleteData {
-                                description = "spotrep delete data from DB";
-																file = PATHTO_FUNC(spotrepDeleteData);
-                                recompile = RECOMPILE;
-                        };
-                        class spotrepOnPlayerConnected {
-                                description = "Handles on player connected event";
-																file = PATHTO_FUNC(spotrepOnPlayerConnected);
-                                recompile = RECOMPILE;
-                        };
-                        class spotrepCreateDiaryRecord {
-                                description = "Adds a spotrep to a diary record";
-																file = PATHTO_FUNC(spotrepCreateDiaryRecord);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(spotrep,"The main class");
+												FUNC_FILEPATH(spotrepInit,"The module initialisation function");
+												FUNC_FILEPATH(spotrepParams,"spotrep parameters");
+												FUNC_FILEPATH(spotrepSaveData,"spotrep save data to DB");
+												FUNC_FILEPATH(spotrepLoadData,"spotrep load data to DB");
+												FUNC_FILEPATH(spotrepDeleteData,"spotrep delete data from DB");
+												FUNC_FILEPATH(spotrepOnPlayerConnected,"Handles on player connected event");
+												FUNC_FILEPATH(spotrepCreateDiaryRecord,"Adds a spotrep to a diary record");
+								};
+				};
 };

--- a/addons/sys_spotrep/CfgFunctions.hpp
+++ b/addons/sys_spotrep/CfgFunctions.hpp
@@ -3,43 +3,43 @@ class cfgFunctions {
                 class COMPONENT {
                         class spotrep {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_spotrep\fnc_spotrep.sqf";
+																file = PATHTO_FUNC(spotrep);
                                 recompile = RECOMPILE;
                         };
                         class spotrepInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_spotrep\fnc_spotrepInit.sqf";
+																file = PATHTO_FUNC(spotrepInit);
                                 recompile = RECOMPILE;
                         };
                         class spotrepParams {
                                 description = "spotrep parameters";
-                                file = "\x\alive\addons\sys_spotrep\fnc_spotrepParams.sqf";
+																file = PATHTO_FUNC(spotrepParams);
                                 recompile = RECOMPILE;
                         };
                         class spotrepSaveData {
                                 description = "spotrep save data to DB";
-                                file = "\x\alive\addons\sys_spotrep\fnc_spotrepSaveData.sqf";
-                                                                recompile = RECOMPILE;
+																file = PATHTO_FUNC(spotrepSaveData);
+                                recompile = RECOMPILE;
                         };
                         class spotrepLoadData {
                                 description = "spotrep load data to DB";
-                                file = "\x\alive\addons\sys_spotrep\fnc_spotrepLoadData.sqf";
-                                                                recompile = RECOMPILE;
+																file = PATHTO_FUNC(spotrepLoadData);
+                                recompile = RECOMPILE;
                         };
                         class spotrepDeleteData {
                                 description = "spotrep delete data from DB";
-                                file = "\x\alive\addons\sys_spotrep\fnc_spotrepDeleteData.sqf";
-                                                                recompile = RECOMPILE;
+																file = PATHTO_FUNC(spotrepDeleteData);
+                                recompile = RECOMPILE;
                         };
                         class spotrepOnPlayerConnected {
                                 description = "Handles on player connected event";
-                                file = "\x\alive\addons\sys_spotrep\fnc_spotrepOnPlayerConnected.sqf";
-                                                                recompile = RECOMPILE;
+																file = PATHTO_FUNC(spotrepOnPlayerConnected);
+                                recompile = RECOMPILE;
                         };
                         class spotrepCreateDiaryRecord {
                                 description = "Adds a spotrep to a diary record";
-                                file = "\x\alive\addons\sys_spotrep\fnc_spotrepCreateDiaryRecord.sqf";
-                                                                recompile = RECOMPILE;
+																file = PATHTO_FUNC(spotrepCreateDiaryRecord);
+                                recompile = RECOMPILE;
                         };
                 };
         };

--- a/addons/sys_statistics/CfgFunctions.hpp
+++ b/addons/sys_statistics/CfgFunctions.hpp
@@ -1,61 +1,17 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class statisticsMenuDef {
-                                description = "The module menu definition";
-																file = PATHTO_FUNC(statisticsMenuDef);
-                                recompile = RECOMPILE;
-                        };
-                        class statisticsDisable {
-                                description = "The module disable function";
-																file = PATHTO_FUNC(statisticsDisable);
-                                recompile = RECOMPILE;
-                        };
-                        class statisticsModuleFunction {
-                                description = "The module function definition";
-																file = PATHTO_FUNC(statisticsModuleFunction);
-                                recompile = RECOMPILE;
-                        };
-                        class stats_OnPlayerDisconnected {
-                                description = "The module onPlayerDisconnected handler";
-																file = PATHTO_FUNC(stats_onPlayerDisconnected);
-                                recompile = RECOMPILE;
-                        };
-                        class stats_OnPlayerConnected {
-                                description = "The module onPlayerConnected handler";
-																file = PATHTO_FUNC(stats_onPlayerConnected);
-                                recompile = RECOMPILE;
-                        };
-                        class stats_createPlayerProfile {
-                                description = "The module onPlayerConnected handler";
-																file = PATHTO_FUNC(stats_createPlayerProfile);
-                                recompile = RECOMPILE;
-                        };
-                        class statisticsInit {
-                                description = "The module init function";
-																file = PATHTO_FUNC(statisticsInit);
-                                recompile = RECOMPILE;
-                        };
-                        class getPlayerGroup {
-                                description = "Get's the player group associated with a unit";
-																file = PATHTO_FUNC(getPlayerGroup);
-                                recompile = RECOMPILE;
-                        };
-                        class updateShotsFired {
-                                description = "Update shots fired on server";
-																file = PATHTO_FUNC(updateShotsFired);
-                                recompile = RECOMPILE;
-                        };
-                        class addHandleHeal {
-                                description = "Adds a handleHeal EH to a player object on the local machine";
-																file = PATHTO_FUNC(addHandleHeal);
-                                recompile = RECOMPILE;
-                        };
-                        class checkIsDiving {
-                                description = "Monitors whether or not the unit is on a combat dive";
-																file = PATHTO_FUNC(checkIsDiving);
-                                recompile = RECOMPILE;
-                        };
-                };
-        };
+												FUNC_FILEPATH(statisticsMenuDef,"The module menu definition");
+												FUNC_FILEPATH(statisticsDisable,"The module disable function");
+												FUNC_FILEPATH(statisticsModuleFunction,"The module function definition");
+												FUNC_FILEPATH(stats_OnPlayerDisconnected,"The module onPlayerDisconnected handler");
+												FUNC_FILEPATH(stats_OnPlayerConnected,"The module onPlayerConnected handler");
+												FUNC_FILEPATH(stats_createPlayerProfile,"The module onPlayerConnected handler");
+												FUNC_FILEPATH(statisticsInit,"The module init function");
+												FUNC_FILEPATH(getPlayerGroup,"Get's the player group associated with a unit");
+												FUNC_FILEPATH(updateShotsFired,"Update shots fired on server");
+												FUNC_FILEPATH(addHandleHeal,"Adds a handleHeal EH to a player object on the local machine");
+												FUNC_FILEPATH(checkIsDiving,"Monitors whether or not the unit is on a combat dive");
+								};
+				};
 };

--- a/addons/sys_statistics/CfgFunctions.hpp
+++ b/addons/sys_statistics/CfgFunctions.hpp
@@ -3,57 +3,57 @@ class cfgFunctions {
                 class COMPONENT {
                         class statisticsMenuDef {
                                 description = "The module menu definition";
-                                file = "\x\alive\addons\sys_statistics\fnc_statisticsMenuDef.sqf";
+																file = PATHTO_FUNC(statisticsMenuDef);
                                 recompile = RECOMPILE;
                         };
                         class statisticsDisable {
                                 description = "The module disable function";
-                                file = "\x\alive\addons\sys_statistics\fnc_statisticsDisable.sqf";
+																file = PATHTO_FUNC(statisticsDisable);
                                 recompile = RECOMPILE;
                         };
                         class statisticsModuleFunction {
                                 description = "The module function definition";
-                                file = "\x\alive\addons\sys_statistics\fnc_statisticsModuleFunction.sqf";
+																file = PATHTO_FUNC(statisticsModuleFunction);
                                 recompile = RECOMPILE;
                         };
                         class stats_OnPlayerDisconnected {
                                 description = "The module onPlayerDisconnected handler";
-                                file = "\x\alive\addons\sys_statistics\fnc_stats_onPlayerDisconnected.sqf";
+																file = PATHTO_FUNC(stats_onPlayerDisconnected);
                                 recompile = RECOMPILE;
                         };
                         class stats_OnPlayerConnected {
                                 description = "The module onPlayerConnected handler";
-                                file = "\x\alive\addons\sys_statistics\fnc_stats_onPlayerConnected.sqf";
+																file = PATHTO_FUNC(stats_onPlayerConnected);
                                 recompile = RECOMPILE;
                         };
                         class stats_createPlayerProfile {
                                 description = "The module onPlayerConnected handler";
-                                file = "\x\alive\addons\sys_statistics\fnc_stats_createPlayerProfile.sqf";
+																file = PATHTO_FUNC(stats_createPlayerProfile);
                                 recompile = RECOMPILE;
                         };
                         class statisticsInit {
                                 description = "The module init function";
-                                file = "\x\alive\addons\sys_statistics\fnc_statisticsInit.sqf";
+																file = PATHTO_FUNC(statisticsInit);
                                 recompile = RECOMPILE;
                         };
                         class getPlayerGroup {
                                 description = "Get's the player group associated with a unit";
-                                file = "\x\alive\addons\sys_statistics\fnc_getPlayerGroup.sqf";
+																file = PATHTO_FUNC(getPlayerGroup);
                                 recompile = RECOMPILE;
                         };
                         class updateShotsFired {
                                 description = "Update shots fired on server";
-                                file = "\x\alive\addons\sys_statistics\fnc_updateShotsFired.sqf";
+																file = PATHTO_FUNC(updateShotsFired);
                                 recompile = RECOMPILE;
                         };
                         class addHandleHeal {
                                 description = "Adds a handleHeal EH to a player object on the local machine";
-                                file = "\x\alive\addons\sys_statistics\fnc_addHandleHeal.sqf";
+																file = PATHTO_FUNC(addHandleHeal);
                                 recompile = RECOMPILE;
                         };
                         class checkIsDiving {
                                 description = "Monitors whether or not the unit is on a combat dive";
-                                file = "\x\alive\addons\sys_statistics\fnc_checkIsDiving.sqf";
+																file = PATHTO_FUNC(checkIsDiving);
                                 recompile = RECOMPILE;
                         };
                 };

--- a/addons/sys_tour/CfgFunctions.hpp
+++ b/addons/sys_tour/CfgFunctions.hpp
@@ -3,12 +3,12 @@ class CfgFunctions {
         class COMPONENT {
             class tour {
                 description = "The main class";
-                file = "\x\alive\addons\sys_tour\fnc_tour.sqf";
+								file = PATHTO_FUNC(tour);
                 recompile = RECOMPILE;
             };
             class tourInit {
                 description = "The module initialisation function";
-                file = "\x\alive\addons\sys_tour\fnc_tourInit.sqf";
+								file = PATHTO_FUNC(tourInit);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/sys_tour/CfgFunctions.hpp
+++ b/addons/sys_tour/CfgFunctions.hpp
@@ -1,16 +1,8 @@
 class CfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class tour {
-                description = "The main class";
-								file = PATHTO_FUNC(tour);
-                recompile = RECOMPILE;
-            };
-            class tourInit {
-                description = "The module initialisation function";
-								file = PATHTO_FUNC(tourInit);
-                recompile = RECOMPILE;
-            };
-        };
-    };
+						FUNC_FILEPATH(tour,"The main class");
+						FUNC_FILEPATH(tourInit,"The module initialisation function");
+				};
+		};
 };

--- a/addons/sys_viewdistance/CfgFunctions.hpp
+++ b/addons/sys_viewdistance/CfgFunctions.hpp
@@ -1,26 +1,14 @@
 class cfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class vDist {
-                description = "The main class";
-								file = PATHTO_FUNC(vDist);
-                recompile = RECOMPILE;
-            };
-            class vDistInit {
-                description = "The module initialisation function";
-								file = PATHTO_FUNC(vDistInit);
-                recompile = RECOMPILE;
-            };
-            class vDistMenuDef {
-                description = "The module menu definition";
-								file = PATHTO_FUNC(vDistMenuDef);
-                recompile = RECOMPILE;
-            };
+						FUNC_FILEPATH(vDist,"The main class");
+						FUNC_FILEPATH(vDistInit,"The module initialisation function");
+						FUNC_FILEPATH(vDistMenuDef,"The module menu definition");
             class vDistGuiInit {
                 description = "The Gui";
-								file = PATHTO_FUNC(vdist_init);
+                file = PATHTO_FUNC(vdist_init);
                 recompile = RECOMPILE;
             };
-        };
-    };
+				};
+		};
 };

--- a/addons/sys_viewdistance/CfgFunctions.hpp
+++ b/addons/sys_viewdistance/CfgFunctions.hpp
@@ -3,22 +3,22 @@ class cfgFunctions {
         class COMPONENT {
             class vDist {
                 description = "The main class";
-                file = "\x\alive\addons\sys_viewdistance\fnc_vDist.sqf";
+								file = PATHTO_FUNC(vDist);
                 recompile = RECOMPILE;
             };
             class vDistInit {
                 description = "The module initialisation function";
-                file = "\x\alive\addons\sys_viewdistance\fnc_vDistInit.sqf";
+								file = PATHTO_FUNC(vDistInit);
                 recompile = RECOMPILE;
             };
             class vDistMenuDef {
                 description = "The module menu definition";
-                file = "\x\alive\addons\sys_viewdistance\fnc_vDistMenuDef.sqf";
+								file = PATHTO_FUNC(vDistMenuDef);
                 recompile = RECOMPILE;
             };
             class vDistGuiInit {
                 description = "The Gui";
-                file = "\x\alive\addons\sys_viewdistance\fnc_vdist_init.sqf";
+								file = PATHTO_FUNC(vdist_init);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/sys_weather/CfgFunctions.hpp
+++ b/addons/sys_weather/CfgFunctions.hpp
@@ -1,40 +1,40 @@
-﻿class cfgFunctions {
+class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
                         class weatherInit {
                                 description = "The module initialisation function";
-                                file = "\x\alive\addons\sys_weather\fnc_weatherInit.sqf";
+																file = PATHTO_FUNC(weatherInit);
                                                                 recompile = RECOMPILE;
                         };
                         class weather {
                                 description = "The main class";
-                                file = "\x\alive\addons\sys_weather\fnc_weather.sqf";
+																file = PATHTO_FUNC(weather);
                                                                 recompile = RECOMPILE;
                         };
                         class weatherServerInit {
                                 description = "The weather server initialisation function";
-                                file = "\x\alive\addons\sys_weather\fnc_weatherServerInit.sqf";
+																file = PATHTO_FUNC(weatherServerInit);
                                                                 recompile = RECOMPILE;
                         };
                         class weatherServer {
                                 description = "The weather server function";
-                                file = "\x\alive\addons\sys_weather\fnc_weatherServer.sqf";
+																file = PATHTO_FUNC(weatherServer);
                                                                 recompile = RECOMPILE;
                         };
                         class weatherCycleServer {
                                 description = "The weather cycle function";
-                                file = "\x\alive\addons\sys_weather\fnc_weatherCycleServer.sqf";
+																file = PATHTO_FUNC(weatherCycleServer);
                                                                 recompile = RECOMPILE;
                         };
                         class weatherDebugEvent {
                                 description = "The weather debug cycle function";
-                                file = "\x\alive\addons\sys_weather\fnc_weatherDebugEvent.sqf";
+																file = PATHTO_FUNC(weatherDebugEvent);
                                                                 recompile = RECOMPILE;
                         };
 
                         class getWeather {
                                 description = "Gets real weather for a time and location function";
-                                file = "\x\alive\addons\sys_weather\fnc_getWeather.sqf";
+																file = PATHTO_FUNC(getWeather);
                                                                 recompile = RECOMPILE;
                         };
 

--- a/addons/sys_weather/CfgFunctions.hpp
+++ b/addons/sys_weather/CfgFunctions.hpp
@@ -1,43 +1,13 @@
 class cfgFunctions {
         class PREFIX {
                 class COMPONENT {
-                        class weatherInit {
-                                description = "The module initialisation function";
-																file = PATHTO_FUNC(weatherInit);
-                                                                recompile = RECOMPILE;
-                        };
-                        class weather {
-                                description = "The main class";
-																file = PATHTO_FUNC(weather);
-                                                                recompile = RECOMPILE;
-                        };
-                        class weatherServerInit {
-                                description = "The weather server initialisation function";
-																file = PATHTO_FUNC(weatherServerInit);
-                                                                recompile = RECOMPILE;
-                        };
-                        class weatherServer {
-                                description = "The weather server function";
-																file = PATHTO_FUNC(weatherServer);
-                                                                recompile = RECOMPILE;
-                        };
-                        class weatherCycleServer {
-                                description = "The weather cycle function";
-																file = PATHTO_FUNC(weatherCycleServer);
-                                                                recompile = RECOMPILE;
-                        };
-                        class weatherDebugEvent {
-                                description = "The weather debug cycle function";
-																file = PATHTO_FUNC(weatherDebugEvent);
-                                                                recompile = RECOMPILE;
-                        };
-
-                        class getWeather {
-                                description = "Gets real weather for a time and location function";
-																file = PATHTO_FUNC(getWeather);
-                                                                recompile = RECOMPILE;
-                        };
-
-                };
-        };
+												FUNC_FILEPATH(weatherInit,"The module initialisation function");
+												FUNC_FILEPATH(weather,"The main class");
+												FUNC_FILEPATH(weatherServerInit,"The weather server initialisation function");
+												FUNC_FILEPATH(weatherServer,"The weather server function");
+												FUNC_FILEPATH(weatherCycleServer,"The weather cycle function");
+												FUNC_FILEPATH(weatherDebugEvent,"The weather debug cycle function");
+												FUNC_FILEPATH(getWeather,"Gets real weather for a time and location function");
+								};
+				};
 };

--- a/addons/sys_xstream/CfgFunctions.hpp
+++ b/addons/sys_xstream/CfgFunctions.hpp
@@ -1,26 +1,10 @@
 class CfgFunctions {
     class PREFIX {
         class COMPONENT {
-            class xStream {
-                description = "The main class";
-								file = PATHTO_FUNC(xstream);
-                recompile = RECOMPILE;
-            };
-            class xStreamInit {
-                description = "The module initialisation function";
-								file = PATHTO_FUNC(xStreamInit);
-                recompile = RECOMPILE;
-            };
-            class xStreamMenuDef {
-                description = "The module menu definition";
-								file = PATHTO_FUNC(xStreamMenuDef);
-                recompile = RECOMPILE;
-            };
-            class camera {
-                description = "The module camera function";
-								file = PATHTO_FUNC(camera);
-                recompile = RECOMPILE;
-            };
-        };
-    };
+						FUNC_FILEPATH(xStream,"The main class");
+						FUNC_FILEPATH(xStreamInit,"The module initialisation function");
+						FUNC_FILEPATH(xStreamMenuDef,"The module menu definition");
+						FUNC_FILEPATH(camera,"The module camera function");
+				};
+		};
 };

--- a/addons/sys_xstream/CfgFunctions.hpp
+++ b/addons/sys_xstream/CfgFunctions.hpp
@@ -3,22 +3,22 @@ class CfgFunctions {
         class COMPONENT {
             class xStream {
                 description = "The main class";
-                file = "\x\alive\addons\sys_xstream\fnc_xstream.sqf";
+								file = PATHTO_FUNC(xstream);
                 recompile = RECOMPILE;
             };
             class xStreamInit {
                 description = "The module initialisation function";
-                file = "\x\alive\addons\sys_xstream\fnc_xStreamInit.sqf";
+								file = PATHTO_FUNC(xStreamInit);
                 recompile = RECOMPILE;
             };
             class xStreamMenuDef {
                 description = "The module menu definition";
-                file = "\x\alive\addons\sys_xstream\fnc_xStreamMenuDef.sqf";
+								file = PATHTO_FUNC(xStreamMenuDef);
                 recompile = RECOMPILE;
             };
             class camera {
                 description = "The module camera function";
-                file = "\x\alive\addons\sys_xstream\fnc_camera.sqf";
+								file = PATHTO_FUNC(camera);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/ui/CfgFunctions.hpp
+++ b/addons/ui/CfgFunctions.hpp
@@ -3,34 +3,34 @@ class CfgFunctions {
         class UI {
             class flexiMenu_Add {
                 description = "Add a type-based menu source. Result: TBA (WIP)";
-                file = "\x\alive\addons\ui\flexiMenu\fnc_add.sqf";
+								file = "\x\alive\addons\ui\fleximenu\fnc_add.sqf";
             };
             class flexiMenu_Remove {
                 description = "Remove a type-based menu source. Result: TBA (WIP)";
-                file = "\x\alive\addons\ui\flexiMenu\fnc_remove.sqf";
+								file = "\x\alive\addons\ui\fleximenu\fnc_remove.sqf";
             };
             class flexiMenu_setObjectMenuSource {
                 description = "Set an object's menu source (variable). Result: TBA (WIP)";
-                file = "\x\alive\addons\ui\flexiMenu\fnc_setObjectMenuSource.sqf";
+								file = "\x\alive\addons\ui\fleximenu\fnc_setObjectMenuSource.sqf";
             };
             class displayMenu {
                 description = "Display various UI menus";
-                file = "\x\alive\addons\ui\menu\fnc_displayMenu.sqf";
+								file = "\x\alive\addons\ui\menu\fnc_displayMenu.sqf";
                 recompile = RECOMPILE;
             };
             class RscDisplayLoadingALiVE {
                 description = "Hook loading screen";
-                file = "\x\alive\addons\ui\fnc_RscDisplayLoadingALiVE.sqf";
+								file = PATHTO_FUNC(RscDisplayLoadingALiVE);
                 recompile = RECOMPILE;
             };
             class RscDisplayMPInterruptALiVE {
                 description = "Hook MP interrupt screen";
-                file = "\x\alive\addons\ui\fnc_RscDisplayMPInterruptALiVE.sqf";
+								file = PATHTO_FUNC(RscDisplayMPInterruptALiVE);
                 recompile = RECOMPILE;
             };
             class copyFactionClasses {
                 description = "Copy faction classes from selected objects in 3DEN to clipboard";
-                file = "\x\alive\addons\ui\fnc_copyFactionClasses.sqf";
+								file = PATHTO_FUNC(copyFactionClasses);
                 recompile = RECOMPILE;
             };
         };

--- a/addons/ui/CfgFunctions.hpp
+++ b/addons/ui/CfgFunctions.hpp
@@ -18,21 +18,9 @@ class CfgFunctions {
 								file = "\x\alive\addons\ui\menu\fnc_displayMenu.sqf";
                 recompile = RECOMPILE;
             };
-            class RscDisplayLoadingALiVE {
-                description = "Hook loading screen";
-								file = PATHTO_FUNC(RscDisplayLoadingALiVE);
-                recompile = RECOMPILE;
-            };
-            class RscDisplayMPInterruptALiVE {
-                description = "Hook MP interrupt screen";
-								file = PATHTO_FUNC(RscDisplayMPInterruptALiVE);
-                recompile = RECOMPILE;
-            };
-            class copyFactionClasses {
-                description = "Copy faction classes from selected objects in 3DEN to clipboard";
-								file = PATHTO_FUNC(copyFactionClasses);
-                recompile = RECOMPILE;
-            };
+            FUNC_FILEPATH(RscDisplayLoadingALiVE,"Hook loading screen");
+            FUNC_FILEPATH(RscDisplayMPInterruptALiVE,"Hook MP interrupt screen");
+            FUNC_FILEPATH(copyFactionClasses,"Copy faction classes from selected objects in 3DEN to clipboard");
         };
     };
 };

--- a/addons/x_lib/functions/arrays/fnc_arrayBlockHandler.sqf
+++ b/addons/x_lib/functions/arrays/fnc_arrayBlockHandler.sqf
@@ -39,8 +39,6 @@ nil
 #define SUPERCLASS ALIVE_fnc_baseClassHash
 #define MAINCLASS ALIVE_fnc_arrayBlockHandler
 
-private ["_result"];
-
 TRACE_1("arrayBlockHandler - input",_this);
 
 params [
@@ -48,7 +46,7 @@ params [
     ["_operation", "", [""]],
     ["_args", objNull, [objNull,[],"",0,true,false]]
 ];
-_result = true;
+private _result = true;
 
 #define MTEMPLATE "ALiVE_ARRAY_BLOCK_%1"
 
@@ -81,16 +79,11 @@ switch(_operation) do {
                 */
         };
         case "getNextBlock": {
-                private ["_blockKey","_sourceArray","_blockLimit","_pointers","_currentPointer","_profiles","_limit","_block"];
-
-                _blockKey = _args select 0;
-                _sourceArray = _args select 1;
-                _blockLimit = _args select 2;
-
-                _pointers = [_logic,"pointers"] call ALIVE_fnc_hashGet;
+                private ["_currentPointer"];
+                _args params ["_blockkey","_sourceArray","_blockLimit"];
+                private _pointers = [_logic,"pointers"] call ALIVE_fnc_hashGet;
 
                 //_pointers call ALIVE_fnc_inspectHash;
-
                 if(_blockKey in (_pointers select 1)) then {
                     _currentPointer = [_pointers,_blockKey] call ALIVE_fnc_hashGet;
                 }else{
@@ -98,7 +91,7 @@ switch(_operation) do {
                     [_pointers,_blockKey,_currentPointer] call ALIVE_fnc_hashSet;
                 };
 
-                _limit = count _sourceArray;
+                private _limit = count _sourceArray;
 
                 if((_currentPointer + _blockLimit) >= _limit) then {
                     [_pointers,_blockKey,0] call ALIVE_fnc_hashSet;
@@ -106,8 +99,7 @@ switch(_operation) do {
                     _limit = _currentPointer + _blockLimit;
                     [_pointers,_blockKey,_limit] call ALIVE_fnc_hashSet;
                 };
-
-                _block = [];
+                private _block = [];
                 for "_i" from _currentPointer to (_limit)-1 do {
                     _block pushback (_sourceArray select _i);
                 };
@@ -115,34 +107,35 @@ switch(_operation) do {
                 _result = _block;
         };
         case "state": {
-                private["_state"];
 
-                if(typeName _args != "ARRAY") then {
+                if !(_args isEqualType []) then {
 
                         // Save state
 
-                        _state = [] call ALIVE_fnc_hashCreate;
+                        private _state = [] call ALIVE_fnc_hashCreate;
 
                         // BaseClassHash CHANGE
                         // loop the class hash and set vars on the state hash
                         {
-                            if(!(_x == "super") && !(_x == "class")) then {
-                                [_state,_x,[_logic,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                            };
-                        } forEach (_logic select 1);
+                          if(!(_x == "super") && !(_x == "class")) then {
+                            [_state,_x,[_logic,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                          };
+                          false
+                        } count (_logic select 1);
 
                         _result = _state;
 
                 } else {
-                        ASSERT_TRUE(typeName _args == "ARRAY",str typeName _args);
+                        ASSERT_TRUE((_args isEqualType []),str typeName _args);
 
                         // Restore state
 
                         // BaseClassHash CHANGE
                         // loop the passed hash and set vars on the class hash
                         {
-                            [_logic,_x,[_args,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        } forEach (_args select 1);
+                          [_logic,_x,[_args,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                          false
+                        } count (_args select 1);
                 };
         };
         default {
@@ -150,4 +143,4 @@ switch(_operation) do {
         };
 };
 TRACE_1("arrayBlockHandler - output",_result);
-_result;
+_result


### PR DESCRIPTION
**When merged this pull request will:**

- add the new `PATHTO_FUNC` macro, PATHTO_FUNC accepts one argument `<function name>`

All modules are taking advantage of the new macro except x_lib.
There were a few cases where the `PATHTO_FUNC` cannot be utilized due to the file being placed in a sub-folder of a component
The macro will put in place a standard as to where function files should normally be and will make it easier for people to generate a CfgFunctions file with this macro since they won't have to type out the entire path to their file every time they create a new function.

**What the macro looks like in script_mod.hpp**
`#define PATHTO_FUNC(var1) QUOTE(PATHTO_SYS(PREFIX,COMPONENT,DOUBLES(fnc,var1)))`

**How to use:**

1. Place you're function file in the root of a component, i.e.
    `\x\alive\addons\main\fnc_myFunction.sqf`
2. The class CfgFunctions will need to be defined like so...
```c#
class CfgFunctions {
  class PREFIX {
    class COMPONENT {
      class myFunction {
        description = "My Function";
        file = PATHTO_FUNC(myFunction);
        recompile = RECOMPILE;
      };
    };
  };
};
```
And as you can see above I used `PATHTO_FUNC`. It only takes one argument and that's the name of you're function.
Now it's ready for use and it can be called like so, `[] call ALiVE_fnc_myFunction;`