### PR TITLE
Undefine LOG macro before redefining it

### DIFF
--- a/addons/x_lib/script_macros.hpp
+++ b/addons/x_lib/script_macros.hpp
@@ -8,6 +8,7 @@
 #define LOG_FORMAT(varLevel,varComponent,varText,varParams) \
     [varLevel, varComponent, varText, varParams, __FILE__, __LINE__] call core_fnc_log
 
+#undef LOG
 #define LOG(varLevel,varComponent,varText) \
     LOG_FORMAT(varLevel,varComponent,varText,[])
 


### PR DESCRIPTION
Fixes an error with Rapify (1.76.5.37)