### PR TITLE
[mil_placement_custom] Handle custom composition lookup to prevent init errors

### DIFF
--- a/addons/mil_placement_custom/fnc_CMP.sqf
+++ b/addons/mil_placement_custom/fnc_CMP.sqf
@@ -359,8 +359,13 @@ switch(_operation) do {
                     if (count _comp > 0) then {
                         [_comp, _position, direction _logic, _faction] call ALIVE_fnc_spawnComposition;
                     } else {
-                        _comp = selectRandom ([_compType, [_composition], [], _faction] call ALiVE_fnc_getCompositions);
-                        [_comp, _position, direction _logic, _faction] call ALIVE_fnc_spawnComposition;
+                        private _compDef = ([_compType, [_composition], [], _faction] call ALiVE_fnc_getCompositions);
+
+                        if (count _compDef > 0) then {
+                            [(selectRandom _compDef), _position, direction _logic, _faction] call ALIVE_fnc_spawnComposition;
+                        } else {
+                            ["ALIVE CMP: Custom composition '%1' not found!", _composition] call ALiVE_fnc_dump;
+                        };
                     };
                 };
             };


### PR DESCRIPTION
* Fixes issues seen in #471 

Test with devbuild from master:

<details>
<summary>Pre</summary>
 0:40:48 Spawning Composition: [<null>,[10069.6,10396.8,0],0,"OPF_F"]
 0:40:48 Error in expression < %1, expected %2, on index %3, in %4", [_par] call _fnc_getTypeName, [_x] call _>
 0:40:48   Error position: <_par] call _fnc_getTypeName, [_x] call _>
 0:40:48   Error Undefined variable in expression: _par
 0:40:48 File A3\functions_f\Debug\fn_errorParamsType.sqf [BIS_fnc_errorParamsType], line 146
 0:40:48 Error in expression <0) pushBack _position;


if (configName _config in _brokenCheckpoints) then {
_a>
 0:40:48   Error position: <_config in _brokenCheckpoints) then {
_a>
 0:40:48   Error Undefined variable in expression: _config
 0:40:48 File \x\alive\addons\x_lib\functions\composition\fnc_spawnComposition.sqf [ALiVE_fnc_spawnComposition], line 1921
 0:40:48 Error in expression <,
"CheckpointHBarrier"
];

if (typename _config == "ARRAY") then {
_config = [_c>
 0:40:48   Error position: <_config == "ARRAY") then {
_config = [_c>
 0:40:48   Error Undefined variable in expression: _config
 0:40:48 File \x\alive\addons\x_lib\functions\composition\fnc_spawnComposition.sqf [ALiVE_fnc_spawnComposition], line 1826
 0:40:48 Error in expression <tion] call ALiVE_fnc_getCompositions);
[_comp, _position, direction _logic, _fac>
 0:40:48   Error position: <_comp, _position, direction _logic, _fac>
 0:40:48   Error Undefined variable in expression: _comp
 0:40:48 File \x\alive\addons\mil_placement_custom\fnc_CMP.sqf [ALiVE_fnc_CMP], line 2111</details>

<details>
<summary>Post</summary>
 1:15:34 ALIVE CMP: Custom composition 'mediumMGCamp3' not found!
</details>
