### PR TITLE
Error in rescue task

### DIFF
--- a/addons/mil_c2istar/tasks/fnc_taskRescue.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskRescue.sqf
@@ -550,7 +550,7 @@ switch (_taskState) do {
                             // Join player group
 							private _prevLeader = leader _saverGroup;
                             [_hostage] joinSilent _saverGroup;
-                            _saverGroup selectLeader _prevLeader;
+							[_saverGroup, _prevLeader] remoteExecCall ["selectLeader", groupOwner _saverGroup];
 
                             _taskIDs = [_params,"taskIDs"] call ALIVE_fnc_hashGet;
                             [_params,"nextTask",_taskIDs select 2] call ALIVE_fnc_hashSet;

--- a/addons/mil_c2istar/tasks/fnc_taskRescue.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskRescue.sqf
@@ -533,7 +533,7 @@ switch (_taskState) do {
                         if (_hostage getVariable ["rescued",false]) then {
 
 							// Get closest player
-							private _saver = group ([_position,_taskPlayers] call ALIVE_fnc_taskGetClosestPlayerToPosition);
+							private _saverGroup = group ([_position,_taskPlayers] call ALIVE_fnc_taskGetClosestPlayerToPosition);
 
                             // End Hostage Anim
                             _anims = ([_hostageAnims, "unboundAnims"] call ALIVE_fnc_hashGet) select ([_hostageAnims, "index"] call ALiVE_fnc_hashGet);
@@ -548,8 +548,9 @@ switch (_taskState) do {
                             sleep 1;
 
                             // Join player group
-                            [_hostage] joinSilent _saver;
-                            (group _saver) selectLeader _saver;
+							private _prevLeader = leader _saverGroup;
+                            [_hostage] joinSilent _saverGroup;
+                            _saverGroup selectLeader _prevLeader;
 
                             _taskIDs = [_params,"taskIDs"] call ALIVE_fnc_hashGet;
                             [_params,"nextTask",_taskIDs select 2] call ALIVE_fnc_hashSet;


### PR DESCRIPTION
_saver was a group, not an object

```
16:02:02 Error in expression <eep 1;


[_hostage] joinSilent _saver;
(group _saver) selectLeader _saver;

_tas>
16:02:02   Error position: <group _saver) selectLeader _saver;

_tas>
16:02:02   Error group: Typ Gruppe, erwartet Objekt
16:02:02 File \x\alive\addons\mil_C2ISTAR\tasks\fnc_taskRescue.sqf [ALiVE_fnc_taskRescue], line 2297
```