### PR TITLE
[sup_combatsupport] Hybrid CS assets dual respawn (boom)

### DIFF
--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_RespawnCASAsset.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_RespawnCASAsset.sqf
@@ -36,67 +36,76 @@ CAS_RESPAWN_LIMIT = CAS_RESPAWN_LIMIT - 1;
 
 //Remove from all side-lists
 {
-        private ["_sideArray","_sideIn"];
-        _sideIn = _x;
-        _sideArray = NEO_radioLogic getVariable [format["NEO_radioCasArray_%1", _sideIn],[]];
-        {
-            if (isnull (_x select 0) || {((_x select 0) == _veh)}) then {
-                _sideArray set [_foreachIndex, -1];
-                _sideArray = _sideArray - [-1];
-            };
-        } foreach _sideArray;
-        NEO_radioLogic setVariable [format["NEO_radioCasArray_%1", _sideIn], _sideArray, true];
+    private ["_sideArray","_sideIn"];
+    _sideIn = _x;
+    _sideArray = NEO_radioLogic getVariable [format["NEO_radioCasArray_%1", _sideIn],[]];
+    {
+        if (isnull (_x select 0) || {((_x select 0) == _veh)}) then {
+            _sideArray set [_foreachIndex, -1];
+            _sideArray = _sideArray - [-1];
+        };
+    } foreach _sideArray;
+    NEO_radioLogic setVariable [format["NEO_radioCasArray_%1", _sideIn], _sideArray, true];
 } foreach _sides;
 
-//Delete objects and groups
-deletevehicle _veh;
-{deletevehicle _x} foreach units _grp;
-_grp call ALiVE_fnc_DeleteGroupRemote;
+sleep (floor (random [3,6,9]));
 
-sleep 5;
+//Delete objects and groups
+if (!isNull _veh) then {
+    deletevehicle _veh;
+};
+
+if (!isNull _grp) then {
+    {deletevehicle _x} foreach units _grp;
+    _grp call ALiVE_fnc_DeleteGroupRemote;
+};
+
+waitUntil {isNull _veh};
 
 private ["_veh","_grp"];
 
-_grp = createGroup _side;
-_veh = createVehicle [_type, _pos, [], 0, "CAN_COLLIDE"];
-_veh setDir _dir;
-_veh setPosATL _pos;
+_veh = nearestObjects [_pos, [_type], 5];
 
-if (_height > 0) then {
-    _veh setposASL [getposASL _veh select 0, getposASL _veh select 1, _height];
-} else {
+if (count _veh == 0) then {
+    _grp = createGroup _side;
+    _veh = createVehicle [_type, _pos, [], 0, "CAN_COLLIDE"];
+    _veh setDir _dir;
     _veh setPosATL _pos;
-};
 
-_veh setVelocity [0,0,-1];
-_veh setVariable ["ALIVE_CombatSupport", true];
+    if (_height > 0) then {
+        _veh setposasl [getposASL _veh select 0, getposASL _veh select 1, _height];
+        _veh setVelocity [0, 0, -1];
+    } else {
+        _veh setPosATL _pos
+    };
 
-if (getNumber(configFile >> "CfgVehicles" >> _type >> "isUav")==1) then {
-    createVehicleCrew _veh;
+    if (getNumber(configFile >> "CfgVehicles" >> _type >> "isUav") == 1) then {
+        createVehicleCrew _veh;
+    } else {
+        [_veh, _grp] call BIS_fnc_spawnCrew;
+    };
+
+    _veh lockDriver true;
+    _veh setVariable ["ALIVE_CombatSupport", true];
+    (driver _veh) setvariable ["VCOM_NOAI", true];
 } else {
-    [_veh, _grp] call BIS_fnc_spawnCrew;
+    _veh = _veh select 0;
+    waitUntil {(_veh getVariable ["ALIVE_CombatSupport", false])};
+    _grp = (group (driver _veh));
 };
-
-// Exclude CS from VCOM
-// CS only runs serverside so no PV is needed
-(driver _veh) setvariable ["VCOM_NOAI", true];
-
-_veh lockDriver true;
 
 _ffvTurrets = [_type,true,true,false,true] call ALIVE_fnc_configGetVehicleTurretPositions;
-                                _gunnerTurrets = [_type,false,true,true,true] call ALIVE_fnc_configGetVehicleTurretPositions;
-                                _ffvTurrets = _ffvTurrets - _gunnerTurrets;
+_gunnerTurrets = [_type,false,true,true,true] call ALIVE_fnc_configGetVehicleTurretPositions;
+_ffvTurrets = _ffvTurrets - _gunnerTurrets;
 
-                           if(count _ffvTurrets > 0) then
-                            {
-                                for "_i" from 0 to (count _ffvTurrets)-1 do
-                                    {
-                                          _turretPath = _ffvTurrets call BIS_fnc_arrayPop;
-                                         [_veh turretUnit _turretPath] join grpNull;
-                                         deleteVehicle (_veh turretUnit _turretPath);
-                                    };
-                            };
-
+if (count _ffvTurrets > 0) then
+{
+    for "_i" from 0 to (count _ffvTurrets)-1 do {
+        _turretPath = _ffvTurrets call BIS_fnc_arrayPop;
+        [_veh turretUnit _turretPath] join grpNull;
+        deleteVehicle (_veh turretUnit _turretPath);
+    };
+};
 
 _hdl = [[(units _grp select 0),_callsign], "fnc_setGroupID", false, false] spawn BIS_fnc_MP;
 waituntil {scriptdone _hdl};


### PR DESCRIPTION
Adds checks to make sure only one of the respawn scripts creates the new asset.

`fn_RespawnCASAsset`
`fn_RespawnTransportAsset`

Fixes #447 
