### PR TITLE
[sys_profile] Fixed hitpoints not detected for some RHS vehicles #286

### DIFF
--- a/addons/sys_profile/fnc_profileSimulator.sqf
+++ b/addons/sys_profile/fnc_profileSimulator.sqf
@@ -583,6 +583,10 @@ private _damageModifier = _cycleTime * _combatRate;
                                     if (_profileToAttackHealth isEqualTo []) then {
                                         private _vehicleClass = [_targetToAttack,"vehicleClass"] call ALiVE_fnc_hashGet;
                                         private _totalHitpoints = _vehicleClass call ALiVE_fnc_configGetVehicleHitPoints;
+                                        if (_totalHitpoints isEqualTo []) then {
+                                            private _hp = [(configfile >> "CfgVehicles" >> _vehicleClass >> "HitPoints"),0] call BIS_fnc_returnChildren;
+                                            {_totalHitpoints pushBack (configName _x)} forEach _hp; 
+                                        };
                                         {_profileToAttackHealth pushback [_x,0]} foreach _totalHitpoints;
                                     };
                                 };


### PR DESCRIPTION
Some RHS vehicles were not returning any hitpoints for use when calculating virtualised damage. [(configfile >> "CfgVehicles" >> _vehicleClass >> "HitPoints"),0] call BIS_fnc_returnChildren; is a much slower method of getting the hitpoints but it seems to be more thorough and works on all RHS vehicles. This is only called when the original method doesn't work. 

This solves the "Undefined variable in expression: _randomhitpoint" error.