### PR TITLE
[sys_profile] Integrate spacial grid for profiles, getNearProfiles

### DIFF
--- a/addons/main/fnc_aliveInit.sqf
+++ b/addons/main/fnc_aliveInit.sqf
@@ -96,6 +96,14 @@ TRACE_1("Launching Base ALiVE Systems",true);
 //Start ALiVE loading screen on all localities during init
 ["ALiVE_LOADINGSCREEN"] call BIS_fnc_startLoadingScreen;
 
+ALiVE_lastFrameCheckTime = time;
+ALiVE_gamePaused = false;
+
+[{
+    ALiVE_gamePaused = time == ALiVE_lastFrameCheckTime;
+    ALiVE_lastFrameCheckTime = time;
+}, 1, []] call CBA_fnc_addPerFrameHandler;
+
 // NewsFeed
 [] spawn ALiVE_fnc_newsFeedInit;
 

--- a/addons/sys_profile/CfgVehicles.hpp
+++ b/addons/sys_profile/CfgVehicles.hpp
@@ -136,28 +136,28 @@ class CfgVehicles {
 							class Regular
 							{
 								name = "Regular";
-								Value = 1;
+								Value = 0.75;
 								default = 1;
 							};
 							class Fastest
 							{
 								name = "Fastest";
-								Value = 2;
+								Value = 1.75;
 							};
 							class Faster
 							{
 								name = "Faster";
-								Value = 1.5;
+								Value = 1.25;
 							};
 							class Slower
 							{
 								name = "Slower";
-								Value = 0.5;
+								Value = 0.35;
 							};
 							class Slowest
 							{
 								name = "Slowest";
-								Value = 0.2;
+								Value = 0.1;
 							};
 						};
 					};

--- a/addons/sys_profile/fnc_getNearProfiles.sqf
+++ b/addons/sys_profile/fnc_getNearProfiles.sqf
@@ -40,6 +40,7 @@ if (_categorySelector isEqualTo []) then {
     private _categorySide = _categorySelector param [0, "all"];
     private _categoryType = _categorySelector param [1, "all"];
     private _categoryObjectType = _categorySelector param [2, "none"];
+    private _customFilter = _categorySelector param [3, {}];
 
     private _query = "true";
 
@@ -55,8 +56,16 @@ if (_categorySelector isEqualTo []) then {
         _query = _query + " && {(_x select 2 select 5) == _categoryType}";
     };
 
-    if (_categoryObjectType != "none") then {
-        _query = _query + " && {(_x select 2 select 6) == _categoryObjectType}";
+    if !(_categoryObjectType isEqualTo "none") then {
+        if (_categoryObjectType isEqualType "") then {
+            _query = _query + " && {(_x select 2 select 6) == _categoryObjectType}";
+        } else {
+            _query = _query + " && {(_x select 2 select 6) in _categoryObjectType}";
+        };
+    };
+
+    if !(_customFilter isEqualTo {}) then {
+        _query = _query + (format [" && %1", _customFilter]);
     };
 
     _near select (compile _query);

--- a/addons/sys_profile/fnc_getNearProfiles.sqf
+++ b/addons/sys_profile/fnc_getNearProfiles.sqf
@@ -30,21 +30,21 @@ private _position = _this select 0;
 private _radius = _this select 1;
 private _categorySelector = param [2, []];
 
-//Exit if ALIVE_profileHandler is not existing for any reason (f.e. due to being called on a remote locality with fnc_isEnemyNear)
-if (isnil "ALiVE_profileHandler") exitwith {[]};
-
 private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
 private _near = ([_spacialGrid,"findInRange", [_position,_radius]] call ALiVE_fnc_spacialGrid) apply {_x select 1};
-private "_query";
 
 if (_categorySelector isEqualTo []) then {
-    _query = "(_x select 2 select 5) == 'entity'";
+   _near select {(_x select 2 select 5) == "entity"};
 } else {
-    private _categorySide = _categorySelector select 0;
+    private _categorySide = _categorySelector param [0, "all"];
     private _categoryType = _categorySelector param [1, "all"];
     private _categoryObjectType = _categorySelector param [2, "none"];
 
-    _query = "(_x select 2 select 3) == _categorySide";
+    private _query = "true";
+
+    if (_categorySide != "all") then {
+        _query = _query + " && ((_x select 2 select 3) == _categorySide)";
+    };
 
     if (_categoryType != "all") then {
         _query = _query + " && {(_x select 2 select 5) == _categoryType}";
@@ -53,6 +53,6 @@ if (_categorySelector isEqualTo []) then {
     if (_categoryObjectType != "none") then {
         _query = _query + " && {(_x select 2 select 6) == _categoryObjectType}";
     };
-};
 
-_near select (compile _query);
+    _near select (compile _query);
+};

--- a/addons/sys_profile/fnc_getNearProfiles.sqf
+++ b/addons/sys_profile/fnc_getNearProfiles.sqf
@@ -37,10 +37,12 @@ private _near = ([_spacialGrid,"findInRange", [_position,_radius,_filter2D]] cal
 if (_categorySelector isEqualTo []) then {
    _near select {(_x select 2 select 5) == "entity"};
 } else {
-    private _categorySide = _categorySelector param [0, "all"];
-    private _categoryType = _categorySelector param [1, "all"];
-    private _categoryObjectType = _categorySelector param [2, "none"];
-    private _customFilter = _categorySelector param [3, {}];
+    _categorySelector params [
+        ["_categorySide", "all"],
+        ["_categoryType", "all"],
+        ["_categoryObjectType", "none"],
+        ["_customFilter", {}]
+    ];
 
     private _query = "true";
 

--- a/addons/sys_profile/fnc_getNearProfiles.sqf
+++ b/addons/sys_profile/fnc_getNearProfiles.sqf
@@ -30,30 +30,29 @@ private _position = _this select 0;
 private _radius = _this select 1;
 private _categorySelector = param [2, []];
 
-private _result = [];
-
 //Exit if ALIVE_profileHandler is not existing for any reason (f.e. due to being called on a remote locality with fnc_isEnemyNear)
-if (isnil "ALiVE_profileHandler") exitwith {_result};
+if (isnil "ALiVE_profileHandler") exitwith {[]};
 
 private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
-private _categoryType = "entity";
+private _near = ([_spacialGrid,"findInRange", [_position,_radius]] call ALiVE_fnc_spacialGrid) apply {_x select 1};
+private "_query";
 
 if (_categorySelector isEqualTo []) then {
-    private _near = [_spacialGrid,"findInRange", [_position,_radius]] call ALiVE_fnc_spacialGrid;
-    _result = _near apply {_x select 1};
-    _result = _result select {(_x select 2 select 5) == _categoryType};
-}else{
-    _categorySide = _categorySelector select 0;
-    _categoryType = _categorySelector select 1;
-    _categoryObjectType = _categorySelector param [2,"none"];
+    _query = "(_x select 2 select 5) == 'entity'";
+} else {
+    private _categorySide = _categorySelector select 0;
+    private _categoryType = _categorySelector param [1, "all"];
+    private _categoryObjectType = _categorySelector param [2, "none"];
 
-    private _near = [_spacialGrid,"findInRange", [_position,_radius]] call ALiVE_fnc_spacialGrid;
-    _result = _near apply {_x select 1};
-    _result = _result select {(_x select 2 select 5) == _categoryType && {(_x select 2 select 3) == _categorySide}};
+    _query = "(_x select 2 select 3) == _categorySide";
+
+    if (_categoryType != "all") then {
+        _query = _query + " && {(_x select 2 select 5) == _categoryType}";
+    };
 
     if (_categoryObjectType != "none") then {
-        _result = _result select {(_x select 2 select 6) == _categoryObjectType};
+        _query = _query + " && {(_x select 2 select 6) == _categoryObjectType}";
     };
 };
 
-_result
+_near select (compile _query);

--- a/addons/sys_profile/fnc_getNearProfiles.sqf
+++ b/addons/sys_profile/fnc_getNearProfiles.sqf
@@ -29,9 +29,10 @@ ARJay
 private _position = _this select 0;
 private _radius = _this select 1;
 private _categorySelector = param [2, []];
+private _filter2D = param [3, false];
 
 private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
-private _near = ([_spacialGrid,"findInRange", [_position,_radius]] call ALiVE_fnc_spacialGrid) apply {_x select 1};
+private _near = ([_spacialGrid,"findInRange", [_position,_radius,_filter2D]] call ALiVE_fnc_spacialGrid) apply {_x select 1};
 
 if (_categorySelector isEqualTo []) then {
    _near select {(_x select 2 select 5) == "entity"};
@@ -42,8 +43,12 @@ if (_categorySelector isEqualTo []) then {
 
     private _query = "true";
 
-    if (_categorySide != "all") then {
-        _query = _query + " && ((_x select 2 select 3) == _categorySide)";
+    if !(_categorySide isEqualTo "all") then {
+        if (_categorySide isEqualType []) then {
+            _query = _query + " && ((_x select 2 select 3) in _categorySide)";
+        } else {
+            _query = _query + " && ((_x select 2 select 3) == _categorySide)";
+        };
     };
 
     if (_categoryType != "all") then {

--- a/addons/sys_profile/fnc_profile.sqf
+++ b/addons/sys_profile/fnc_profile.sqf
@@ -33,10 +33,8 @@ Peer reviewed:
 nil
 ---------------------------------------------------------------------------- */
 
-#define SUPERCLASS ALIVE_fnc_baseClassHash
-#define MAINCLASS ALIVE_fnc_profile
-
-private ["_result","_deleteMarkers","_createMarkers"];
+#define SUPERCLASS  ALIVE_fnc_baseClassHash
+#define MAINCLASS   ALIVE_fnc_profile
 
 TRACE_1("profile - input",_this);
 
@@ -45,85 +43,105 @@ params [
     ["_operation", "", [""]],
     ["_args", objNull, [objNull,[],"",0,true,false]]
 ];
-_result = true;
+private _result = true;
 
 #define MTEMPLATE "ALiVE_PROFILE_%1"
 
 switch(_operation) do {
-        case "init": {
-                /*
-                MODEL - no visual just reference data
-                - nodes
-                - center
-                - size
-                */
 
-                if (isServer) then {
-                        // if server, initialise module game logic
-                        // nil these out they add a lot of code to the hash..
-                        [_logic,"super"] call ALIVE_fnc_hashRem;
-                        [_logic,"class"] call ALIVE_fnc_hashRem;
-                        //TRACE_1("After module init",_logic);
+    case "init": {
 
-                        [_logic,"debug",false] call ALIVE_fnc_hashSet; // select 2 select 0
-                        [_logic,"active",false] call ALIVE_fnc_hashSet; // select 2 select 1
-                        [_logic,"position",[0,0]] call ALIVE_fnc_hashSet; // select 2 select 2
-                        [_logic,"side","EAST"] call ALIVE_fnc_hashSet; // select 2 select 3
-                        [_logic,"profileID",""] call ALIVE_fnc_hashSet; // select 2 select 4
-                        [_logic,"type","entity"] call ALIVE_fnc_hashSet; // select 2 select 5
-                        [_logic,"objectType","inf"] call ALIVE_fnc_hashSet; // select 2 select 6
-                        [_logic,"vehicleAssignments",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet; // select 2 select 7
+        /*
+        MODEL - no visual just reference data
+        - nodes
+        - center
+        - size
+        */
 
+        if (isServer) then {
+            // if server, initialise module game logic
+            // nil these out they add a lot of code to the hash..
+            [_logic,"super"] call ALIVE_fnc_hashRem;
+            [_logic,"class"] call ALIVE_fnc_hashRem;
+            //TRACE_1("After module init",_logic);
+
+            // at this point we've got a blank hash
+            // we can safely create a new hash with a more efficient method
+            // than setting each value to the existing one
+
+            private _fields = [
+                ["debug", false],       // select 2 select 0
+                ["active", false],      // select 2 select 1
+                ["position", [0,0]],    // select 2 select 2
+                ["side", "EAST"],       // select 2 select 3
+                ["profileID", ""],      // select 2 select 4
+                ["type", "entity"],     // select 2 select 5
+                ["objectType", "inf"],  // select 2 select 6
+                ["vehicleAssignments", [] call ALIVE_fnc_hashCreate] // select 2 select 7
+            ];
+
+            {
+                (_logic select 1) pushback (_x select 0);
+                (_logic select 2) pushback (_x select 1);
+            } foreach _fields;
+        };
+
+        /*
+        VIEW - purely visual
+        */
+
+        /*
+        CONTROLLER  - coordination
+        */
+
+    };
+
+    case "destroy": {
+
+        [_logic, "debug", false] call MAINCLASS;
+
+        if (isServer) then {
+            [_logic, "destroy"] call SUPERCLASS;
+        };
+
+    };
+
+    case "state": {
+
+        if (_args isEqualType []) then {
+            // Save state
+
+            private _state = [] call ALIVE_fnc_hashCreate;
+
+            // BaseClassHash CHANGE
+            // loop the class hash and set vars on the state hash
+            {
+                if(!(_x == "super") && !(_x == "class")) then {
+                    [_state,_x,[_logic,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
                 };
+            } forEach (_logic select 1);
 
-                /*
-                VIEW - purely visual
-                */
+            _result = _state;
+        } else {
+            ASSERT_TRUE(_args isEqualType [], str typeName _args);
 
-                /*
-                CONTROLLER  - coordination
-                */
+            // Restore state
+
+            // BaseClassHash CHANGE
+            // loop the passed hash and set vars on the class hash
+            {
+                [_logic,_x,[_args,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+            } forEach (_args select 1);
         };
-        case "destroy": {
-                [_logic, "debug", false] call MAINCLASS;
-                if (isServer) then {
-                    [_logic, "destroy"] call SUPERCLASS;
-                };
-        };
-        case "state": {
-                private["_state"];
 
-                if(typeName _args != "ARRAY") then {
+    };
 
-                        // Save state
+    default {
+        _result = [_logic, _operation, _args] call SUPERCLASS;
+    };
 
-                        _state = [] call ALIVE_fnc_hashCreate;
-
-                        // BaseClassHash CHANGE
-                        // loop the class hash and set vars on the state hash
-                        {
-                            if(!(_x == "super") && !(_x == "class")) then {
-                                [_state,_x,[_logic,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                            };
-                        } forEach (_logic select 1);
-
-                        _result = _state;
-
-                } else {
-                        ASSERT_TRUE(typeName _args == "ARRAY",str typeName _args);
-
-                        // Restore state
-
-                        // BaseClassHash CHANGE
-                        // loop the passed hash and set vars on the class hash
-                        {
-                            [_logic,_x,[_args,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        } forEach (_args select 1);
-                };
-        };
-        default {
-                _result = [_logic, _operation, _args] call SUPERCLASS;
-        };
 };
+
 TRACE_1("profile - output",_result);
+
 _result;

--- a/addons/sys_profile/fnc_profileAttack.sqf
+++ b/addons/sys_profile/fnc_profileAttack.sqf
@@ -44,24 +44,27 @@ params [
 
 switch (_operation) do {
 
-    case "init": {
+    case "create": {
 
-        [_logic,"super", QUOTE(SUPERCLASS)] call ALiVE_fnc_hashSet; // select 2 select 0
-        [_logic,"class", QUOTE(MAINCLASS)] call ALiVE_fnc_hashSet;  // select 2 select 1
+        private _position = _args select 0;
+        private _attacker = _args select 1;
+        private _targets = _args select 2;
+        private _attackerSide = _args select 3;
 
-        [_logic,"attackID", ""] call ALiVE_fnc_hashSet;             // select 2 select 2
-        [_logic,"position", [0,0,0]] call ALiVE_fnc_hashSet;        // select 2 select 3
-        [_logic,"timeStarted", time] call ALiVE_fnc_hashSet;        // select 2 select 4
-
-        [_logic,"attacker", []] call ALiVE_fnc_hashSet;             // select 2 select 5
-        [_logic,"targets", []] call ALiVE_fnc_hashSet;              // select 2 select 6
-
-        // for arty set to max arty range, else leave default
-
-        [_logic,"maxRange", [MOD(profileCombatHandler),"combatRange"] call ALiVE_fnc_hashGet] call ALiVE_fnc_hashSet;            // select 2 select 7
-
-        [_logic,"cyclesLeft", 9999] call ALiVE_fnc_hashSet;         // select 2 select 8
-        [_logic,"attackerSide", "WEST"] call ALiVE_fnc_hashSet;     // select 2 select 9
+        _result = [
+            [
+                ["super", QUOTE(SUPERCLASS)],       // select 2 select 0
+                ["class", QUOTE(MAINCLASS)],        // select 2 select 1
+                ["cyclesLeft", 9999],               // select 2 select 2
+                ["attackID", ""],                   // select 2 select 3
+                ["attackerSide", _attackerSide],    // select 2 select 4
+                ["position", _position],            // select 2 select 5
+                ["timeStarted", time],              // select 2 select 6
+                ["attacker", _attacker],            // select 2 select 7
+                ["targets", _targets],              // select 2 select 8
+                ["maxRange", [MOD(profileCombatHandler),"combatRange"] call ALiVE_fnc_hashGet] // for arty set to max arty range, else leave default
+            ]
+        ] call ALiVE_fnc_hashCreate;
 
     };
 

--- a/addons/sys_profile/fnc_profileCombatHandler.sqf
+++ b/addons/sys_profile/fnc_profileCombatHandler.sqf
@@ -164,27 +164,26 @@ switch (_operation) do {
         private _profilesInCombatBySide = ([_logic,"profilesInCombatBySide"] call ALiVE_fnc_hashGet) select 2;
 
         private _attackerID = [_attack,"attacker"] call ALiVE_fnc_hashGet;
-        private _attackerSide = ([MOD(profileHandler),"getProfile", _attackerID] call ALiVE_fnc_profileHandler) select 2 select 3;
+        private _attackerSide = [_attack,"attackerSide"] call ALiVE_fnc_hashGet;
 
-		if !(isNil "_attackerSide") then {
-	        switch (_attackerSide) do {
-	            case "EAST": {(_profilesInCombatBySide select 0) pushback _attackerID};
-	            case "WEST": {(_profilesInCombatBySide select 1) pushback _attackerID};
-	            case "GUER": {(_profilesInCombatBySide select 2) pushback _attackerID};
-	        };
-	
-	        // log event
-	
-	        private _targets = _attack select 2 select 6;
-	        private _attackPosition = _attack select 2 select 3;
-	        private _maxRange = _attack select 2 select 7;
-	        private _cyclesLeft = _attack select 2 select 8;
-	
-	        private _event = ['PROFILE_ATTACK_START', [_attackID,_attackerID,_targets,_attackPosition,_attackerSide,_maxRange,_cyclesLeft], "profileCombatHandler"] call ALiVE_fnc_event;
-	        [MOD(eventLog), "addEvent", _event] call ALiVE_fnc_eventLog;
+        switch (_attackerSide) do {
+            case "EAST": {(_profilesInCombatBySide select 0) pushback _attackerID};
+            case "WEST": {(_profilesInCombatBySide select 1) pushback _attackerID};
+            case "GUER": {(_profilesInCombatBySide select 2) pushback _attackerID};
+        };
 
-        	_result = _attackID;
-		};
+        // log event
+
+        private _targets = [_attack,"targets"] call ALiVE_fnc_hashGet;
+        private _attackPosition = [_attack,"position"] call ALiVE_fnc_hashGet;
+        private _maxRange = [_attack,"maxRange"] call ALiVE_fnc_hashGet;
+        private _cyclesLeft = [_attack,"cyclesLeft"] call ALiVE_fnc_hashGet;
+
+        private _event = ['PROFILE_ATTACK_START', [_attackID,_attackerID,_targets,_attackPosition,_attackerSide,_maxRange,_cyclesLeft], "profileCombatHandler"] call ALiVE_fnc_event;
+        [MOD(eventLog),"addEvent", _event] call ALiVE_fnc_eventLog;
+
+        _result = _attackID;
+
     };
 
     case "removeAttacks": {
@@ -197,40 +196,40 @@ switch (_operation) do {
 
         {
             private _attack = _x;
-            private _attackID = _attack select 2 select 2;
+            private _attackID = [_attack,"attackID"] call ALiVE_fnc_hashGet;
 
-            private _attackPosition = _attack select 2 select 3;
-            private _attackerID = _attack select 2 select 5;
-            private _targetsLeft = _attack select 2 select 6;
+            private _attackPosition = [_attack,"position"] call ALiVE_fnc_hashGet;
+            private _attackerID = [_attack,"attacker"] call ALiVE_fnc_hashGet;
+            private _targetsLeft = [_attack,"targets"] call ALiVE_fnc_hashGet;
 
             // remove from combatBySide
             private _attackerSide = [_attack,"attackerSide"] call ALiVE_fnc_hashGet;
 
             switch (_attackerSide) do {
                 case "EAST": {
-                        private _array = (_profilesInCombatBySide select 0);
-                        _array deleteAt (_array find _attackerID);
+                    private _array = (_profilesInCombatBySide select 0);
+                    _array deleteAt (_array find _attackerID);
                 };
                 case "WEST": {
-                        private _array = (_profilesInCombatBySide select 1);
-                        _array deleteAt (_array find _attackerID);
+                    private _array = (_profilesInCombatBySide select 1);
+                    _array deleteAt (_array find _attackerID);
                 };
                 case "GUER": {
-                        private _array = (_profilesInCombatBySide select 2);
-                        _array deleteAt (_array find _attackerID);
+                    private _array = (_profilesInCombatBySide select 2);
+                    _array deleteAt (_array find _attackerID);
                 };
             };
 
-            [_attacksByID,_attackID, nil] call ALiVE_fnc_hashSet;
+            [_attacksByID,_attackID] call ALiVE_fnc_hashRem;
 
             // log event
 
-            private _timeStarted = _attack select 2 select 4;
-            private _maxRange = _attack select 2 select 7;
-            private _cyclesLeft = _attack select 2 select 8;
+            private _timeStarted = [_attack,"timeStarted"] call ALiVE_fnc_hashGet;
+            private _maxRange = [_attack,"maxRange"] call ALiVE_fnc_hashGet;
+            private _cyclesLeft = [_attack,"cyclesLeft"] call ALiVE_fnc_hashGet;
 
             private _event = ['PROFILE_ATTACK_END', [_attackID,_attackerID,_targetsLeft,_attackPosition,_attackerSide,_timeStarted,_maxRange,_cyclesLeft], "profileCombatHandler"] call ALiVE_fnc_event;
-            [MOD(eventLog), "addEvent", _event] call ALiVE_fnc_eventLog;
+            [MOD(eventLog),"addEvent", _event] call ALiVE_fnc_eventLog;
         } foreach _attacks;
 
     };

--- a/addons/sys_profile/fnc_profileEntity.sqf
+++ b/addons/sys_profile/fnc_profileEntity.sqf
@@ -372,6 +372,11 @@ switch(_operation) do {
                         };
 
                         if!(((_args select 0) + (_args select 1)) == 0) then {
+                            private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
+
+                            private _currPos = _logic select 2 select 2;
+                            [_spacialGrid,"move", [_currPos, _args, _logic]] call ALiVE_fnc_spacialGrid;
+
                             [_logic,"position",_args] call ALIVE_fnc_hashSet;
 
                             if([_logic,"debug"] call ALIVE_fnc_hashGet) then {
@@ -514,7 +519,7 @@ switch(_operation) do {
                         [_logic,_vehicleProfile] call ALIVE_fnc_removeProfileVehicleAssignment;
                     };
                 } foreach (_vehiclesInCommandOf + _vehiclesInCargoOf);
-                
+
                 // reset data
                 [_logic,"vehicleAssignments",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
                 [_logic,"vehiclesInCommandOf",[]] call ALIVE_fnc_hashSet;
@@ -841,6 +846,11 @@ switch(_operation) do {
 
             if(typeName _args == "ARRAY") then {
 
+                private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
+
+                private _currPos = _logic select 2 select 2;
+                [_spacialGrid,"move", [_currPos, _args, _logic]] call ALiVE_fnc_spacialGrid;
+
                 [_logic,"position",_args] call ALIVE_fnc_hashSet;
 
                 //["ENTITY %1 setPosition: %2",_logic select 2 select 4,_args] call ALIVE_fnc_dump;
@@ -912,7 +922,7 @@ switch(_operation) do {
                     //["SPAWN ENTITY [%1] pos: %2 command: %3 cargo: %4",_profileID,_position,_vehiclesInCommandOf,_vehiclesInCargoOf] call ALIVE_fnc_dump;
 
                     if (((count _vehiclesInCommandOf) == 0) && {(count _vehiclesInCargoOf) == 0}) then {
-	                    
+
                         // If entity is not in a vehicle but in air give it a parachute
                         if ((_position select 2) > 300) then {
 	                    	_paraDrop = true;
@@ -1137,7 +1147,8 @@ switch(_operation) do {
                         _position = getPosATL _leader;
 
                         // update the profiles position
-                        [_logic,"position", _position] call ALIVE_fnc_hashSet;
+                        //[_logic,"position", _position] call ALIVE_fnc_hashSet;
+                        [_logic,"position", _position] call MAINCLASS;
                         [_logic,"despawnPosition", _position] call ALIVE_fnc_hashSet;
 
                         // delete units

--- a/addons/sys_profile/fnc_profileEntity.sqf
+++ b/addons/sys_profile/fnc_profileEntity.sqf
@@ -1008,11 +1008,19 @@ switch(_operation) do {
             [ALIVE_profileHandler,"setActive",[_profileID,_side,_logic]] call ALIVE_fnc_profileHandler;
             [ALIVE_profileHandler,"setEntityActive",_profileID] call ALIVE_fnc_profileHandler;
 
-            //Remove combat flag
-            //[_logic, "combat"] call ALIVE_fnc_HashRem; // combat flag must be kept for new combat system
+            // remove profiled attacks
+
+            private _attackID = [_logic,"attackID"] call ALiVE_fnc_hashGet;
+            if (!isnil "_attackID") then {
+                private _attack = [MOD(profileCombatHandler),"getAttack", _attackID] call ALiVE_fnc_profileCombatHandler;
+                [MOD(profileCombatHandler),"removeAttacks", [_attack]] call ALiVE_fnc_profileCombatHandler;
+            };
+
+            [_logic,"combat", false] call ALIVE_fnc_HashSet;
+
 
             // Indicate profile has been spawned and unlock for asynchronous waits
-            [_logic, "locked",false] call ALIVE_fnc_HashSet;
+            [_logic,"locked", false] call ALIVE_fnc_HashSet;
 
             // profile is fully spawned and cannot be corrupted
             // allow damage again
@@ -1072,7 +1080,7 @@ switch(_operation) do {
                 } forEach (_linked select 2);
             };
 
-            if!(_despawnPrevented) then {
+            if !(_despawnPrevented) then {
 
                 [_logic,"active", false] call ALIVE_fnc_hashSet;
 

--- a/addons/sys_profile/fnc_profileEntity.sqf
+++ b/addons/sys_profile/fnc_profileEntity.sqf
@@ -139,8 +139,6 @@ nil
 #define SUPERCLASS ALIVE_fnc_profile
 #define MAINCLASS ALIVE_fnc_profileEntity
 
-private ["_result","_deleteMarkers","_createMarkers"];
-
 TRACE_1("profileEntity - input",_this);
 
 params [
@@ -149,32 +147,1056 @@ params [
     ["_args", objNull, [objNull,[],"",0,true,false]]
 ];
 
-_result = true;
+private _result = true;
 
 #define MTEMPLATE "ALiVE_PROFILEENTITY_%1"
 
-_deleteMarkers = {
-        private ["_logic"];
-        _logic = _this;
+switch(_operation) do {
+
+    case "init": {
+        /*
+        MODEL - no visual just reference data
+        - nodes
+        - center
+        - size
+        */
+
+        if (isServer) then {
+            // if server, initialise module game logic
+            // nil these out they add a lot of code to the hash..
+            [_logic,"super"] call ALIVE_fnc_hashRem;
+            [_logic,"class"] call ALIVE_fnc_hashRem;
+            //TRACE_1("After module init",_logic);
+
+            // init the super class
+            [_logic, "init"] call SUPERCLASS;
+
+/*
+            private _fields = [
+                ["vehiclesInCommandOf", []],
+                ["vehiclesInCargoOf", []],
+                ["leader", objnull],
+                ["unitClasses", []],
+                ["unitCount", 0],
+                ["group", grpnull],
+                ["companyID", ""],
+                ["groupID", ""],
+                ["waypoints", []],
+                ["waypointsCompleted", []],
+                ["positions", []],
+                ["damages", []],
+                ["ranks", []],
+                ["units", []],
+                ["speedPerSecond", "Man" call ALIVE_fnc_vehicleGetSpeedPerSecond],
+                ["despawnPosition", [0,0]],
+                ["hasSimulated", false],
+                ["isCycling", false],
+                ["activeCommands", []],
+                ["inactiveCommands", []],
+                ["spawnType", []],
+                ["faction", []],
+                ["isPlayer", false],
+                ["_rev", ""],
+                ["_id", ""],
+                ["busy", false]
+            ];
+
+            private _logicFields = _logic select 1;
+            private _logicFieldValues = _logic select 2;
+            {
+                _logicFields pushback (_x select 0);
+                _logicFieldValues pushback (_x select 1);
+            } foreach _fields;
+*/
+
+
+            // set defaults
+            [_logic,"type","entity"] call ALIVE_fnc_hashSet;            // select 2 select 5
+            [_logic,"vehiclesInCommandOf",[]] call ALIVE_fnc_hashSet;   // select 2 select 8
+            [_logic,"vehiclesInCargoOf",[]] call ALIVE_fnc_hashSet;     // select 2 select 9
+            [_logic,"leader",objNull] call ALIVE_fnc_hashSet;           // select 2 select 10
+            [_logic,"unitClasses",[]] call ALIVE_fnc_hashSet;           // select 2 select 11
+            [_logic,"unitCount",0] call ALIVE_fnc_hashSet;              // select 2 select 12
+            [_logic,"group",grpNull] call ALIVE_fnc_hashSet;            // select 2 select 13
+            [_logic,"companyID",""] call ALIVE_fnc_hashSet;             // select 2 select 14
+            [_logic,"groupID",""] call ALIVE_fnc_hashSet;               // select 2 select 15
+            [_logic,"waypoints",[]] call ALIVE_fnc_hashSet;             // select 2 select 16
+            [_logic,"waypointsCompleted",[]] call ALIVE_fnc_hashSet;    // select 2 select 17
+            [_logic,"positions",[]] call ALIVE_fnc_hashSet;             // select 2 select 18
+            [_logic,"damages",[]] call ALIVE_fnc_hashSet;               // select 2 select 19
+            [_logic,"ranks",[]] call ALIVE_fnc_hashSet;                 // select 2 select 20
+            [_logic,"units",[]] call ALIVE_fnc_hashSet;                 // select 2 select 21
+            [_logic,"speedPerSecond","Man" call ALIVE_fnc_vehicleGetSpeedPerSecond] call ALIVE_fnc_hashSet; // select 2 select 22
+            [_logic,"despawnPosition",[0,0]] call ALIVE_fnc_hashSet;    // select 2 select 23
+            [_logic,"hasSimulated",false] call ALIVE_fnc_hashSet;       // select 2 select 24
+            [_logic,"isCycling",false] call ALIVE_fnc_hashSet;          // select 2 select 25
+            [_logic,"activeCommands",[]] call ALIVE_fnc_hashSet;        // select 2 select 26
+            [_logic,"inactiveCommands",[]] call ALIVE_fnc_hashSet;      // select 2 select 27
+            [_logic,"spawnType",[]] call ALIVE_fnc_hashSet;             // select 2 select 28
+            [_logic,"faction",[]] call ALIVE_fnc_hashSet;               // select 2 select 29
+            [_logic,"isPlayer",false] call ALIVE_fnc_hashSet;           // select 2 select 30
+            [_logic,"_rev",""] call ALIVE_fnc_hashSet;                  // select 2 select 31
+            [_logic,"_id",""] call ALIVE_fnc_hashSet;                   // select 2 select 32
+            [_logic,"busy",false] call ALIVE_fnc_hashSet;               // select 2 select 33
+        };
+
+        /*
+        VIEW - purely visual
+        */
+
+        /*
+        CONTROLLER  - coordination
+        */
+    };
+
+    case "debug": {
+        if (_args isEqualType true) then {
+            [_logic,"debug", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"debug"] call ALIVE_fnc_hashGet;
+        };
+
+        [_logic,"deleteMarkers"] call MAINCLASS;
+
+        if (_args) then {
+            [_logic,"createMarkers"] call MAINCLASS;
+        };
+    };
+
+    case "active": {
+        if (_args isEqualType true) then {
+            [_logic,"active", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"active"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "profileID": {
+        if (_args isEqualType "") then {
+            [_logic,"profileID", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"profileID"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "side": {
+        if (_args isEqualType "") then {
+            [_logic,"side", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"side"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "faction": {
+        if (_args isEqualType "") then {
+            [_logic,"faction", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"faction"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "objectType": {
+        if (_args isEqualType "") then {
+            [_logic,"objectType", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"objectType"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "companyID": {
+        if (_args isEqualType "") then {
+            [_logic,"companyID", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"companyID"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "unitClasses": {
+        if (_args isEqualType []) then {
+            [_logic,"unitClasses", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"unitClasses"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "position": {
+        if (_args isEqualType []) then {
+            if (count _args == 2) then  {
+                _args pushback 0;
+            };
+
+            if !(((_args select 0) + (_args select 1)) == 0) then {
+                private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
+
+                private _currPos = _logic select 2 select 2;
+                [_spacialGrid,"move", [_currPos, _args, _logic]] call ALiVE_fnc_spacialGrid;
+
+                [_logic,"position", _args] call ALIVE_fnc_hashSet;
+
+                if([_logic,"debug"] call ALIVE_fnc_hashGet) then {
+                    [_logic,"debug",true] call MAINCLASS;
+                };
+
+                //["ENTITY %1 position: %2",_logic select 2 select 4,_args] call ALIVE_fnc_dump;
+
+                // store position on handler position index
+                private _profileID = [_logic,"profileID"] call ALIVE_fnc_hashGet;
+                [ALIVE_profileHandler,"setPosition", [_profileID, _args]] call ALIVE_fnc_profileHandler;
+            };
+        } else {
+            _result = _logic select 2 select 2; //[_logic,"position"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "despawnPosition": {
+        if (_args isEqualType []) then {
+            [_logic,"despawnPosition", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"despawnPosition"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "positions": {
+        if (_args isEqualType []) then {
+            [_logic,"positions", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = _logic select 2 select 18; //[_logic,"positions"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "damages": {
+        if (_args isEqualType []) then {
+            [_logic,"damages", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"damages"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "ranks": {
+        if (_args isEqualType []) then {
+            [_logic,"ranks", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"ranks"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "leader": {
+        if (_args isEqualType objnull) then {
+            [_logic,"leader", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"leader"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "group": {
+        if (_args isEqualType objnull) then {
+            [_logic,"group", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"group"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "units": {
+        if (_args isEqualType []) then {
+            [_logic,"units", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"units"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "spawnType": {
+        if (_args isEqualType []) then {
+            [_logic,"spawnType", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"spawnType"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "isPlayer": {
+        if (_args isEqualType true) then {
+            [_logic,"isPlayer", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"isPlayer"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "busy": {
+        if (_args isEqualType true) then {
+            [_logic,"busy", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"busy"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "ignore_HC": {
+        if (_args isEqualType true) then {
+            [_logic,"ignore_HC", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"ignore_HC"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "unitCount": {
+        private _unitClasses = _logic select 2 select 11; //[_logic,"unitClasses"] call ALIVE_fnc_hashGet;
+        private _unitCount = count _unitClasses;
+        [_logic,"unitCount",_unitCount] call ALIVE_fnc_hashSet;
+
+        _result = _unitCount;
+    };
+
+    case "unitIndexes": {
+        private _unitCount = [_logic, "unitCount"] call MAINCLASS;
+        private _unitIndexes = [];
+
+        for "_i" from 0 to _unitCount - 1 do {
+            _unitIndexes pushback _i;
+        };
+
+        _result = _unitIndexes;
+    };
+
+    case "speedPerSecond": {
+        if (_args isEqualType []) then {
+            [_logic,"speedPerSecond",_args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"speedPerSecond"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "addVehicleAssignment": {
+        if (_args isEqualType []) then {
+            private _assignments = [_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
+            private _key = _args select 0;
+            [_assignments, _key, _args] call ALIVE_fnc_hashSet;
+
+            // take assignments and determine if this entity is in command of any of them
+            [_logic,"vehiclesInCommandOf",[_assignments,_logic] call ALIVE_fnc_profileVehicleAssignmentsGetInCommand] call ALIVE_fnc_hashSet;
+
+            // take assignments and determine if this entity is in cargo of any of them
+            [_logic,"vehiclesInCargoOf",[_assignments,_logic] call ALIVE_fnc_profileVehicleAssignmentsGetInCargo] call ALIVE_fnc_hashSet;
+
+            // take assignments and determine the max speed per second for the entire group
+            [_logic,"speedPerSecond",[_assignments,_logic] call ALIVE_fnc_profileVehicleAssignmentsGetSpeedPerSecond] call ALIVE_fnc_hashSet;
+
+            // if spawned make the unit get in
+            private _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet
+            if (_active) then {
+                [_args, _logic, true] call ALIVE_fnc_profileVehicleAssignmentToVehicleAssignment;
+            };
+        };
+    };
+
+    case "clearVehicleAssignments": {
+        // remove this entity from referenced vehicles
+        private _vehiclesInCommandOf = [_logic,"vehiclesInCommandOf",[]] call ALIVE_fnc_hashGet;
+        private _vehiclesInCargoOf = [_logic,"vehiclesInCargoOf",[]] call ALIVE_fnc_hashGet;
         {
-                deleteMarker _x;
-        } forEach ([_logic,"debugMarkers", []] call ALIVE_fnc_hashGet);
-};
+            private _vehicleProfile = [ALiVE_ProfileHandler,"getProfile",_x] call ALIVE_fnc_ProfileHandler;
 
-_createMarkers = {
-        private ["_logic","_markers","_m","_position","_dimensions","_debugColor","_debugIcon","_debugAlpha"
-        ,"_profileID","_profileSide","_profileType","_profileActive","_profileWaypoints","_typePrefix","_label",
-        "_waypointCount","_waypointPosition","_waypointCount"];
-        _logic = _this;
-        _markers = [];
+            if (!isnil "_vehicleProfile") then {
+                [_logic,_vehicleProfile] call ALIVE_fnc_removeProfileVehicleAssignment;
+            };
+        } foreach (_vehiclesInCommandOf + _vehiclesInCargoOf);
 
-        _position = [_logic,"position"] call ALIVE_fnc_hashGet;
-        _profileID = [_logic,"profileID"] call ALIVE_fnc_hashGet;
-        _profileSide = [_logic,"side"] call ALIVE_fnc_hashGet;
-        _profileType = [_logic,"objectType"] call ALIVE_fnc_hashGet;
-        _profileActive = [_logic,"active"] call ALIVE_fnc_hashGet;
-        _profileWaypoints = [_logic,"waypoints"] call ALIVE_fnc_hashGet;
+        // reset data
+        [_logic,"vehicleAssignments",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
+        [_logic,"vehiclesInCommandOf",[]] call ALIVE_fnc_hashSet;
+        [_logic,"vehiclesInCargoOf",[]] call ALIVE_fnc_hashSet;
+    };
 
+    case "insertWaypoint": {
+        if (_args isEqualType []) then {
+            private _waypoints = _logic select 2 select 16; //[_logic,"waypoints"] call ALIVE_fnc_hashGet;
+            _waypoints = [_waypoints, [_args], 0] call BIS_fnc_arrayInsert;
+            [_logic,"waypoints",_waypoints] call ALIVE_fnc_hashSet;
+
+            private _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet
+            if (_active) then {
+                private _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
+                private _unit = _units select 0;
+
+                if !(isnil "_unit") then {
+                    [_args, group _unit, true] call ALIVE_fnc_profileWaypointToWaypoint;
+                };
+            };
+            _result = _args;
+        };
+    };
+
+    case "addWaypoint": {
+        private ["_waypoints","_units","_unit","_group","_active"];
+
+        if (_args isEqualType []) then {
+            _waypoints = _logic select 2 select 16; //[_logic,"waypoints"] call ALIVE_fnc_hashGet;
+            _waypoints pushback _args;
+
+            if(([_args,"type"] call ALIVE_fnc_hashGet) == 'CYCLE') then {
+                [_logic,"isCycling",true] call ALIVE_fnc_hashSet;
+            };
+
+            _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet
+            if (_active) then {
+                _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
+                _unit = _units select 0;
+
+                if !(isnil "_unit") then {
+                    _group = group _unit;
+                    [_args, _group] call ALIVE_fnc_profileWaypointToWaypoint;
+                };
+            };
+            _result = _args;
+        };
+    };
+
+    case "clearWaypoints": {
+        [_logic,"waypoints",[]] call ALIVE_fnc_hashSet;
+        [_logic,"waypointsCompleted",[]] call ALIVE_fnc_hashSet;
+
+        private _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet
+        if (_active) then {
+            private _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
+
+            if (count _units > 0) then {
+                private _unit = _units select 0;
+                private _group = group _unit;
+                while { count (waypoints _group) > 0 } do
+                {
+                    deleteWaypoint ((waypoints _group) select 0);
+                };
+            };
+        };
+    };
+
+    case "setActiveCommand": {
+        if (_args isEqualType []) then {
+
+            [_logic, "clearActiveCommands"] call MAINCLASS;
+
+            [_logic, "addActiveCommand", _args] call MAINCLASS;
+
+            private _active = _logic select 2 select 1; //[_profile, "active"] call ALIVE_fnc_hashGet;
+            if (_active) then {
+                private _activeCommands = _logic select 2 select 26; //[_logic,"commands"] call ALIVE_fnc_hashGet;
+                [ALIVE_commandRouter, "activate", [_logic, _activeCommands]] call ALIVE_fnc_commandRouter;
+            };
+        };
+    };
+
+    case "addActiveCommand": {
+        if (_args isEqualType []) then {
+            private _type = _logic select 2 select 5;
+
+            if (!(isnil "_type") && {_type == "entity"}) then {
+
+                private _activeCommands = _logic select 2 select 26; //[_logic,"commands"] call ALIVE_fnc_hashGet;
+                _activeCommands pushback _args;
+            };
+        };
+    };
+
+    case "clearActiveCommands": {
+        private _type = _logic select 2 select 5;
+
+        if (!(isnil "_type") && {_type == "entity"}) then {
+            private _activeCommands = _logic select 2 select 26; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
+
+            if(count _activeCommands > 0) then {
+                [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
+                [_logic,"activeCommands",[]] call ALIVE_fnc_hashSet;
+            };
+        };
+    };
+
+    case "addInactiveCommand": {
+        private _type = _logic select 2 select 5;
+
+        if (!(isnil "_type") && {_type == "entity"}) then {
+            if (_args isEqualType []) then {
+                private _inactiveCommands = _logic select 2 select 27; //[_logic,"commands"] call ALIVE_fnc_hashGet;
+                _inactiveCommands pushback _args;
+            };
+        };
+    };
+
+    case "clearInactiveCommands": {
+        private _type = _logic select 2 select 5;
+
+        if (!(isnil "_type") && {_type == "entity"}) then {
+            private _inactiveCommands = _logic select 2 select 27; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
+
+            if (count _inactiveCommands > 0) then {
+                [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
+                [_logic,"inactiveCommands",[]] call ALIVE_fnc_hashSet;
+            };
+        };
+    };
+
+    case "mergePositions": {
+        private _position = _logic select 2 select 2; //[_logic,"position"] call ALIVE_fnc_hashGet;
+        private _unitCount = [_logic,"unitCount"] call MAINCLASS;
+        private _positions = _logic select 2 select 18; //[_logic,"positions"] call ALIVE_fnc_hashGet;
+
+        //["ENTITY %1 mergePosition: %2",_logic select 2 select 4,_position] call ALIVE_fnc_dump;
+
+        for "_i" from 0 to _unitCount - 1 do {
+            _positions set [_i, _position];
+        };
+    };
+
+    case "addUnit": {
+        if (_args isEqualType []) then {
+            _args params [
+                "_class",
+                ["_position", [0,0,0], [[]]],
+                ["_damage", 0, [0]],
+                ["_rank", "PRIVATE", [""]]
+            ];
+            private _unitClasses = _logic select 2 select 11;   //[_logic,"unitClasses"] call ALIVE_fnc_hashGet;
+            private _positions = _logic select 2 select 18;     //[_logic,"positions"] call ALIVE_fnc_hashGet;
+            private _damages = _logic select 2 select 19;       //[_logic,"damages"] call ALIVE_fnc_hashGet;
+            private _ranks = _logic select 2 select 20;         //[_logic,"ranks"] call ALIVE_fnc_hashGet;
+
+            _unitClasses pushback _class;
+            _positions pushback _position;
+            _damages pushback _damage;
+            _ranks pushback _rank;
+        };
+    };
+
+    case "removeUnit": {
+        if (_args isEqualType 0) then {
+            private _unitIndex = _args;
+
+            private _unitClasses = _logic select 2 select 11;   //[_logic,"unitClasses"] call ALIVE_fnc_hashGet;
+            private _positions = _logic select 2 select 18;     //[_logic,"positions"] call ALIVE_fnc_hashGet;
+            private _damages = _logic select 2 select 19;       //[_logic,"damages"] call ALIVE_fnc_hashGet;
+            private _ranks = _logic select 2 select 20;         //[_logic,"ranks"] call ALIVE_fnc_hashGet;
+            private _unitCount = _logic select 2 select 12;
+
+            _unitClasses deleteAt _unitIndex;
+            _positions deleteAt _unitIndex;
+            _damages deleteAt _unitIndex;
+            _ranks deleteAt _unitIndex;
+
+            //[_logic,"unitClasses",_unitClasses] call ALIVE_fnc_hashSet;
+            //[_logic,"positions",_positions] call ALIVE_fnc_hashSet;
+            //[_logic,"damages",_damages] call ALIVE_fnc_hashSet;
+            //[_logic,"ranks",_ranks] call ALIVE_fnc_hashSet;
+            [_logic,"unitCount", count _unitClasses] call ALiVE_fnc_hashSet; // use count to ensure unitIndex is within range
+
+            private  _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet
+            if (_active) then {
+                private _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
+                _units deleteAt _unitIndex;
+                //[_logic,"units",_units] call ALIVE_fnc_hashSet;
+
+                // update unitIndex variables
+                {_x setVariable ["profileIndex",_forEachIndex]} foreach _units;
+            };
+
+            _result = true;
+            if (_unitClasses isEqualTo []) then {
+                _result = false;
+            };
+        };
+    };
+
+    case "removeUnitByObject": {
+        if (_args isEqualType objnull) then {
+            private _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
+
+            {
+                if(_x == _args) then {
+                    _result = [_logic, "removeUnit", _forEachIndex] call MAINCLASS;
+                };
+            } forEach _units;
+        };
+    };
+
+    case "resize": {
+        private ["_newGroup"];
+
+        if (_args isEqualType 0) then {
+            private _size = _args;
+
+            private _unitClasses = _logic select 2 select 11;
+            private _active = _logic select 2 select 1;     //[_logic,"active"] call ALIVE_fnc_hashGet
+            private _units = _logic select 2 select 21;     //[_logic,"units"] call ALIVE_fnc_hashGet;
+            private _side = _logic select 2 select 3;       //[_logic, "side"] call MAINCLASS;
+            private _sideObject = [_side] call ALIVE_fnc_sideTextToObject;
+
+            if(_active) then {
+                _newGroup = createGroup _sideObject;
+            };
+
+            private _removeIndexes = [];
+
+            {
+                if((_forEachIndex + 1) > _size) then {
+
+                    if(_active) then {
+                        private _unit = _units select (_forEachIndex - 1);
+                        [_unit] joinSilent _newGroup;
+                    };
+
+                    _removeIndexes pushback (_forEachIndex - 1);
+
+                };
+            } forEach _unitClasses;
+
+            reverse _removeIndexes;
+
+            {
+                [_logic, "removeUnit", _x] call MAINCLASS;
+            } forEach _removeIndexes;
+        };
+    };
+
+    case "checkWaypointComplete": {
+        private _active = _logic select 2 select 1;
+        private _profileID = _logic select 2 select 4;
+
+        private _waypointCompleted = false;
+
+        if (_active) then {
+            private _group = _logic select 2 select 13;
+            private _leader = leader _group;
+            private _currentPosition = position _leader;
+            private _currentWaypoint = currentWaypoint _group;
+            private _waypoints = waypoints _group;
+            private _currentWaypoint = _waypoints select ((count _waypoints)-1);
+
+            if !(isNil "_currentWaypoint") then {
+
+                private _destination = waypointPosition _currentWaypoint;
+                private _completionRadius = waypointCompletionRadius _currentWaypoint;
+
+                _completionRadius = (_completionRadius * 2) + 20;
+
+                private _distance = _currentPosition distance _destination;
+
+                if(_distance < _completionRadius) then {
+                    _waypointCompleted = true;
+                };
+
+            }else{
+                _waypointCompleted = true;
+            }
+
+        } else {
+            private _waypoints = [_logic,"waypoints"] call ALIVE_fnc_hashGet;
+
+            if (count _waypoints == 0) then {
+                _waypointCompleted = true;
+            };
+        };
+
+        _result = _waypointCompleted;
+    };
+
+    case "setPosition": {
+        if (_args isEqualType []) then {
+            private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
+
+            private _currPos = _logic select 2 select 2;
+            [_spacialGrid,"move", [_currPos, _args, _logic]] call ALiVE_fnc_spacialGrid;
+
+            [_logic,"position",_args] call ALIVE_fnc_hashSet;
+
+            //["ENTITY %1 setPosition: %2",_logic select 2 select 4,_args] call ALIVE_fnc_dump;
+
+            private _active = _logic select 2 select 1; //[_profile, "active"] call ALIVE_fnc_hashGet;
+            if(_active) then {
+
+                private _group = _logic select 2 select 13;
+
+                {
+                    _x setPos _args;
+                } forEach (units _group);
+
+            };
+        };
+    };
+
+    case "spawn": {
+        private _debug = _logic select 2 select 0; //[_logic,"debug"] call ALIVE_fnc_hashGet;
+        private _profileID = _logic select 2 select 4; //[_profile,"profileID"] call ALIVE_fnc_hashGet;
+        private _side = _logic select 2 select 3; //[_logic, "side"] call MAINCLASS;
+        private _sideObject = [_side] call ALIVE_fnc_sideTextToObject;
+        private _unitClasses = _logic select 2 select 11; //[_logic,"unitClasses"] call ALIVE_fnc_hashGet;
+        private _position = _logic select 2 select 2; //[_entityProfile,"position"] call ALIVE_fnc_hashGet;
+        private _positions = _logic select 2 select 18; //[_entityProfile,"positions"] call ALIVE_fnc_hashGet;
+        private _damages = _logic select 2 select 19; //[_logic,"damages"] call ALIVE_fnc_hashGet;
+        private _ranks = _logic select 2 select 20; //[_logic,"ranks"] call ALIVE_fnc_hashGet;
+        private _active = _logic select 2 select 1; //[_profile, "active"] call ALIVE_fnc_hashGet;
+        private _waypoints = _logic select 2 select 16; //[_entityProfile,"waypoints"] call ALIVE_fnc_hashGet;
+        private _waypointsCompleted = _logic select 2 select 17; //[_entityProfile,"waypointsCompleted"] call ALIVE_fnc_hashGet;
+        private _vehicleAssignments = _logic select 2 select 7; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
+        private _activeCommands = _logic select 2 select 26; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
+        private _inactiveCommands = _logic select 2 select 27; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
+        private _vehiclesInCommandOf = _logic select 2 select 8; //[_profile,"vehiclesInCommandOf",[]] call ALIVE_fnc_hashSet;
+        private _vehiclesInCargoOf = _logic select 2 select 9; //[_profile,"vehiclesInCargoOf",[]] call ALIVE_fnc_hashSet;
+        private _locked = [_logic, "locked",false] call ALIVE_fnc_hashGet;
+        private _ignore_HC = [_logic, "ignore_HC",false] call ALIVE_fnc_hashGet;
+
+        private _formation = selectRandom ["COLUMN","STAG COLUMN","WEDGE","ECH LEFT","ECH RIGHT","VEE","LINE"];
+        private _unitCount = 0;
+        private _units = [];
+        private _paraDrop = false;
+        private _spawnOnGround = false;
+
+        // not already active and spawning has not yet been triggered
+        if (!_active && {!_locked}) then {
+
+            // Indicate profile has been despawned and unlock for asynchronous waits
+            [_logic, "locked",true] call ALIVE_fnc_HashSet;
+
+            private _group = createGroup _sideObject;
+
+            // determine a suitable spawn position
+            //["Profile [%1] Spawn - Get good spawn position",_profileID] call ALIVE_fnc_dump;
+            //[true] call ALIVE_fnc_timer;
+            [_logic] call ALIVE_fnc_profileGetGoodSpawnPosition;
+            //[] call ALIVE_fnc_timer;
+
+            _position = _logic select 2 select 2; //[_entityProfile,"position"] call ALIVE_fnc_hashGet;
+
+            //["SPAWN ENTITY [%1] pos: %2 command: %3 cargo: %4",_profileID,_position,_vehiclesInCommandOf,_vehiclesInCargoOf] call ALIVE_fnc_dump;
+
+            if (((count _vehiclesInCommandOf) == 0) && {(count _vehiclesInCargoOf) == 0}) then {
+
+                // If entity is not in a vehicle but in air give it a parachute
+                if ((_position select 2) > 300) then {
+                    _paraDrop = true;
+                };
+            } else {
+
+                // If entity is in a vehicle spawn the unit on groundlevel to avoid falling to death with slowspawn, altering pos array directly
+                if (surfaceIsWater _position) then {
+                    _position set [2,(ATLtoASL _position) select 2];
+                } else {
+                    _position set [2,0];
+                };
+
+                _spawnOnGround = true;
+            };
+
+            // ["Profile [%1] Spawn - Spawn Units",_profileID] call ALIVE_fnc_dump;
+            //[true] call ALIVE_fnc_timer;
+            {
+                if !(isnil "_x") then {
+
+                    private _unitPosition = _position;
+                    if (count _positions > 0 && {_unitCount < count _positions} && {!_spawnOnGround}) then {
+                        _unitPosition = _positions select _unitCount;
+                    };
+                    if (count _unitPosition == 2) then {_unitPosition set [2,0]};
+
+                    private _damage = 0;
+                    if (count _damages > 0 && {_unitCount < count _damages}) then {
+                        _damage = _damages select _unitCount;
+                    };
+
+                    private _rank = "PRIVATE";
+                    if (count _ranks > 0 && {_unitCount < count _ranks}) then {
+                        _rank = _ranks select _unitCount;
+                        if (_rank isEqualTo "") then {_rank = "PRIVATE"};
+                    };
+
+                    private "_unit";
+                    if (_forEachIndex == 0) then {
+
+                        _unit = _group createUnit [_x, _unitPosition, [], 0 , "NONE"];
+
+                        // select a random formation, must be at least one unit in group for formation to stick
+                        _group setFormation _formation;
+                        _group selectLeader _unit;
+
+                    } else {
+                        _unit = _group createUnit [_x, _unitPosition, [], 0 , "FORM"];
+
+                        // sadly still needed, even though "FORM" is used above :(
+                        _unit setpos (formationPosition _unit);
+                    };
+
+                    _unit allowDamage false; // allow all units to spawn first so profile isn't corrupted
+
+                    //Set name
+                    //_unit setVehicleVarName format["%1_%2",_profileID, _unitCount];
+
+                    // Set damages and rank on all units including leader and reset position
+                    _unit setposATL _unitPosition;
+                    _unit setDamage _damage;
+                    _unit setRank _rank;
+
+                    // set profile id on the unit
+                    _unit setVariable ["ALiVE_ignore_HC", _ignore_HC];
+                    _unit setVariable ["profileID", _profileID];
+                    _unit setVariable ["profileIndex", _unitCount];
+
+                    // killed event handler
+                    private _eventID = _unit addMPEventHandler["MPKilled", ALIVE_fnc_profileKilledEventHandler];
+
+                    _units pushback _unit;
+                    _unitCount = _unitCount + 1;
+
+                    if(_paraDrop) then {
+
+                        //Creating parachute on original position
+                        private _parachute = createvehicle ["Steerable_Parachute_F",_unitPosition,[],0,"none"];
+
+                        //Resetting unit to original position
+                        _unit setpos _unitPosition;
+                        _unit moveindriver _parachute;
+
+                        _parachute setdir direction _unit;
+                        _parachute setvelocity [0,0,-1];
+
+                        if (time - (missionnamespace getvariable ["bis_fnc_curatorobjectedited_paraSoundTime",0]) > 0) then {
+                            private _soundFlyover = selectRandom ["BattlefieldJet1","BattlefieldJet2"];
+                            [_parachute,_soundFlyover,"say3d"] remoteExec ["bis_fnc_sayMessage"];
+                            missionnamespace setvariable ["bis_fnc_curatorobjectedited_paraSoundTime",time + 10]
+                        };
+
+                        [_unit,_parachute] spawn {
+                            _unit = _this select 0;
+                            _parachute = _this select 1;
+
+                            waituntil {isnull _parachute || isnull _unit};
+                            _unit setdir direction _unit;
+                            deletevehicle _parachute;
+                        };
+                    };
+                };
+                sleep ALiVE_smoothSpawn;
+            } forEach _unitClasses;
+            //[] call ALIVE_fnc_timer;
+
+            // set group profile as active and store references to units on the profile
+            [_logic,"leader", leader _group] call ALIVE_fnc_hashSet;
+            [_logic,"group", _group] call ALIVE_fnc_hashSet;
+            [_logic,"units", _units] call ALIVE_fnc_hashSet;
+            [_logic,"active", true] call ALIVE_fnc_hashSet;
+
+            //["Profile [%1] Spawn - Create Waypoints",_profileID] call ALIVE_fnc_dump;
+            //[true] call ALIVE_fnc_timer;
+            // create waypoints from profile waypoints
+            _waypoints append _waypointsCompleted;
+            [_waypoints, _group] call ALIVE_fnc_profileWaypointsToWaypoints;
+            //[] call ALIVE_fnc_timer;
+
+            //["Profile [%1] Spawn - Create Vehicle Assignments",_profileID] call ALIVE_fnc_dump;
+            //[true] call ALIVE_fnc_timer;
+            // create vehicle assignments from profile vehicle assignments
+            [_vehicleAssignments, _logic] call ALIVE_fnc_profileVehicleAssignmentsToVehicleAssignments;
+            //[] call ALIVE_fnc_timer;
+
+            //["Profile [%1] Spawn - Process Commands",_profileID] call ALIVE_fnc_dump;
+            //[true] call ALIVE_fnc_timer;
+            // process commands
+            if(count _inactiveCommands > 0) then {
+                [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
+            };
+            if(count _activeCommands > 0) then {
+                [ALIVE_commandRouter, "activate", [_logic, _activeCommands]] call ALIVE_fnc_commandRouter;
+            };
+            //[] call ALIVE_fnc_timer;
+
+            //["Profile [%1] Spawn - Set Active",_profileID] call ALIVE_fnc_dump;
+            //[true] call ALIVE_fnc_timer;
+            // store the profile id on the active profiles index
+            [ALIVE_profileHandler,"setActive",[_profileID,_side,_logic]] call ALIVE_fnc_profileHandler;
+            [ALIVE_profileHandler,"setEntityActive",_profileID] call ALIVE_fnc_profileHandler;
+
+            //Remove combat flag
+            //[_logic, "combat"] call ALIVE_fnc_HashRem; // combat flag must be kept for new combat system
+
+            // Indicate profile has been spawned and unlock for asynchronous waits
+            [_logic, "locked",false] call ALIVE_fnc_HashSet;
+
+            // profile is fully spawned and cannot be corrupted
+            // allow damage again
+            {_x allowDamage true} foreach _units;
+
+            //[] call ALIVE_fnc_timer;
+
+            //["Profile [%1] Spawn - Debug",_profileID] call ALIVE_fnc_dump;
+            //[true] call ALIVE_fnc_timer;
+
+            // DEBUG -------------------------------------------------------------------------------------
+            if(_debug) then {
+                //["Profile [%1] Spawn - pos: %2",_profileID,_position] call ALIVE_fnc_dump;
+                [_logic,"debug",true] call MAINCLASS;
+            };
+            // DEBUG -------------------------------------------------------------------------------------
+
+            //[] call ALIVE_fnc_timer;
+
+        };
+    };
+
+    case "despawn": {
+        private _debug = _logic select 2 select 0;      //[_logic,"debug"] call ALIVE_fnc_hashGet;
+        private _group = _logic select 2 select 13;     //[_logic,"group"] call ALIVE_fnc_hashGet;
+        private _leader = _logic select 2 select 10;    //[_logic,"leader"] call ALIVE_fnc_hashGet;
+        private _units = _logic select 2 select 21;     //[_logic,"units"] call ALIVE_fnc_hashGet;
+        private _positions = _logic select 2 select 18; //[_logic,"positions"] call ALIVE_fnc_hashGet;
+        private _damages = _logic select 2 select 19;   //[_logic,"damages"] call ALIVE_fnc_hashGet;
+        private _ranks = _logic select 2 select 20;     //[_logic,"ranks"] call ALIVE_fnc_hashGet;
+        private _active = _logic select 2 select 1;     //[_logic,"active"] call ALIVE_fnc_hashGet;
+        private _profileID = _logic select 2 select 4;  //[_logic,"profileID"] call ALIVE_fnc_hashGet;
+        private _side = _logic select 2 select 3;       //[_logic, "side"] call MAINCLASS;
+        private _activeCommands = _logic select 2 select 26;    //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
+        private _inactiveCommands = _logic select 2 select 27;  //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
+
+        //Don't despawn player profiles
+        if ([_logic, "isPlayer",false] call ALIVE_fnc_HashGet) exitwith {};
+
+        private _unitCount = 0;
+
+        // not already inactive
+        if (_active) then {
+
+            // if any linked profiles have despawn prevented
+            private _despawnPrevented = false;
+            private _linked = [_logic] call ALIVE_fnc_vehicleAssignmentsGetLinkedProfiles;
+            //_linked call ALIVE_fnc_inspectHash;
+            if (count (_linked select 1) > 1) then {
+                {
+                    private _spawnType = [_x,"spawnType"] call ALIVE_fnc_hashGet;
+                    if (count _spawnType > 0) then {
+                        if(_spawnType select 0 == "preventDespawn") then {
+                            _despawnPrevented = true;
+                        };
+                    }
+                } forEach (_linked select 2);
+            };
+
+            if!(_despawnPrevented) then {
+
+                [_logic,"active", false] call ALIVE_fnc_hashSet;
+
+                // update profile waypoints before despawn
+                [_logic,"clearWaypoints"] call MAINCLASS;
+                [_logic,_group] call ALIVE_fnc_waypointsToProfileWaypoints;
+
+                [_logic] call ALIVE_fnc_vehicleAssignmentsToProfileVehicleAssignments;
+
+                _position = getPosATL _leader;
+
+                // update the profiles position
+                //[_logic,"position", _position] call ALIVE_fnc_hashSet;
+                [_logic,"position", _position] call MAINCLASS;
+                [_logic,"despawnPosition", _position] call ALIVE_fnc_hashSet;
+
+                // delete units
+                {
+                    private _unit = _x;
+                    _positions set [_unitCount, getPosATL _unit];
+                    _damages set [_unitCount, damage _unit];
+                    _ranks set [_unitCount, rank _unit];
+                    deleteVehicle _unit;
+                    _unitCount = _unitCount + 1;
+                } forEach _units;
+
+                // delete group
+                // FIX YOUR FUCKING CODES BIS. FINALLY. AFTER 239475987 gazillion years
+                _group call ALiVE_fnc_DeleteGroupRemote;
+
+                [_logic,"leader", objNull] call ALIVE_fnc_hashSet;
+                [_logic,"positions", _positions] call ALIVE_fnc_hashSet;
+                [_logic,"damages", _damages] call ALIVE_fnc_hashSet;
+                [_logic,"group", objNull] call ALIVE_fnc_hashSet;
+                [_logic,"units", []] call ALIVE_fnc_hashSet;
+
+                // process commands
+                if(count _activeCommands > 0) then {
+                    [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
+                };
+                if(count _inactiveCommands > 0) then {
+                    [ALIVE_commandRouter, "activate", [_logic, _inactiveCommands]] call ALIVE_fnc_commandRouter;
+                };
+
+                // store the profile id on the in active profiles index
+                [ALIVE_profileHandler,"setInActive",[_profileID,_side,_logic]] call ALIVE_fnc_profileHandler;
+                [ALIVE_profileHandler,"setEntityInActive",_profileID] call ALIVE_fnc_profileHandler;
+
+                // DEBUG -------------------------------------------------------------------------------------
+                if(_debug) then {
+                    //["Profile [%1] Despawn - pos: %2",_profileID,_position] call ALIVE_fnc_dump;
+                    [_logic,"debug",true] call MAINCLASS;
+                };
+                // DEBUG -------------------------------------------------------------------------------------
+            };
+        };
+    };
+
+    case "handleDeath": {
+        if (_args isEqualType objnull) then {
+            _result = [_logic, "removeUnitByObject", _args] call MAINCLASS;
+
+            if!(_result) then {
+                [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
+            };
+        };
+    };
+
+    case "destroy": {
+        private _debug = _logic select 2 select 0; //[_logic,"debug"] call ALIVE_fnc_hashGet;
+        private _group = _logic select 2 select 13; //[_logic,"group"] call ALIVE_fnc_hashGet;
+        private _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
+        private _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet;
+        private _profileID = _logic select 2 select 4; //[_logic,"profileID"] call ALIVE_fnc_hashGet;
+
+        private _unitCount = 0;
+
+        // DEBUG -------------------------------------------------------------------------------------
+        if(_debug) then {
+            ["Profile [%1] Destroying",_profileID] call ALIVE_fnc_dump;
+        };
+        // DEBUG -------------------------------------------------------------------------------------
+
+        // clear waypoints
+        [_logic,"clearWaypoints"] call MAINCLASS;
+
+        // clear assignments
+        [_logic,"clearVehicleAssignments"] call MAINCLASS;
+
+        // deactivate command
+        [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
+
+        // not already inactive
+        if(_active) then {
+
+            // delete units
+            {
+                private _unit = _x;
+                deleteVehicle _unit;
+                _unitCount = _unitCount + 1;
+            } forEach _units;
+
+            // delete group
+            _group call ALiVE_fnc_DeleteGroupRemote;
+        };
+
+        // unregister
+        [ALIVE_profileHandler, "unregisterProfile", _logic] call ALIVE_fnc_profileHandler;
+
+        [_logic, "destroy"] call SUPERCLASS;
+    };
+
+    case "createMarkers": {
+        private _markers = [];
+
+        private _position = [_logic,"position"] call ALIVE_fnc_hashGet;
+        private _profileID = [_logic,"profileID"] call ALIVE_fnc_hashGet;
+        private _profileSide = [_logic,"side"] call ALIVE_fnc_hashGet;
+        private _profileType = [_logic,"objectType"] call ALIVE_fnc_hashGet;
+        private _profileActive = [_logic,"active"] call ALIVE_fnc_hashGet;
+        private _profileWaypoints = [_logic,"waypoints"] call ALIVE_fnc_hashGet;
+
+        private _debugColor = [_logic,"debugColor","ColorGreen"] call ALIVE_fnc_hashGet;
+        private _typePrefix = "n";
         switch(_profileSide) do {
             case "EAST":{
                 _debugColor = "ColorRed";
@@ -192,29 +1214,28 @@ _createMarkers = {
                 _debugColor = "ColorGreen";
                 _typePrefix = "n";
             };
-            default {
-                _debugColor = [_logic,"debugColor","ColorGreen"] call ALIVE_fnc_hashGet;
-                _typePrefix = "n";
-            };
         };
 
+        private _debugIcon = format["%1_inf",_typePrefix];
+        /*
         switch(_profileType) do {
             default {
                 _debugIcon = format["%1_inf",_typePrefix];
             };
         };
+        */
 
-        _label = [_profileID, "_"] call CBA_fnc_split;
+        private _label = [_profileID, "_"] call CBA_fnc_split;
+        private _debugAlpha = 1;
 
-        _debugAlpha = 0.3;
-        if(_profileActive) then {
-            _debugAlpha = 1;
-        }else{
-            _waypointCount = 0;
+        if (!_profileActive) then {
+            _debugAlpha = 0.3;
+
+            private _waypointCount = 0;
             {
-                _waypointPosition = [_x,"position"] call ALIVE_fnc_hashGet;
+                private _waypointPosition = [_x,"position"] call ALIVE_fnc_hashGet;
 
-                _m = createMarker [format["SIM_MARKER_%1_%2",_profileID,_waypointCount], _waypointPosition];
+                private _m = createMarker [format["SIM_MARKER_%1_%2",_profileID,_waypointCount], _waypointPosition];
                 _m setMarkerShape "ICON";
                 _m setMarkerSize [.6, .6];
                 _m setMarkerType "waypoint";
@@ -225,1114 +1246,40 @@ _createMarkers = {
 
                 _markers pushback _m;
 
-                [_logic,"debugMarkers",_markers] call ALIVE_fnc_hashSet;
+                [_logic,"debugMarkers", _markers] call ALIVE_fnc_hashSet;
 
                 _waypointCount = _waypointCount + 1;
             } forEach _profileWaypoints;
         };
 
-        if(count _position > 0) then {
-                _m = createMarker [format[MTEMPLATE, format["%1_debug",_profileID]], _position];
-                _m setMarkerShape "ICON";
-                _m setMarkerSize [.4, .4];
-                _m setMarkerType _debugIcon;
-                _m setMarkerColor _debugColor;
-                _m setMarkerAlpha _debugAlpha;
+        if (count _position > 0) then {
+            private _m = createMarker [format[MTEMPLATE, format["%1_debug",_profileID]], _position];
+            _m setMarkerShape "ICON";
+            _m setMarkerSize [.4, .4];
+            _m setMarkerType _debugIcon;
+            _m setMarkerColor _debugColor;
+            _m setMarkerAlpha _debugAlpha;
 
-                _m setMarkerText format["e%1",_label select ((count _label) - 1)];
+            _m setMarkerText format["e%1",_label select ((count _label) - 1)];
 
-                _markers pushback _m;
+            _markers pushback _m;
 
-                [_logic,"debugMarkers",_markers] call ALIVE_fnc_hashSet;
+            [_logic,"debugMarkers", _markers] call ALIVE_fnc_hashSet;
         };
+    };
+
+    case "deleteMarkers": {
+        {
+            deleteMarker _x;
+        } forEach ([_logic,"debugMarkers", []] call ALIVE_fnc_hashGet);
+    };
+
+    default {
+        _result = [_logic, _operation, _args] call SUPERCLASS;
+    };
+
 };
 
-switch(_operation) do {
-        case "init": {
-                /*
-                MODEL - no visual just reference data
-                - nodes
-                - center
-                - size
-                */
-
-                if (isServer) then {
-                    // if server, initialise module game logic
-                    // nil these out they add a lot of code to the hash..
-                    [_logic,"super"] call ALIVE_fnc_hashRem;
-                    [_logic,"class"] call ALIVE_fnc_hashRem;
-                    //TRACE_1("After module init",_logic);
-
-                    // init the super class
-                    [_logic, "init"] call SUPERCLASS;
-
-                    // set defaults
-                    [_logic,"type","entity"] call ALIVE_fnc_hashSet; // select 2 select 5
-                    [_logic,"vehiclesInCommandOf",[]] call ALIVE_fnc_hashSet; // select 2 select 8
-                    [_logic,"vehiclesInCargoOf",[]] call ALIVE_fnc_hashSet; // select 2 select 9
-                    [_logic,"leader",objNull] call ALIVE_fnc_hashSet; // select 2 select 10
-                    [_logic,"unitClasses",[]] call ALIVE_fnc_hashSet; // select 2 select 11
-                    [_logic,"unitCount",0] call ALIVE_fnc_hashSet; // select 2 select 12
-                    [_logic,"group",grpNull] call ALIVE_fnc_hashSet; // select 2 select 13
-                    [_logic,"companyID",""] call ALIVE_fnc_hashSet; // select 2 select 14
-                    [_logic,"groupID",""] call ALIVE_fnc_hashSet; // select 2 select 15
-                    [_logic,"waypoints",[]] call ALIVE_fnc_hashSet; // select 2 select 16
-                    [_logic,"waypointsCompleted",[]] call ALIVE_fnc_hashSet; // select 2 select 17
-                    [_logic,"positions",[]] call ALIVE_fnc_hashSet; // select 2 select 18
-                    [_logic,"damages",[]] call ALIVE_fnc_hashSet; // select 2 select 19
-                    [_logic,"ranks",[]] call ALIVE_fnc_hashSet; // select 2 select 20
-                    [_logic,"units",[]] call ALIVE_fnc_hashSet; // select 2 select 21
-                    [_logic,"speedPerSecond","Man" call ALIVE_fnc_vehicleGetSpeedPerSecond] call ALIVE_fnc_hashSet; // select 2 select 22
-                    [_logic,"despawnPosition",[0,0]] call ALIVE_fnc_hashSet; // select 2 select 23
-                    [_logic,"hasSimulated",false] call ALIVE_fnc_hashSet; // select 2 select 24
-                    [_logic,"isCycling",false] call ALIVE_fnc_hashSet; // select 2 select 25
-                    [_logic,"activeCommands",[]] call ALIVE_fnc_hashSet; // select 2 select 26
-                    [_logic,"inactiveCommands",[]] call ALIVE_fnc_hashSet; // select 2 select 27
-                    [_logic,"spawnType",[]] call ALIVE_fnc_hashSet; // select 2 select 28
-                    [_logic,"faction",[]] call ALIVE_fnc_hashSet; // select 2 select 29
-                    [_logic,"isPlayer",false] call ALIVE_fnc_hashSet; // select 2 select 30
-                    [_logic,"_rev",""] call ALIVE_fnc_hashSet; // select 2 select 31
-                    [_logic,"_id",""] call ALIVE_fnc_hashSet; // select 2 select 32
-                    [_logic,"busy",false] call ALIVE_fnc_hashSet; // select 2 select 33
-                };
-
-                /*
-                VIEW - purely visual
-                */
-
-                /*
-                CONTROLLER  - coordination
-                */
-        };
-        case "debug": {
-                if(typeName _args != "BOOL") then {
-                        _args = [_logic,"debug"] call ALIVE_fnc_hashGet;
-                } else {
-                        [_logic,"debug",_args] call ALIVE_fnc_hashSet;
-                };
-                ASSERT_TRUE(typeName _args == "BOOL",str _args);
-
-                 _logic call _deleteMarkers;
-
-                if(_args) then {
-                        _logic call _createMarkers;
-                };
-
-                _result = _args;
-        };
-        case "active": {
-                if(typeName _args == "BOOL") then {
-                        [_logic,"active",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"active"] call ALIVE_fnc_hashGet;
-        };
-        case "profileID": {
-                if(typeName _args == "STRING") then {
-                        [_logic,"profileID",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"profileID"] call ALIVE_fnc_hashGet;
-        };
-        case "side": {
-                if(typeName _args == "STRING") then {
-                        [_logic,"side",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"side"] call ALIVE_fnc_hashGet;
-        };
-        case "faction": {
-                if(typeName _args == "STRING") then {
-                        [_logic,"faction",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"faction"] call ALIVE_fnc_hashGet;
-        };
-        case "objectType": {
-                if(typeName _args == "STRING") then {
-                        [_logic,"objectType",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"objectType"] call ALIVE_fnc_hashGet;
-        };
-        case "companyID": {
-                if(typeName _args == "STRING") then {
-                        [_logic,"companyID",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"companyID"] call ALIVE_fnc_hashGet;
-        };
-        case "unitClasses": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"unitClasses",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"unitClasses"] call ALIVE_fnc_hashGet;
-        };
-        case "position": {
-                private ["_profileID"];
-
-                if(typeName _args == "ARRAY") then {
-
-                        if(count _args == 2) then  {
-                            _args pushback 0;
-                        };
-
-                        if!(((_args select 0) + (_args select 1)) == 0) then {
-                            private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
-
-                            private _currPos = _logic select 2 select 2;
-                            [_spacialGrid,"move", [_currPos, _args, _logic]] call ALiVE_fnc_spacialGrid;
-
-                            [_logic,"position",_args] call ALIVE_fnc_hashSet;
-
-                            if([_logic,"debug"] call ALIVE_fnc_hashGet) then {
-                                [_logic,"debug",true] call MAINCLASS;
-                            };
-
-                            //["ENTITY %1 position: %2",_logic select 2 select 4,_args] call ALIVE_fnc_dump;
-
-                            // store position on handler position index
-                            _profileID = [_logic,"profileID"] call ALIVE_fnc_hashGet;
-                            [ALIVE_profileHandler, "setPosition", [_profileID, _args]] call ALIVE_fnc_profileHandler;
-                        };
-
-                };
-                _result = _logic select 2 select 2; //[_logic,"position"] call ALIVE_fnc_hashGet;
-        };
-        case "despawnPosition": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"despawnPosition",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"despawnPosition"] call ALIVE_fnc_hashGet;
-        };
-        case "positions": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"positions",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = _logic select 2 select 18; //[_logic,"positions"] call ALIVE_fnc_hashGet;
-        };
-        case "damages": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"damages",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"damages"] call ALIVE_fnc_hashGet;
-        };
-        case "ranks": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"ranks",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"ranks"] call ALIVE_fnc_hashGet;
-        };
-        case "leader": {
-                if(typeName _args == "OBJECT") then {
-                        [_logic,"leader",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"leader"] call ALIVE_fnc_hashGet;
-        };
-        case "group": {
-                if(typeName _args == "OBJECT") then {
-                        [_logic,"group",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"group"] call ALIVE_fnc_hashGet;
-        };
-        case "units": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"units",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"units"] call ALIVE_fnc_hashGet;
-        };
-        case "spawnType": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"spawnType",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"spawnType"] call ALIVE_fnc_hashGet;
-        };
-        case "isPlayer": {
-                if(typeName _args == "BOOL") then {
-                        [_logic,"isPlayer",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"isPlayer"] call ALIVE_fnc_hashGet;
-        };
-        case "busy": {
-                if(typeName _args == "BOOL") then {
-                        [_logic,"busy",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"busy"] call ALIVE_fnc_hashGet;
-        };
-        case "ignore_HC": {
-                if(typeName _args == "BOOL") then {
-                        [_logic,"ignore_HC",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"ignore_HC"] call ALIVE_fnc_hashGet;
-        };
-        case "unitCount": {
-                private ["_unitClasses","_unitCount"];
-                _unitClasses = _logic select 2 select 11; //[_logic,"unitClasses"] call ALIVE_fnc_hashGet;
-                _unitCount = count _unitClasses;
-                [_logic,"unitCount",_unitCount] call ALIVE_fnc_hashSet;
-
-                _result = _unitCount;
-        };
-        case "unitIndexes": {
-                private ["_unitIndexes","_unitCount"];
-                _unitCount = [_logic, "unitCount"] call MAINCLASS;
-                _unitIndexes = [];
-                for "_i" from 0 to _unitCount-1 do {
-                    _unitIndexes set [_i, _i];
-                };
-
-                _result = _unitIndexes;
-        };
-        case "speedPerSecond": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"speedPerSecond",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"speedPerSecond"] call ALIVE_fnc_hashGet;
-        };
-        case "addVehicleAssignment": {
-                private ["_assignments","_key","_active"];
-
-                if(typeName _args == "ARRAY") then {
-                        _assignments = [_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
-                        _key = _args select 0;
-                        [_assignments, _key, _args] call ALIVE_fnc_hashSet;
-
-                        // take assignments and determine if this entity is in command of any of them
-                        [_logic,"vehiclesInCommandOf",[_assignments,_logic] call ALIVE_fnc_profileVehicleAssignmentsGetInCommand] call ALIVE_fnc_hashSet;
-
-                        // take assignments and determine if this entity is in cargo of any of them
-                        [_logic,"vehiclesInCargoOf",[_assignments,_logic] call ALIVE_fnc_profileVehicleAssignmentsGetInCargo] call ALIVE_fnc_hashSet;
-
-                        // take assignments and determine the max speed per second for the entire group
-                        [_logic,"speedPerSecond",[_assignments,_logic] call ALIVE_fnc_profileVehicleAssignmentsGetSpeedPerSecond] call ALIVE_fnc_hashSet;
-
-                        // if spawned make the unit get in
-                        _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet
-                        if(_active) then {
-                            [_args, _logic, true] call ALIVE_fnc_profileVehicleAssignmentToVehicleAssignment;
-                        };
-                };
-        };
-        case "clearVehicleAssignments": {
-
-                // remove this entity from referenced vehicles
-                private _vehiclesInCommandOf = [_logic,"vehiclesInCommandOf",[]] call ALIVE_fnc_hashGet;
-                private _vehiclesInCargoOf = [_logic,"vehiclesInCargoOf",[]] call ALIVE_fnc_hashGet;
-                {
-                    private _vehicleProfile = [ALiVE_ProfileHandler,"getProfile",_x] call ALIVE_fnc_ProfileHandler;
-
-                    if (!isnil "_vehicleProfile") then {
-                        [_logic,_vehicleProfile] call ALIVE_fnc_removeProfileVehicleAssignment;
-                    };
-                } foreach (_vehiclesInCommandOf + _vehiclesInCargoOf);
-
-                // reset data
-                [_logic,"vehicleAssignments",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                [_logic,"vehiclesInCommandOf",[]] call ALIVE_fnc_hashSet;
-                [_logic,"vehiclesInCargoOf",[]] call ALIVE_fnc_hashSet;
-        };
-        case "insertWaypoint": {
-                private ["_waypoints","_units","_unit","_group","_active"];
-
-                if(typeName _args == "ARRAY") then {
-                        _waypoints = _logic select 2 select 16; //[_logic,"waypoints"] call ALIVE_fnc_hashGet;
-                        _waypoints = [_waypoints, [_args], 0] call BIS_fnc_arrayInsert;
-                        [_logic,"waypoints",_waypoints] call ALIVE_fnc_hashSet;
-
-                        _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet
-                        if(_active) then {
-                            _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
-                            _unit = _units select 0;
-
-                            if !(isnil "_unit") then {
-                                _group = group _unit;
-                                [_args, _group, true] call ALIVE_fnc_profileWaypointToWaypoint;
-                            };
-                        };
-                        _result = _args;
-                };
-        };
-        case "addWaypoint": {
-                private ["_waypoints","_units","_unit","_group","_active"];
-
-                if(typeName _args == "ARRAY") then {
-                        _waypoints = _logic select 2 select 16; //[_logic,"waypoints"] call ALIVE_fnc_hashGet;
-                        _waypoints pushback _args;
-
-                        if(([_args,"type"] call ALIVE_fnc_hashGet) == 'CYCLE') then {
-                            [_logic,"isCycling",true] call ALIVE_fnc_hashSet;
-                        };
-
-                        _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet
-                        if(_active) then {
-                            _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
-                            _unit = _units select 0;
-
-                            if !(isnil "_unit") then {
-                                _group = group _unit;
-                                [_args, _group] call ALIVE_fnc_profileWaypointToWaypoint;
-                            };
-                        };
-                        _result = _args;
-                };
-        };
-        case "clearWaypoints": {
-                private ["_units","_unit","_group","_active"];
-
-                [_logic,"waypoints",[]] call ALIVE_fnc_hashSet;
-                [_logic,"waypointsCompleted",[]] call ALIVE_fnc_hashSet;
-
-                _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet
-                if(_active) then {
-                        _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
-
-                        if (count _units > 0) then {
-	                        _unit = _units select 0;
-	                        _group = group _unit;
-	                        while { count (waypoints _group) > 0 } do
-	                        {
-	                            deleteWaypoint ((waypoints _group) select 0);
-	                        };
-                        };
-                };
-        };
-        case "setActiveCommand": {
-                private ["_activeCommands","_type","_active"];
-
-                if(typeName _args == "ARRAY") then {
-
-                    [_logic, "clearActiveCommands"] call MAINCLASS;
-
-                    [_logic, "addActiveCommand", _args] call MAINCLASS;
-
-                    _active = _logic select 2 select 1; //[_profile, "active"] call ALIVE_fnc_hashGet;
-
-                    if(_active) then {
-                        _activeCommands = _logic select 2 select 26; //[_logic,"commands"] call ALIVE_fnc_hashGet;
-                        [ALIVE_commandRouter, "activate", [_logic, _activeCommands]] call ALIVE_fnc_commandRouter;
-                    };
-                };
-        };
-        case "addActiveCommand": {
-                private ["_activeCommands","_type"];
-
-                if(typeName _args == "ARRAY") then {
-
-                    _type = _logic select 2 select 5;
-
-                    if (!(isnil "_type") && {_type == "entity"}) then {
-
-                        _activeCommands = _logic select 2 select 26; //[_logic,"commands"] call ALIVE_fnc_hashGet;
-                        _activeCommands pushback _args;
-                    };
-                };
-        };
-        case "clearActiveCommands": {
-                private ["_activeCommands","_type"];
-
-                _type = _logic select 2 select 5;
-
-                if (!(isnil "_type") && {_type == "entity"}) then {
-                    _activeCommands = _logic select 2 select 26; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
-
-                    if(count _activeCommands > 0) then {
-                        [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
-                        [_logic,"activeCommands",[]] call ALIVE_fnc_hashSet;
-                    };
-                };
-        };
-        case "addInactiveCommand": {
-                private ["_inactiveCommands","_type"];
-
-                _type = _logic select 2 select 5;
-
-                if (!(isnil "_type") && {_type == "entity"}) then {
-                    if(typeName _args == "ARRAY") then {
-                            _inactiveCommands = _logic select 2 select 27; //[_logic,"commands"] call ALIVE_fnc_hashGet;
-                            _inactiveCommands pushback _args;
-                    };
-                };
-        };
-        case "clearInactiveCommands": {
-                private ["_inactiveCommands","_type"];
-
-                _type = _logic select 2 select 5;
-
-                if (!(isnil "_type") && {_type == "entity"}) then {
-                    _inactiveCommands = _logic select 2 select 27; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
-
-                    if(count _inactiveCommands > 0) then {
-                        [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
-                        [_logic,"inactiveCommands",[]] call ALIVE_fnc_hashSet;
-                    };
-                };
-        };
-        case "mergePositions": {
-                private ["_position","_unitCount","_positions"];
-
-                _position = _logic select 2 select 2; //[_logic,"position"] call ALIVE_fnc_hashGet;
-                _unitCount = [_logic,"unitCount"] call MAINCLASS;
-                _positions = _logic select 2 select 18; //[_logic,"positions"] call ALIVE_fnc_hashGet;
-
-                //["ENTITY %1 mergePosition: %2",_logic select 2 select 4,_position] call ALIVE_fnc_dump;
-
-                for "_i" from 0 to _unitCount-1 do
-                {
-                        _positions set [_i, _position];
-                };
-        };
-        case "addUnit": {
-                private ["_class","_position","_damage","_rank","_unitIndex","_unitClasses","_positions","_damages","_ranks"];
-
-                if(typeName _args == "ARRAY") then {
-                        _args params [
-                            "_class",
-                            ["_position", [0,0,0], [[]]],
-                            ["_damage", 0, [0]],
-                            ["_rank", "PRIVATE", [""]]
-                        ];
-                        _unitClasses = _logic select 2 select 11;   //[_logic,"unitClasses"] call ALIVE_fnc_hashGet;
-                        _positions = _logic select 2 select 18;     //[_logic,"positions"] call ALIVE_fnc_hashGet;
-                        _damages = _logic select 2 select 19;       //[_logic,"damages"] call ALIVE_fnc_hashGet;
-                        _ranks = _logic select 2 select 20;         //[_logic,"ranks"] call ALIVE_fnc_hashGet;
-
-                        _unitIndex = count _unitClasses;
-
-                        _unitClasses set [_unitIndex, _class];
-                        _positions set [_unitIndex, _position];
-                        _damages set [_unitIndex, _damage];
-                        _ranks set [_unitIndex, _rank];
-                };
-        };
-        case "removeUnit": {
-                private ["_unitIndex","_damages","_ranks","_units","_unitClasses","_positions","_active"];
-
-                if(typeName _args == "SCALAR") then {
-
-                        _unitIndex = _args;
-                        _unitClasses = _logic select 2 select 11;   //[_logic,"unitClasses"] call ALIVE_fnc_hashGet;
-                        _positions = _logic select 2 select 18;     //[_logic,"positions"] call ALIVE_fnc_hashGet;
-                        _damages = _logic select 2 select 19;       //[_logic,"damages"] call ALIVE_fnc_hashGet;
-                        _ranks = _logic select 2 select 20;         //[_logic,"ranks"] call ALIVE_fnc_hashGet;
-                        _unitCount = _logic select 2 select 12;
-
-                        _unitClasses deleteAt _unitIndex;
-                        _positions deleteAt _unitIndex;
-                        _damages deleteAt _unitIndex;
-                        _ranks deleteAt _unitIndex;
-
-                        //[_logic,"unitClasses",_unitClasses] call ALIVE_fnc_hashSet;
-                        //[_logic,"positions",_positions] call ALIVE_fnc_hashSet;
-                        //[_logic,"damages",_damages] call ALIVE_fnc_hashSet;
-                        //[_logic,"ranks",_ranks] call ALIVE_fnc_hashSet;
-                        [_logic,"unitCount", count _unitClasses] call ALiVE_fnc_hashSet; // use count to ensure unitIndex is within range
-
-                        _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet
-                        if(_active) then {
-                            _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
-                            _units deleteAt _unitIndex;
-                            //[_logic,"units",_units] call ALIVE_fnc_hashSet;
-
-                            // update unitIndex variables
-                            {_x setVariable ["profileIndex",_forEachIndex]} foreach _units;
-                        };
-
-                        _result = true;
-                        if(count(_unitClasses) == 0) then {
-                            _result = false;
-                        };
-                };
-        };
-        case "removeUnitByObject": {
-                private ["_units"];
-
-                if(typeName _args == "OBJECT") then {
-                    _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
-                    {
-                        if(_x == _args) then {
-                            _result = [_logic, "removeUnit", _forEachIndex] call MAINCLASS;
-                        };
-                    } forEach _units;
-                };
-        };
-        case "resize": {
-                private ["_size","_unitClasses","_active","_units","_side","_sideObject","_newGroup","_unit","_removeIndexes"];
-
-                if(typeName _args == "SCALAR") then {
-                        _size = _args;
-
-                        _unitClasses = _logic select 2 select 11;
-                        _active = _logic select 2 select 1;     //[_logic,"active"] call ALIVE_fnc_hashGet
-                        _units = _logic select 2 select 21;     //[_logic,"units"] call ALIVE_fnc_hashGet;
-                        _side = _logic select 2 select 3;       //[_logic, "side"] call MAINCLASS;
-                        _sideObject = [_side] call ALIVE_fnc_sideTextToObject;
-
-                        if(_active) then {
-                            _newGroup = createGroup _sideObject;
-                        };
-
-                        _removeIndexes = [];
-
-                        {
-                            if((_forEachIndex + 1) > _size) then {
-
-                                if(_active) then {
-                                    _unit = _units select (_forEachIndex - 1);
-                                    [_unit] joinSilent _newGroup;
-                                };
-
-                                _removeIndexes pushback (_forEachIndex - 1);
-
-                            };
-                        } forEach _unitClasses;
-
-                        reverse _removeIndexes;
-
-                        {
-                            [_logic, "removeUnit", _x] call MAINCLASS;
-                        } forEach _removeIndexes;
-
-                };
-        };
-        case "checkWaypointComplete": {
-
-                private ["_debug","_active","_profileID","_waypointCompleted"];
-
-                _debug = [_logic, "debug"] call MAINCLASS;
-
-                _active = _logic select 2 select 1;
-                _profileID = _logic select 2 select 4;
-
-                _waypointCompleted = false;
-
-                if(_active) then {
-                    private ["_group","_leader","_currentPosition","_currentWaypoint","_waypoints","_waypointCount",
-                    "_destination","_completionRadius","_distance"];
-
-                    _group = _logic select 2 select 13;
-                    _leader = leader _group;
-                    _currentPosition = position _leader;
-                    _currentWaypoint = currentWaypoint _group;
-                    _waypoints = waypoints _group;
-                    _currentWaypoint = _waypoints select ((count _waypoints)-1);
-
-                    if!(isNil "_currentWaypoint") then {
-
-                        _destination = waypointPosition _currentWaypoint;
-                        _completionRadius = waypointCompletionRadius _currentWaypoint;
-
-                        _completionRadius = (_completionRadius * 2) + 20;
-
-                        _distance = _currentPosition distance _destination;
-
-                        if(_distance < _completionRadius) then {
-                            _waypointCompleted = true;
-                        };
-
-                    }else{
-                        _waypointCompleted = true;
-                    }
-
-                } else {
-                    private ["_waypoints"];
-
-                    _waypoints = [_logic,"waypoints"] call ALIVE_fnc_hashGet;
-
-                    if(count _waypoints == 0) then {
-                        _waypointCompleted = true;
-                    };
-                };
-
-                _result = _waypointCompleted;
-
-        };
-        case "setPosition": {
-
-            private ["_active","_group"];
-
-            if(typeName _args == "ARRAY") then {
-
-                private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
-
-                private _currPos = _logic select 2 select 2;
-                [_spacialGrid,"move", [_currPos, _args, _logic]] call ALiVE_fnc_spacialGrid;
-
-                [_logic,"position",_args] call ALIVE_fnc_hashSet;
-
-                //["ENTITY %1 setPosition: %2",_logic select 2 select 4,_args] call ALIVE_fnc_dump;
-
-                _active = _logic select 2 select 1; //[_profile, "active"] call ALIVE_fnc_hashGet;
-
-                if(_active) then {
-
-                    _group = _logic select 2 select 13;
-
-                    {
-                        _x setPos _args;
-                    } forEach (units _group);
-
-                };
-            };
-        };
-        case "spawn": {
-                private [
-                    "_debug","_side","_sideObject","_unitClasses","_unitClass","_position","_positions",
-                    "_damage","_damages","_ranks","_rank","_profileID","_active","_waypoints","_waypointsCompleted",
-                    "_vehicleAssignments","_activeCommands","_inactiveCommands","_group","_unitPosition","_eventID",
-                    "_waypointCount","_unitCount","_units","_unit","_vehiclesInCommandOf","_vehiclesInCargoOf",
-                    "_paraDrop","_parachute","_soundFlyover","_formations","_formation","_locked","_formationPosition"
-                ];
-
-                _debug = _logic select 2 select 0; //[_logic,"debug"] call ALIVE_fnc_hashGet;
-                _profileID = _logic select 2 select 4; //[_profile,"profileID"] call ALIVE_fnc_hashGet;
-                _side = _logic select 2 select 3; //[_logic, "side"] call MAINCLASS;
-                _sideObject = [_side] call ALIVE_fnc_sideTextToObject;
-                _unitClasses = _logic select 2 select 11; //[_logic,"unitClasses"] call ALIVE_fnc_hashGet;
-                _position = _logic select 2 select 2; //[_entityProfile,"position"] call ALIVE_fnc_hashGet;
-                _positions = _logic select 2 select 18; //[_entityProfile,"positions"] call ALIVE_fnc_hashGet;
-                _damages = _logic select 2 select 19; //[_logic,"damages"] call ALIVE_fnc_hashGet;
-                _ranks = _logic select 2 select 20; //[_logic,"ranks"] call ALIVE_fnc_hashGet;
-                _active = _logic select 2 select 1; //[_profile, "active"] call ALIVE_fnc_hashGet;
-                _waypoints = _logic select 2 select 16; //[_entityProfile,"waypoints"] call ALIVE_fnc_hashGet;
-                _waypointsCompleted = _logic select 2 select 17; //[_entityProfile,"waypointsCompleted"] call ALIVE_fnc_hashGet;
-                _vehicleAssignments = _logic select 2 select 7; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
-                _activeCommands = _logic select 2 select 26; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
-                _inactiveCommands = _logic select 2 select 27; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
-                _vehiclesInCommandOf = _logic select 2 select 8; //[_profile,"vehiclesInCommandOf",[]] call ALIVE_fnc_hashSet;
-                _vehiclesInCargoOf = _logic select 2 select 9; //[_profile,"vehiclesInCargoOf",[]] call ALIVE_fnc_hashSet;
-                _locked = [_logic, "locked",false] call ALIVE_fnc_hashGet;
-                _ignore_HC = [_logic, "ignore_HC",false] call ALIVE_fnc_hashGet;
-
-                _formation = selectRandom ["COLUMN","STAG COLUMN","WEDGE","ECH LEFT","ECH RIGHT","VEE","LINE"];
-                _unitCount = 0;
-                _units = [];
-                _paraDrop = false;
-                _spawnOnGround = false;
-
-                // not already active and spawning has not yet been triggered
-                if (!_active && {!_locked}) then {
-
-                    // Indicate profile has been despawned and unlock for asynchronous waits
-                    [_logic, "locked",true] call ALIVE_fnc_HashSet;
-
-                    _group = createGroup _sideObject;
-
-                    // determine a suitable spawn position
-                    //["Profile [%1] Spawn - Get good spawn position",_profileID] call ALIVE_fnc_dump;
-                    //[true] call ALIVE_fnc_timer;
-                    [_logic] call ALIVE_fnc_profileGetGoodSpawnPosition;
-                    //[] call ALIVE_fnc_timer;
-
-                    _position = _logic select 2 select 2; //[_entityProfile,"position"] call ALIVE_fnc_hashGet;
-
-                    //["SPAWN ENTITY [%1] pos: %2 command: %3 cargo: %4",_profileID,_position,_vehiclesInCommandOf,_vehiclesInCargoOf] call ALIVE_fnc_dump;
-
-                    if (((count _vehiclesInCommandOf) == 0) && {(count _vehiclesInCargoOf) == 0}) then {
-
-                        // If entity is not in a vehicle but in air give it a parachute
-                        if ((_position select 2) > 300) then {
-	                    	_paraDrop = true;
-	                    };
-                    } else {
-
-                        // If entity is in a vehicle spawn the unit on groundlevel to avoid falling to death with slowspawn, altering pos array directly
-                        if (surfaceIsWater _position) then {
-                            _position set [2,(ATLtoASL _position) select 2];
-                        } else {
-                            _position set [2,0];
-                        };
-
-                        _spawnOnGround = true;
-                    };
-
-                    // ["Profile [%1] Spawn - Spawn Units",_profileID] call ALIVE_fnc_dump;
-                    //[true] call ALIVE_fnc_timer;
-                    {
-                        if !(isnil "_x") then {
-
-                            if (count _positions > 0 && {_unitCount < count _positions} && {!_spawnOnGround}) then {
-                                _unitPosition = _positions select _unitCount;
-                            } else {
-                                _unitPosition = _position;
-                            };
-                            if (count _unitPosition == 2) then {_unitPosition set [2,0]};
-
-                            if (count _damages > 0 && {_unitCount < count _damages}) then {
-                                _damage = _damages select _unitCount;
-                            } else {
-                                _damage = 0;
-                            };
-
-                            if (count _ranks > 0 && {_unitCount < count _ranks}) then {
-                                _rank = _ranks select _unitCount;
-                                if (_rank isEqualTo "") then {_rank = "PRIVATE"};
-                            } else {
-                                _rank = "PRIVATE";
-                            };
-
-                            if (_forEachIndex == 0) then {
-
-                                _unit = _group createUnit [_x, _unitPosition, [], 0 , "NONE"];
-
-                                // select a random formation, must be at least one unit in group for formation to stick
-                                _group setFormation _formation;
-                                _group selectLeader _unit;
-
-                            } else {
-                                _unit = _group createUnit [_x, _unitPosition, [], 0 , "FORM"];
-
-                                // sadly still needed, even though "FORM" is used above :(
-                                _unit setpos (formationPosition _unit);
-                            };
-
-                            _unit allowDamage false; // allow all units to spawn first so profile isn't corrupted
-
-                            //Set name
-                            //_unit setVehicleVarName format["%1_%2",_profileID, _unitCount];
-
-                            // Set damages and rank on all units including leader and reset position
-                            _unit setposATL _unitPosition;
-                            _unit setDamage _damage;
-                            _unit setRank _rank;
-
-                            // set profile id on the unit
-                            _unit setVariable ["ALiVE_ignore_HC", _ignore_HC];
-                            _unit setVariable ["profileID", _profileID];
-                            _unit setVariable ["profileIndex", _unitCount];
-
-                            // killed event handler
-                            _eventID = _unit addMPEventHandler["MPKilled", ALIVE_fnc_profileKilledEventHandler];
-
-                            _units pushback _unit;
-                            _unitCount = _unitCount + 1;
-
-                            if(_paraDrop) then {
-
-                                //Creating parachute on original position
-                                _parachute = createvehicle ["Steerable_Parachute_F",_unitPosition,[],0,"none"];
-
-                                //Resetting unit to original position
-                                _unit setpos _unitPosition;
-                                _unit moveindriver _parachute;
-
-                                _parachute setdir direction _unit;
-                                _parachute setvelocity [0,0,-1];
-
-                                if (time - (missionnamespace getvariable ["bis_fnc_curatorobjectedited_paraSoundTime",0]) > 0) then {
-                                    _soundFlyover = selectRandom ["BattlefieldJet1","BattlefieldJet2"];
-                                    [_parachute,_soundFlyover,"say3d"] remoteExec ["bis_fnc_sayMessage"];
-                                    missionnamespace setvariable ["bis_fnc_curatorobjectedited_paraSoundTime",time + 10]
-                                };
-
-                                [_unit,_parachute] spawn {
-                                    _unit = _this select 0;
-                                    _parachute = _this select 1;
-
-                                    waituntil {isnull _parachute || isnull _unit};
-                                    _unit setdir direction _unit;
-                                    deletevehicle _parachute;
-                                };
-                            };
-                        };
-                        sleep ALiVE_smoothSpawn;
-                    } forEach _unitClasses;
-                    //[] call ALIVE_fnc_timer;
-
-                    // set group profile as active and store references to units on the profile
-                    [_logic,"leader", leader _group] call ALIVE_fnc_hashSet;
-                    [_logic,"group", _group] call ALIVE_fnc_hashSet;
-                    [_logic,"units", _units] call ALIVE_fnc_hashSet;
-                    [_logic,"active", true] call ALIVE_fnc_hashSet;
-
-                    //["Profile [%1] Spawn - Create Waypoints",_profileID] call ALIVE_fnc_dump;
-                    //[true] call ALIVE_fnc_timer;
-                    // create waypoints from profile waypoints
-                    _waypoints append _waypointsCompleted;
-                    [_waypoints, _group] call ALIVE_fnc_profileWaypointsToWaypoints;
-                    //[] call ALIVE_fnc_timer;
-
-                    //["Profile [%1] Spawn - Create Vehicle Assignments",_profileID] call ALIVE_fnc_dump;
-                    //[true] call ALIVE_fnc_timer;
-                    // create vehicle assignments from profile vehicle assignments
-                    [_vehicleAssignments, _logic] call ALIVE_fnc_profileVehicleAssignmentsToVehicleAssignments;
-                    //[] call ALIVE_fnc_timer;
-
-                    //["Profile [%1] Spawn - Process Commands",_profileID] call ALIVE_fnc_dump;
-                    //[true] call ALIVE_fnc_timer;
-                    // process commands
-                    if(count _inactiveCommands > 0) then {
-                        [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
-                    };
-                    if(count _activeCommands > 0) then {
-                        [ALIVE_commandRouter, "activate", [_logic, _activeCommands]] call ALIVE_fnc_commandRouter;
-                    };
-                    //[] call ALIVE_fnc_timer;
-
-                    //["Profile [%1] Spawn - Set Active",_profileID] call ALIVE_fnc_dump;
-                    //[true] call ALIVE_fnc_timer;
-                    // store the profile id on the active profiles index
-                    [ALIVE_profileHandler,"setActive",[_profileID,_side,_logic]] call ALIVE_fnc_profileHandler;
-                    [ALIVE_profileHandler,"setEntityActive",_profileID] call ALIVE_fnc_profileHandler;
-
-                    //Remove combat flag
-                    //[_logic, "combat"] call ALIVE_fnc_HashRem; // combat flag must be kept for new combat system
-
-                    // Indicate profile has been spawned and unlock for asynchronous waits
-                    [_logic, "locked",false] call ALIVE_fnc_HashSet;
-
-                    // profile is fully spawned and cannot be corrupted
-                    // allow damage again
-                    {_x allowDamage true} foreach _units;
-
-                    //[] call ALIVE_fnc_timer;
-
-                    //["Profile [%1] Spawn - Debug",_profileID] call ALIVE_fnc_dump;
-                    //[true] call ALIVE_fnc_timer;
-
-                    // DEBUG -------------------------------------------------------------------------------------
-                    if(_debug) then {
-                        //["Profile [%1] Spawn - pos: %2",_profileID,_position] call ALIVE_fnc_dump;
-                        [_logic,"debug",true] call MAINCLASS;
-                    };
-                    // DEBUG -------------------------------------------------------------------------------------
-
-                    //[] call ALIVE_fnc_timer;
-
-                };
-        };
-        case "despawn": {
-                private ["_debug","_group","_leader","_units","_positions","_damages","_ranks","_active","_profileID","_side","_activeCommands","_inactiveCommands","_unitCount","_waypoints",
-                "_profileWaypoint","_unit","_vehicle","_vehicleID","_profileVehicle","_profileVehicleAssignments","_assignments","_vehicleAssignments","_despawnPrevented","_linked","_spawnType"];
-
-                _debug = _logic select 2 select 0; //[_logic,"debug"] call ALIVE_fnc_hashGet;
-                _group = _logic select 2 select 13; //[_logic,"group"] call ALIVE_fnc_hashGet;
-                _leader = _logic select 2 select 10; //[_logic,"leader"] call ALIVE_fnc_hashGet;
-                _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
-                _positions = _logic select 2 select 18; //[_logic,"positions"] call ALIVE_fnc_hashGet;
-                _damages = _logic select 2 select 19; //[_logic,"damages"] call ALIVE_fnc_hashGet;
-                _ranks = _logic select 2 select 20; //[_logic,"ranks"] call ALIVE_fnc_hashGet;
-                _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet;
-                _profileID = _logic select 2 select 4; //[_logic,"profileID"] call ALIVE_fnc_hashGet;
-                _side = _logic select 2 select 3; //[_logic, "side"] call MAINCLASS;
-                _activeCommands = _logic select 2 select 26; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
-                _inactiveCommands = _logic select 2 select 27; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
-
-                //Don't despawn player profiles
-                if ([_logic, "isPlayer",false] call ALIVE_fnc_HashGet) exitwith {};
-
-                _unitCount = 0;
-
-                // not already inactive
-                if(_active) then {
-
-                    // if any linked profiles have despawn prevented
-                    _despawnPrevented = false;
-                    _linked = [_logic] call ALIVE_fnc_vehicleAssignmentsGetLinkedProfiles;
-                    //_linked call ALIVE_fnc_inspectHash;
-                    if(count (_linked select 1) > 1) then {
-                        {
-                            _spawnType = [_x,"spawnType"] call ALIVE_fnc_hashGet;
-                            if(count _spawnType > 0) then {
-                                if(_spawnType select 0 == "preventDespawn") then {
-                                    _despawnPrevented = true;
-                                };
-                            }
-                        } forEach (_linked select 2);
-                    };
-
-                    if!(_despawnPrevented) then {
-
-                        [_logic,"active", false] call ALIVE_fnc_hashSet;
-
-                        // update profile waypoints before despawn
-                        [_logic,"clearWaypoints"] call MAINCLASS;
-                        [_logic,_group] call ALIVE_fnc_waypointsToProfileWaypoints;
-
-                        [_logic] call ALIVE_fnc_vehicleAssignmentsToProfileVehicleAssignments;
-
-                        _position = getPosATL _leader;
-
-                        // update the profiles position
-                        //[_logic,"position", _position] call ALIVE_fnc_hashSet;
-                        [_logic,"position", _position] call MAINCLASS;
-                        [_logic,"despawnPosition", _position] call ALIVE_fnc_hashSet;
-
-                        // delete units
-                        {
-                            _unit = _x;
-                            _positions set [_unitCount, getPosATL _unit];
-                            _damages set [_unitCount, damage _unit];
-                            _ranks set [_unitCount, rank _unit];
-                            deleteVehicle _unit;
-                            _unitCount = _unitCount + 1;
-                        } forEach _units;
-
-                        // delete group
-                        // FIX YOUR FUCKING CODES BIS. FINALLY. AFTER 239475987 gazillion years
-                        _group call ALiVE_fnc_DeleteGroupRemote;
-
-                        [_logic,"leader", objNull] call ALIVE_fnc_hashSet;
-                        [_logic,"positions", _positions] call ALIVE_fnc_hashSet;
-                        [_logic,"damages", _damages] call ALIVE_fnc_hashSet;
-                        [_logic,"group", objNull] call ALIVE_fnc_hashSet;
-                        [_logic,"units", []] call ALIVE_fnc_hashSet;
-
-                        // process commands
-                        if(count _activeCommands > 0) then {
-                            [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
-                        };
-                        if(count _inactiveCommands > 0) then {
-                            [ALIVE_commandRouter, "activate", [_logic, _inactiveCommands]] call ALIVE_fnc_commandRouter;
-                        };
-
-                        // store the profile id on the in active profiles index
-                        [ALIVE_profileHandler,"setInActive",[_profileID,_side,_logic]] call ALIVE_fnc_profileHandler;
-                        [ALIVE_profileHandler,"setEntityInActive",_profileID] call ALIVE_fnc_profileHandler;
-
-                        // DEBUG -------------------------------------------------------------------------------------
-                        if(_debug) then {
-                            //["Profile [%1] Despawn - pos: %2",_profileID,_position] call ALIVE_fnc_dump;
-                            [_logic,"debug",true] call MAINCLASS;
-                        };
-                        // DEBUG -------------------------------------------------------------------------------------
-                    };
-                };
-        };
-        case "handleDeath": {
-                if(typeName _args == "OBJECT") then {
-                    _result = [_logic, "removeUnitByObject", _args] call MAINCLASS;
-
-                    if!(_result) then {
-                        [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
-                    };
-                };
-        };
-        case "destroy": {
-            private ["_debug","_group","_units","_active","_profileID","_unitCount","_unit"];
-
-            _debug = _logic select 2 select 0; //[_logic,"debug"] call ALIVE_fnc_hashGet;
-            _group = _logic select 2 select 13; //[_logic,"group"] call ALIVE_fnc_hashGet;
-            _units = _logic select 2 select 21; //[_logic,"units"] call ALIVE_fnc_hashGet;
-            _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet;
-            _profileID = _logic select 2 select 4; //[_logic,"profileID"] call ALIVE_fnc_hashGet;
-
-            _unitCount = 0;
-
-            // DEBUG -------------------------------------------------------------------------------------
-            if(_debug) then {
-                ["Profile [%1] Destroying",_profileID] call ALIVE_fnc_dump;
-            };
-            // DEBUG -------------------------------------------------------------------------------------
-
-            // clear waypoints
-            [_logic,"clearWaypoints"] call MAINCLASS;
-
-            // clear assignments
-            [_logic,"clearVehicleAssignments"] call MAINCLASS;
-
-            // deactivate command
-            [ALIVE_commandRouter, "deactivate", _logic] call ALIVE_fnc_commandRouter;
-
-            // not already inactive
-            if(_active) then {
-
-                // delete units
-                {
-                    _unit = _x;
-                    deleteVehicle _unit;
-                    _unitCount = _unitCount + 1;
-                } forEach _units;
-
-                // delete group
-                _group call ALiVE_fnc_DeleteGroupRemote;
-            };
-
-            // unregister
-            [ALIVE_profileHandler, "unregisterProfile", _logic] call ALIVE_fnc_profileHandler;
-
-            [_logic, "destroy"] call SUPERCLASS;
-        };
-        case "createMarker": {
-                private ["_markers","_m","_position","_dimensions","_color","_icon","_alpha","_vehicleMarkers","_inCommand",
-                "_profileID","_profileSide","_profileType","_profileActive","_vehiclesInCommandOf","_typePrefix","_label",
-                "_vehicleProfile","_vehicleMarkers"];
-
-                _alpha = _args param [0, 0.5, [1]];
-
-                _markers = [];
-
-                _position = _logic select 2 select 2; //[_entityProfile,"position"] call ALIVE_fnc_hashGet;
-                _profileID = _logic select 2 select 4; //[_profile,"profileID"] call ALIVE_fnc_hashGet;
-                _profileSide = _logic select 2 select 3; //[_logic, "side"] call MAINCLASS;
-                _profileType  = _logic select 2 select 6; //[_logic,"objectType"] call ALIVE_fnc_hashGet;
-                _profileActive = _logic select 2 select 1; //[_profile, "active"] call ALIVE_fnc_hashGet;
-                _vehiclesInCommandOf = _logic select 2 select 8; //[_profile,"vehiclesInCommandOf",[]] call ALIVE_fnc_hashSet;
-
-                if(count _vehiclesInCommandOf > 0) then {
-
-                    _vehicleMarkers = [];
-                    _inCommand = true;
-                    {
-                        _vehicleProfile = [ALIVE_profileHandler, "getProfile", _x] call ALIVE_fnc_profileHandler;
-
-                        if !(isnil "_vehicleProfile") then {
-                            _markers = [_vehicleProfile, "createMarker", _args] call ALIVE_fnc_profileVehicle;
-                        };
-
-                        _vehicleMarkers = _vehicleMarkers + _markers;
-                    } forEach _vehiclesInCommandOf;
-
-                    [_logic,"markers",_vehicleMarkers] call ALIVE_fnc_hashSet;
-
-                }else{
-
-                    switch(_profileSide) do {
-                        case "EAST":{
-                            _color = "ColorRed";
-                            _typePrefix = "o";
-                        };
-                        case "WEST":{
-                            _color = "ColorBlue";
-                            _typePrefix = "b";
-                        };
-                        case "CIV":{
-                            _color = "ColorYellow";
-                            _typePrefix = "n";
-                        };
-                        case "GUER":{
-                            _color = "ColorGreen";
-                            _typePrefix = "n";
-                        };
-                        default {
-                            _color = [_logic,"debugColor","ColorGreen"] call ALIVE_fnc_hashGet;
-                            _typePrefix = "n";
-                        };
-                    };
-
-                    switch(_profileType) do {
-                        default {
-                            _icon = format["%1_inf",_typePrefix];
-                        };
-                    };
-
-                    if(count _position > 0) then {
-                        _m = createMarker [format[MTEMPLATE, _profileID], _position];
-                        _m setMarkerShape "ICON";
-                        _m setMarkerSize [0.4, 0.4];
-                        _m setMarkerType _icon;
-                        _m setMarkerColor _color;
-                        _m setMarkerAlpha _alpha;
-
-                        _markers pushback _m;
-
-                        [_logic,"markers",_markers] call ALIVE_fnc_hashSet;
-                    };
-                };
-
-                _result = _markers;
-        };
-        case "deleteMarker": {
-                {
-                    deleteMarker _x;
-                } forEach ([_logic,"markers", []] call ALIVE_fnc_hashGet);
-        };
-        default {
-                _result = [_logic, _operation, _args] call SUPERCLASS;
-        };
-};
 TRACE_1("profileEntity - output",_result);
+
 _result;

--- a/addons/sys_profile/fnc_profileGetGoodSpawnPosition.sqf
+++ b/addons/sys_profile/fnc_profileGetGoodSpawnPosition.sqf
@@ -104,7 +104,7 @@ switch(_type) do {
                             _vehicleObjectType = _vehicleProfile select 2 select 6; //[_profile,"objectType"] call ALIVE_fnc_hashGet;
 
                             _vehicles pushback _vehicleProfile;
-                            
+
                             switch tolower(_vehicleObjectType) do {
                                 case "car" : {_inCar = true};
                                 case "truck" : {_inCar = true};
@@ -142,7 +142,7 @@ switch(_type) do {
 					///*
 
                     _spawnPosition = [_position] call ALIVE_fnc_getClosestRoad;
-                    
+
                     ///*
                     _positionSeries = [_spawnPosition,100,10] call ALIVE_fnc_getSeriesRoadPositions;
 
@@ -173,7 +173,7 @@ switch(_type) do {
                         };
                     };
                     //*/
-                    
+
                     //_spawnPosition = [_position,0,100,10,0,0.5,0,[],[_position]] call BIS_fnc_findSafePos;
 
                     //["GGSP [%1] - road position: %2 road direction: %3",_profileID,_spawnPosition,_direction] call ALIVE_fnc_dump;
@@ -182,7 +182,7 @@ switch(_type) do {
 
                 // update the entities position
 
-                [_profile,"position",_spawnPosition] call ALIVE_fnc_hashSet;
+                [_profile,"position",_spawnPosition] call ALIVE_fnc_profileEntity;
                 [_profile,"mergePositions"] call ALIVE_fnc_profileEntity;
 
                 // update any vehicle profile positions
@@ -216,7 +216,7 @@ switch(_type) do {
                         {
 
                             _vehicleProfile = _x;
-                            
+
                             _vehicleClass = _vehicleProfile select 2 select 11; //[_vehicleProfile,"vehicleClass"] call ALIVE_fnc_hashGet;
 
                             if (_inAir) then {
@@ -227,7 +227,7 @@ switch(_type) do {
 
                             //["GROUP POS: %1",_position] call ALIVE_fnc_dump;
                             //[_position,"GROUP",_profileID] call _createMarker;
-                            
+
                             /*
 
                             _isFlat = _position isflatempty [
@@ -242,9 +242,9 @@ switch(_type) do {
                             if !(count _isFlat > 0) then {_position = [_position, 0, 50, 5, 0, 5 , 0, [], [_position]] call BIS_fnc_findSafePos};
 
 							*/
-                            
+
                             _position = [_position,0,20,10,0,0.5,0,[],[_position]] call BIS_fnc_findSafePos;
-                            
+
                             //["GROUP POS FINAL: %1",_position] call ALIVE_fnc_dump;
                             //[_position,"GROUP FINAL",_profileID] call _createMarker;
 
@@ -308,8 +308,8 @@ switch(_type) do {
                     //_spawnPosition = [_position] call ALIVE_fnc_getClosestLand;
                     _spawnPosition = [_position,0,500,1,0,0.5,0,[],[_position]] call BIS_fnc_findSafePos;
 
-                    [_profile,"position",_spawnPosition] call ALIVE_fnc_hashSet;
-                    [_profile,"mergePositions"] call ALIVE_fnc_profileEntity; 
+                    [_profile,"position",_spawnPosition] call ALIVE_fnc_profileEntity;
+                    [_profile,"mergePositions"] call ALIVE_fnc_profileEntity;
 
                     //[_spawnPosition,"LAND",_profileID] call _createMarker;
                 };
@@ -354,7 +354,7 @@ switch(_type) do {
                 //[_spawnPosition,"DESP",_profileID] call _createMarker;
             };
 
-            [_profile,"position",_spawnPosition] call ALIVE_fnc_hashSet;
+            [_profile,"position",_spawnPosition] call ALIVE_fnc_profileVehicle;
 
             //["GGSP [%1] - not simulated - set pos as despawn position: %2",_profileID,_result] call ALIVE_fnc_dump;
         };

--- a/addons/sys_profile/fnc_profileHandler.sqf
+++ b/addons/sys_profile/fnc_profileHandler.sqf
@@ -394,6 +394,10 @@ switch(_operation) do {
                         _profilePosition = [_profile, "position"] call ALIVE_fnc_hashGet;
                         _profileIsPlayer = [_profile, "isPlayer"] call ALIVE_fnc_hashGet;
 
+                        // insert into spacial grid
+                        private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
+                        [_spacialGrid,"insert", [[_profilePosition,_profile]]] call ALiVE_fnc_spacialGrid;
+
                         _profilesCatagorisedSide = [_profilesCatagorised, _profileSide] call ALIVE_fnc_hashGet;
 
                         if (isNil "_profilesCatagorisedSide") exitwith {["ALIVE Error on detecting correct side #hash for profile %1",_profileID] call ALiVE_fnc_Dump};
@@ -574,6 +578,11 @@ switch(_operation) do {
                         _profileType = [_profile, "type"] call ALIVE_fnc_hashGet;
                         _profileVehicleType = [_profile, "objectType"] call ALIVE_fnc_hashGet;
                         _profileIsPlayer = [_profile, "isPlayer"] call ALIVE_fnc_hashGet;
+                        _profilePosition = [_profile, "position"] call ALIVE_fnc_hashGet;
+
+                        // remove from spacial grid
+                        private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
+                        [_spacialGrid,"remove", [_profilePosition,_profile]] call ALiVE_fnc_spacialGrid;
 
                         _profilesCatagorisedSide = [_profilesCatagorised, _profileSide] call ALIVE_fnc_hashGet;
                         _profilesCatagorisedTypes = [_profilesCatagorisedSide, "type"] call ALIVE_fnc_hashGet;
@@ -1111,7 +1120,7 @@ switch(_operation) do {
             private ["_message","_messages","_saveResult","_datahandler","_exportProfiles","_async","_missionName","_message"];
 
             _result = [false,[]];
-            
+
             _exportProfiles = [_logic, "exportProfileData"] call MAINCLASS;
 
             if(isNil"ALIVE_profileDatahandler") then {
@@ -1128,13 +1137,13 @@ switch(_operation) do {
             _messages = _result select 1;
             _messages pushback _message;
 
-			
+
             _async = false; // Wait for response from server
             _missionName = [missionName, "%20", "-"] call CBA_fnc_replace;
             _missionName = format["%1_%2", ALIVE_sys_data_GROUP_ID, _missionName]; // must include group_id to ensure mission reference is unique across groups
-            
+
             _saveResult = [ALIVE_profileDatahandler, "bulkSave", ["sys_profile", _exportProfiles, _missionName, _async]] call ALIVE_fnc_Data;
-           
+
             _result set [0,_saveResult];
 
             _message = format["ALiVE Profile System - Save Result: %1",_saveResult];
@@ -1159,7 +1168,7 @@ switch(_operation) do {
                 ALIVE_profileDatahandler = [nil, "create"] call ALIVE_fnc_Data;
                 [ALIVE_profileDatahandler,"storeType",true] call ALIVE_fnc_Data;
             };
-			
+
             _async = false; // Wait for response from server
             _missionName = [missionName, "%20", "-"] call CBA_fnc_replace;
             _missionName = format["%1_%2", ALIVE_sys_data_GROUP_ID, _missionName]; // must include group_id to ensure mission reference is unique across groups
@@ -1486,11 +1495,11 @@ switch(_operation) do {
 
                         if("activeCommands" in (_profile select 1)) then {
                             [_profileEntity, "activeCommands", [_profile,"activeCommands"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        };                        
+                        };
 
                         if("boat" in (_profile select 1)) then {
                             [_profileEntity, "boat", [_profile,"boat"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        };                                                                                 
+                        };
 
                         if(ALiVE_SYS_DATA_DEBUG_ON) then {
                             ["ALiVE SYS PROFILE - RECREATED PROFILE ENTITY:"] call ALIVE_fnc_dump;

--- a/addons/sys_profile/fnc_profileHandler.sqf
+++ b/addons/sys_profile/fnc_profileHandler.sqf
@@ -87,1515 +87,1408 @@ params [
 #define MTEMPLATE "ALiVE_PROFILEHANDLER_%1"
 
 switch(_operation) do {
-        case "init": {
-                /*
-                MODEL - no visual just reference data
-                - nodes
-                - center
-                - size
-                */
 
-                if (isServer) then {
-                        private["_profilesByType","_profilesBySide"];
+    case "init": {
+        /*
+        MODEL - no visual just reference data
+        - nodes
+        - center
+        - size
+        */
 
-                        // if server, initialise module game logic
-                        [_logic,"super"] call ALIVE_fnc_hashRem;
-                        [_logic,"class"] call ALIVE_fnc_hashRem;
-                        TRACE_1("After module init",_logic);
+        if (isServer) then {
+            // if server, initialise module game logic
+            [_logic,"super"] call ALIVE_fnc_hashRem;
+            [_logic,"class"] call ALIVE_fnc_hashRem;
+            TRACE_1("After module init",_logic);
 
-                        // set defaults
-                        [_logic,"debug",false] call ALIVE_fnc_hashSet;
-                        [_logic,"profiles",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesByCompany",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesActive",[]] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesInActive",[]] call ALIVE_fnc_hashSet;
-                        [_logic,"entitiesActive",[]] call ALIVE_fnc_hashSet;
-                        [_logic,"entitiesInActive",[]] call ALIVE_fnc_hashSet;
-                        [_logic,"profilePositions",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_logic,"profileCount",0] call ALIVE_fnc_hashSet;
-                        [_logic,"profileEntityCount",0] call ALIVE_fnc_hashSet;
-                        [_logic,"profileVehicleCount",0] call ALIVE_fnc_hashSet;
-                        [_logic,"playerEntities",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_logic,"playerIndex",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
+            private _blankHash = [] call ALiVE_fnc_hashCreate;
 
-                        _profilesBySide = [] call ALIVE_fnc_hashCreate;
-                        [_profilesBySide, "EAST", []] call ALIVE_fnc_hashSet;
-                        [_profilesBySide, "WEST", []] call ALIVE_fnc_hashSet;
-                        [_profilesBySide, "GUER", []] call ALIVE_fnc_hashSet;
-                        [_profilesBySide, "CIV", []] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesBySide",_profilesBySide] call ALIVE_fnc_hashSet;
+            // set defaults
+            [_logic,"debug", false] call ALIVE_fnc_hashSet;
+            [_logic,"profiles", +_blankHash] call ALIVE_fnc_hashSet;
+            [_logic,"profilesByCompany", +_blankHash] call ALIVE_fnc_hashSet;
+            [_logic,"profilesActive", []] call ALIVE_fnc_hashSet;
+            [_logic,"profilesInActive", []] call ALIVE_fnc_hashSet;
+            [_logic,"entitiesActive", []] call ALIVE_fnc_hashSet;
+            [_logic,"entitiesInActive", []] call ALIVE_fnc_hashSet;
+            [_logic,"profilePositions", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
+            [_logic,"profileCount", 0] call ALIVE_fnc_hashSet;
+            [_logic,"profileEntityCount", 0] call ALIVE_fnc_hashSet;
+            [_logic,"profileVehicleCount", 0] call ALIVE_fnc_hashSet;
+            [_logic,"playerEntities", _blankHash] call ALIVE_fnc_hashSet;
+            [_logic,"playerIndex", _blankHash] call ALIVE_fnc_hashSet;
 
-                        private["_profilesBySideFull","_profilesActiveBySide","_profilesInActiveBySide"];
+            private _profilesBySide = [
+                [
+                    ["EAST", []],
+                    ["WEST", []],
+                    ["GUER", []],
+                    ["CIV", []]
+                ]
+            ] call ALIVE_fnc_hashCreate;
+            [_logic,"profilesBySide", _profilesBySide] call ALIVE_fnc_hashSet;
 
-                        _profilesBySideFull = [] call ALIVE_fnc_hashCreate;
-                        [_profilesBySideFull, "EAST", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_profilesBySideFull, "WEST", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_profilesBySideFull, "GUER", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_profilesBySideFull, "CIV", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesBySideFull",_profilesBySideFull] call ALIVE_fnc_hashSet;
+            private _profilesBySideFull = [
+                [
+                    ["EAST", +_blankHash],
+                    ["WEST", +_blankHash],
+                    ["GUER", +_blankHash],
+                    ["CIV", +_blankHash]
+                ]
+            ] call ALIVE_fnc_hashCreate;
+            [_logic,"profilesBySideFull", _profilesBySideFull] call ALIVE_fnc_hashSet;
 
-                        _profilesActiveBySide = [] call ALIVE_fnc_hashCreate;
-                        [_profilesActiveBySide, "EAST", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_profilesActiveBySide, "WEST", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_profilesActiveBySide, "GUER", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_profilesActiveBySide, "CIV", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesActiveBySide",_profilesActiveBySide] call ALIVE_fnc_hashSet;
+            _profilesActiveBySide = +_profilesBySideFull;
+            [_logic,"profilesActiveBySide", _profilesActiveBySide] call ALIVE_fnc_hashSet;
 
-                        _profilesInActiveBySide = [] call ALIVE_fnc_hashCreate;
-                        [_profilesInActiveBySide, "EAST", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_profilesInActiveBySide, "WEST", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_profilesInActiveBySide, "GUER", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_profilesInActiveBySide, "CIV", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesInActiveBySide",_profilesInActiveBySide] call ALIVE_fnc_hashSet;
+            _profilesInActiveBySide = +_profilesBySideFull;
+            [_logic,"profilesInActiveBySide", _profilesInActiveBySide] call ALIVE_fnc_hashSet;
 
-                        [_logic,"profilesByFaction",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesByFactionByType",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesByFactionByVehicleType",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
+            [_logic,"profilesByFaction", +_blankHash] call ALIVE_fnc_hashSet;
+            [_logic,"profilesByFactionByType", +_blankHash] call ALIVE_fnc_hashSet;
+            [_logic,"profilesByFactionByVehicleType", +_blankHash] call ALIVE_fnc_hashSet;
 
-                        private["_profilesByType","_profilesByVehicleType","_profilesByVehicleTypeEAST","_profilesByVehicleTypeWEST",
-                        "_profilesByVehicleTypeGUER","_profilesByVehicleTypeCIV"];
+            private _profilesByType = [
+                [
+                    ["entity", []],
+                    ["vehicle", []]
+                ]
+            ] call ALIVE_fnc_hashCreate;
+            [_logic,"profilesByType", _profilesByType] call ALIVE_fnc_hashSet;
 
-                        _profilesByType = [] call ALIVE_fnc_hashCreate;
-                        [_profilesByType, "entity", []] call ALIVE_fnc_hashSet;
-                        [_profilesByType, "vehicle", []] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesByType",_profilesByType] call ALIVE_fnc_hashSet;
+            private _profilesByVehicleType = [
+                [
+                    ["Car", []],
+                    ["Tank", []],
+                    ["Armored", []],
+                    ["Truck", []],
+                    ["Ship", []],
+                    ["Helicopter", []],
+                    ["Plane", []],
+                    ["StaticWeapon", []],
+                    ["Vehicle", []]
+                ]
+            ] call ALIVE_fnc_hashCreate;
+            [_logic,"profilesByVehicleType", _profilesByVehicleType] call ALIVE_fnc_hashSet;
 
-                        _profilesByVehicleType = [] call ALIVE_fnc_hashCreate;
-                        [_profilesByVehicleType, "Car", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleType, "Tank", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleType, "Armored", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleType, "Truck", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleType, "Ship", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleType, "Helicopter", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleType, "Plane", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleType, "StaticWeapon", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleType, "Vehicle", []] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesByVehicleType",_profilesByVehicleType] call ALIVE_fnc_hashSet;
+            _profilesByVehicleTypeEAST = +_profilesByVehicleType;
+            [_profilesByVehicleTypeEAST,"Vehicle", []] call ALIVE_fnc_hashSet;
 
-                        _profilesByVehicleTypeEAST = [] call ALIVE_fnc_hashCreate;
-                        [_profilesByVehicleTypeEAST, "Car", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeEAST, "Tank", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeEAST, "Armored", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeEAST, "Truck", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeEAST, "Ship", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeEAST, "Helicopter", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeEAST, "Plane", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeEAST, "StaticWeapon", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeEAST, "Vehicle", []] call ALIVE_fnc_hashSet;
+            _profilesByVehicleTypeWEST = +_profilesByVehicleType;
+            [_profilesByVehicleTypeWEST,"Vehicle", []] call ALIVE_fnc_hashSet;
 
-                        _profilesByVehicleTypeWEST = [] call ALIVE_fnc_hashCreate;
-                        [_profilesByVehicleTypeWEST, "Car", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeWEST, "Tank", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeWEST, "Armored", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeWEST, "Truck", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeWEST, "Ship", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeWEST, "Helicopter", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeWEST, "Plane", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeWEST, "StaticWeapon", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeWEST, "Vehicle", []] call ALIVE_fnc_hashSet;
+            _profilesByVehicleTypeGUER = +_profilesByVehicleType;
+            [_profilesByVehicleTypeGUER,"Vehicle", []] call ALIVE_fnc_hashSet;
 
-                        _profilesByVehicleTypeGUER = [] call ALIVE_fnc_hashCreate;
-                        [_profilesByVehicleTypeGUER, "Car", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeGUER, "Tank", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeGUER, "Armored", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeGUER, "Truck", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeGUER, "Ship", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeGUER, "Helicopter", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeGUER, "Plane", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeGUER, "StaticWeapon", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeGUER, "Vehicle", []] call ALIVE_fnc_hashSet;
+            _profilesByVehicleTypeCIV = +_profilesByVehicleType;
+            [_profilesByVehicleTypeCIV,"Vehicle", []] call ALIVE_fnc_hashSet;
 
-                        _profilesByVehicleTypeCIV = [] call ALIVE_fnc_hashCreate;
-                        [_profilesByVehicleTypeCIV, "Car", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeCIV, "Tank", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeCIV, "Armored", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeCIV, "Truck", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeCIV, "Ship", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeCIV, "Helicopter", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeCIV, "Plane", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeCIV, "StaticWeapon", []] call ALIVE_fnc_hashSet;
-                        [_profilesByVehicleTypeCIV, "Vehicle", []] call ALIVE_fnc_hashSet;
+            _profilesByTypeEAST = +_profilesByType;
+            _profilesByTypeWEST = +_profilesByType;
+            _profilesByTypeGUER = +_profilesByType;
+            _profilesByTypeCIV = +_profilesByType;
 
-                        private ["_profilesByTypeEAST","_profilesByTypeWEST","_profilesByTypeGUER","_profilesByTypeCIV"];
+            private _catagoriesEAST = [
+                [
+                    ["type", _profilesByTypeEAST],
+                    ["vehicleType", _profilesByVehicleTypeEAST]
+                ]
+            ] call ALIVE_fnc_hashCreate;
 
-                        _profilesByTypeEAST = [] call ALIVE_fnc_hashCreate;
-                        [_profilesByTypeEAST, "entity", []] call ALIVE_fnc_hashSet;
-                        [_profilesByTypeEAST, "vehicle", []] call ALIVE_fnc_hashSet;
+            private _catagoriesWEST = [
+                [
+                    ["type", _profilesByTypeWEST],
+                    ["vehicleType", _profilesByVehicleTypeWEST]
+                ]
+            ] call ALIVE_fnc_hashCreate;
 
-                        _profilesByTypeWEST = [] call ALIVE_fnc_hashCreate;
-                        [_profilesByTypeWEST, "entity", []] call ALIVE_fnc_hashSet;
-                        [_profilesByTypeWEST, "vehicle", []] call ALIVE_fnc_hashSet;
+            private _catagoriesGUER = [
+                [
+                    ["type", _profilesByTypeGUER],
+                    ["vehicleType", _profilesByVehicleTypeGUER]
+                ]
+            ] call ALIVE_fnc_hashCreate;
 
-                        _profilesByTypeGUER = [] call ALIVE_fnc_hashCreate;
-                        [_profilesByTypeGUER, "entity", []] call ALIVE_fnc_hashSet;
-                        [_profilesByTypeGUER, "vehicle", []] call ALIVE_fnc_hashSet;
+            private _catagoriesCIV = [
+                [
+                    ["type", _profilesByTypeCIV],
+                    ["vehicleType", _profilesByVehicleTypeCIV]
+                ]
+            ] call ALIVE_fnc_hashCreate;
 
-                        _profilesByTypeCIV = [] call ALIVE_fnc_hashCreate;
-                        [_profilesByTypeCIV, "entity", []] call ALIVE_fnc_hashSet;
-                        [_profilesByTypeCIV, "vehicle", []] call ALIVE_fnc_hashSet;
-
-                        private ["_catagoriesEAST","_catagoriesWEST","_catagoriesGUER","_catagoriesCIV","_profilesCatagorised"];
-
-                        _catagoriesEAST = [] call ALIVE_fnc_hashCreate;
-                        [_catagoriesEAST, "type", _profilesByTypeEAST] call ALIVE_fnc_hashSet;
-                        [_catagoriesEAST, "vehicleType", _profilesByVehicleTypeEAST] call ALIVE_fnc_hashSet;
-
-                        _catagoriesWEST = [] call ALIVE_fnc_hashCreate;
-                        [_catagoriesWEST, "type", _profilesByTypeWEST] call ALIVE_fnc_hashSet;
-                        [_catagoriesWEST, "vehicleType", _profilesByVehicleTypeWEST] call ALIVE_fnc_hashSet;
-
-                        _catagoriesGUER = [] call ALIVE_fnc_hashCreate;
-                        [_catagoriesGUER, "type", _profilesByTypeGUER] call ALIVE_fnc_hashSet;
-                        [_catagoriesGUER, "vehicleType", _profilesByVehicleTypeGUER] call ALIVE_fnc_hashSet;
-
-                        _catagoriesCIV = [] call ALIVE_fnc_hashCreate;
-                        [_catagoriesCIV, "type", _profilesByTypeCIV] call ALIVE_fnc_hashSet;
-                        [_catagoriesCIV, "vehicleType", _profilesByVehicleTypeCIV] call ALIVE_fnc_hashSet;
-
-                        _profilesCatagorised = [] call ALIVE_fnc_hashCreate;
-                        [_profilesCatagorised, "EAST", _catagoriesEAST] call ALIVE_fnc_hashSet;
-                        [_profilesCatagorised, "WEST", _catagoriesWEST] call ALIVE_fnc_hashSet;
-                        [_profilesCatagorised, "GUER", _catagoriesGUER] call ALIVE_fnc_hashSet;
-                        [_profilesCatagorised, "CIV", _catagoriesCIV] call ALIVE_fnc_hashSet;
-                        [_logic,"profilesCatagorised",_profilesCatagorised] call ALIVE_fnc_hashSet;
-
-                };
-
-                /*
-                VIEW - purely visual
-                */
-
-                /*
-                CONTROLLER  - coordination
-                */
+            private _profilesCatagorised = [
+                [
+                    ["EAST", _catagoriesEAST],
+                    ["WEST", _catagoriesWEST],
+                    ["GUER", _catagoriesGUER],
+                    ["CIV", _catagoriesCIV]
+                ]
+            ] call ALIVE_fnc_hashCreate;
+            [_logic,"profilesCatagorised",_profilesCatagorised] call ALIVE_fnc_hashSet;
         };
-        case "destroy": {
-                [_logic, "debug", false] call MAINCLASS;
-                if (isServer) then {
-                        [_logic, "destroy"] call SUPERCLASS;
-                };
+
+        /*
+        VIEW - purely visual
+        */
+
+        /*
+        CONTROLLER  - coordination
+        */
+    };
+
+    case "destroy": {
+        [_logic, "debug", false] call MAINCLASS;
+
+        if (isServer) then {
+            [_logic, "destroy"] call SUPERCLASS;
         };
-        case "debug": {
-                private["_profiles","_profileType"];
+    };
 
-                if(typeName _args != "BOOL") then {
-                        _args = [_logic,"debug"] call ALIVE_fnc_hashGet;
-                } else {
-                        [_logic,"debug",_args] call ALIVE_fnc_hashSet;
-                };
-                ASSERT_TRUE(typeName _args == "BOOL",str _args);
-
-                _profiles = [_logic, "profiles"] call ALIVE_fnc_hashGet;
-
-                if(count _profiles > 0) then {
-                    {
-                        _profileType = [_x, "type"] call ALIVE_fnc_hashGet;
-                        switch(_profileType) do {
-                                case "entity": {
-                                    _result = [_x, "debug", false] call ALIVE_fnc_profileEntity;
-                                };
-                                case "vehicle": {
-                                    _result = [_x, "debug", false] call ALIVE_fnc_profileVehicle;
-                                };
-                        };
-                    } forEach (_profiles select 2);
-
-                    if(_args) then {
-                        {
-                            _profileType = [_x, "type"] call ALIVE_fnc_hashGet;
-                            switch(_profileType) do {
-                                    case "entity": {
-                                        _result = [_x, "debug", true] call ALIVE_fnc_profileEntity;
-                                    };
-                                    case "vehicle": {
-                                        _result = [_x, "debug", true] call ALIVE_fnc_profileVehicle;
-                                    };
-                            };
-                        } forEach (_profiles select 2);
-
-                        // DEBUG -------------------------------------------------------------------------------------
-                        if(_args) then {
-                            //["----------------------------------------------------------------------------------------"] call ALIVE_fnc_dump;
-                            //["ALIVE Profile Handler State"] call ALIVE_fnc_dump;
-                            //_state = [_logic, "state"] call MAINCLASS;
-                            //_state call ALIVE_fnc_inspectHash;
-                        };
-                        // DEBUG -------------------------------------------------------------------------------------
-                    };
-                };
-
-                _result = _args;
+    case "debug": {
+        if !(_args isEqualType true) then {
+            _args = [_logic,"debug"] call ALIVE_fnc_hashGet;
+        } else {
+            [_logic,"debug", _args] call ALIVE_fnc_hashSet;
         };
-        case "state": {
-                private["_state"];
 
-                if(typeName _args != "ARRAY") then {
+        private _profiles = [_logic,"profiles"] call ALIVE_fnc_hashGet;
 
-                        // Save state
-
-                        _state = [] call ALIVE_fnc_hashCreate;
-
-                        // loop the class hash and set vars on the state hash
-                        {
-                            if(!(_x == "super") && !(_x == "class")) then {
-                                [_state,_x,[_logic,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                            };
-                        } forEach (_logic select 1);
-
-                        _result = _state;
-
-                } else {
-                        ASSERT_TRUE(typeName _args == "ARRAY",str typeName _args);
-
-                        // Restore state
-
-                        // loop the passed hash and set vars on the class hash
-                        {
-                            [_logic,_x,[_args,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        } forEach (_args select 1);
-                };
-        };
-        case "registerProfile": {
-                private["_profile","_profilesSide","_profileID","_profiles","_profilesByType","_profilesBySide","_profilesByFaction","_profilesByFactionByType",
-                "_profilesByFactionByVehicleType","_profilesByVehicleType","_profilesActive","_profilesInActive","_profilesActiveBySide","_profilesInActiveBySide",
-                "_entityProfilesActive","_entityProfilesInActive","_profilesByCompany","_profilesCatagorised","_profilePositions","_profileType","_profilesType",
-                "_profileSide","_profileFaction","_profilesSide","_profilesFaction","_profileActive","_profileCompany","_profleByCompanyArray",
-                "_profileVehicleType","_profilesVehicleType","_profilesCatagorisedSide","_profilesCatagorisedTypes","_profilesCatagorisedVehicleTypes",
-                "_profilesCatagorisedType","_profilesCatagorisedVehicleType","_profilePosition","_profilesSideFull","_profilesBySideFull",
-                "_profilesActiveSide","_profilesInActiveSide","_playerEntities","_profileIsPlayer"];
-
-                if(typeName _args == "ARRAY") then {
-                        _profile = _args;
-
-                        _profiles = [_logic, "profiles"] call ALIVE_fnc_hashGet;
-                        _profilesBySideFull = [_logic, "profilesBySideFull"] call ALIVE_fnc_hashGet;
-                        _profilesByType = [_logic, "profilesByType"] call ALIVE_fnc_hashGet;
-                        _profilesBySide = [_logic, "profilesBySide"] call ALIVE_fnc_hashGet;
-                        _profilesByFaction = [_logic, "profilesByFaction"] call ALIVE_fnc_hashGet;
-                        _profilesByFactionByType = [_logic,"profilesByFactionByType"] call ALIVE_fnc_hashGet;
-                        _profilesByFactionByVehicleType = [_logic,"profilesByFactionByVehicleType"] call ALIVE_fnc_hashGet;
-                        _profilesByVehicleType = [_logic, "profilesByVehicleType"] call ALIVE_fnc_hashGet;
-                        _profilesActive = [_logic, "profilesActive"] call ALIVE_fnc_hashGet;
-                        _profilesInActive = [_logic, "profilesInActive"] call ALIVE_fnc_hashGet;
-                        _entityProfilesActive = [_logic, "entitiesActive"] call ALIVE_fnc_hashGet;
-                        _entityProfilesInActive = [_logic, "entitiesInActive"] call ALIVE_fnc_hashGet;
-                        _profilesActiveBySide = [_logic, "profilesActiveBySide"] call ALIVE_fnc_hashGet;
-                        _profilesInActiveBySide = [_logic, "profilesInActiveBySide"] call ALIVE_fnc_hashGet;
-                        _profilesByCompany = [_logic, "profilesByCompany"] call ALIVE_fnc_hashGet;
-                        _profilesCatagorised = [_logic, "profilesCatagorised"] call ALIVE_fnc_hashGet;
-                        _profilePositions = [_logic, "profilePositions"] call ALIVE_fnc_hashGet;
-                        _playerEntities = [_logic, "playerEntities"] call ALIVE_fnc_hashGet;
-
-                        _profileSide = [_profile, "side"] call ALIVE_fnc_hashGet;
-                        _profileFaction = [_profile, "faction"] call ALIVE_fnc_hashGet;
-                        _profileID = [_profile, "profileID"] call ALIVE_fnc_hashGet;
-                        _profileType = [_profile, "type"] call ALIVE_fnc_hashGet;
-                        _profileVehicleType = [_profile, "objectType"] call ALIVE_fnc_hashGet;
-                        _profilePosition = [_profile, "position"] call ALIVE_fnc_hashGet;
-                        _profileIsPlayer = [_profile, "isPlayer"] call ALIVE_fnc_hashGet;
-
-                        // insert into spacial grid
-                        private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
-                        [_spacialGrid,"insert", [[_profilePosition,_profile]]] call ALiVE_fnc_spacialGrid;
-
-                        _profilesCatagorisedSide = [_profilesCatagorised, _profileSide] call ALIVE_fnc_hashGet;
-
-                        if (isNil "_profilesCatagorisedSide") exitwith {["ALIVE Error on detecting correct side #hash for profile %1",_profileID] call ALiVE_fnc_Dump};
-
-                        _profilesCatagorisedTypes = [_profilesCatagorisedSide, "type"] call ALIVE_fnc_hashGet;
-                        _profilesCatagorisedVehicleTypes = [_profilesCatagorisedSide, "vehicleType"] call ALIVE_fnc_hashGet;
-
-                        // store on main profiles hash
-                        [_profiles, _profileID, _profile] call ALIVE_fnc_hashSet;
-
-                        // store the position in the position index
-                        [_profilePositions, _profileID, _profilePosition] call ALIVE_fnc_hashSet;
-
-                        // store reference to main profile on by type hash
-                        _profilesType = [_profilesByType, _profileType] call ALIVE_fnc_hashGet;
-                        _profilesType pushback _profileID;
-
-                        // store reference to main profile on by catagorised type hash
-                        _profilesCatagorisedType = [_profilesCatagorisedTypes, _profileType] call ALIVE_fnc_hashGet;
-                        _profilesCatagorisedType pushback _profileID;
-
-
-                        // DEBUG -------------------------------------------------------------------------------------
-                        if([_logic,"debug"] call ALIVE_fnc_hashGet) then {
-                            switch(_profileType) do {
-                                case "entity": {
-                                    [_profile, "debug", true] call ALIVE_fnc_profileEntity;
-                                };
-                                case "vehicle": {
-                                    [_profile, "debug", true] call ALIVE_fnc_profileVehicle;
-                                };
-                            };
-                            ["ALIVE Profile Handler - Register Profile [%1]",_profileID] call ALIVE_fnc_dump;
-                            //_profile call ALIVE_fnc_inspectHash;
-                        };
-                        // DEBUG -------------------------------------------------------------------------------------
-
-
-                        if(_profileType == "entity" || _profileType == "civ" || _profileType == "vehicle") then {
-
-                            // store reference to main profile on by side hash
-                            _profilesSide = [_profilesBySide, _profileSide] call ALIVE_fnc_hashGet;
-                            _profilesSide pushback _profileID;
-
-                            // store profile on side hash
-                            _profilesSideFull = [_profilesBySideFull, _profileSide] call ALIVE_fnc_hashGet;
-                            [_profilesSideFull, _profileID, _profile] call ALIVE_fnc_hashSet;
-
-                            private["_profilesFaction","_profilesFactionType","_profilesFactionVehicleType","_profileFactionType","_profileFactionVehicleType"];
-
-                            // store reference to main profile on by faction hash
-                            if(_profileFaction in (_profilesByFaction select 1)) then {
-                                _profilesFaction = [_profilesByFaction, _profileFaction] call ALIVE_fnc_hashGet;
-                                _profilesFactionType = [_profilesByFactionByType, _profileFaction] call ALIVE_fnc_hashGet;
-                                _profilesFactionVehicleType = [_profilesByFactionByVehicleType, _profileFaction] call ALIVE_fnc_hashGet;
-                            }else{
-                                [_profilesByFaction, _profileFaction, []] call ALIVE_fnc_hashSet;
-                                _profilesFaction = [_profilesByFaction, _profileFaction] call ALIVE_fnc_hashGet;
-
-                                _profilesFactionType = [] call ALIVE_fnc_hashCreate;
-                                [_profilesFactionType, "entity", []] call ALIVE_fnc_hashSet;
-                                [_profilesFactionType, "vehicle", []] call ALIVE_fnc_hashSet;
-
-                                [_profilesByFactionByType, _profileFaction, _profilesFactionType] call ALIVE_fnc_hashSet;
-
-                                _profilesFactionVehicleType = [] call ALIVE_fnc_hashCreate;
-                                [_profilesFactionVehicleType, "Car", []] call ALIVE_fnc_hashSet;
-                                [_profilesFactionVehicleType, "Tank", []] call ALIVE_fnc_hashSet;
-                                [_profilesFactionVehicleType, "Armored", []] call ALIVE_fnc_hashSet;
-                                [_profilesFactionVehicleType, "Truck", []] call ALIVE_fnc_hashSet;
-                                [_profilesFactionVehicleType, "Ship", []] call ALIVE_fnc_hashSet;
-                                [_profilesFactionVehicleType, "Helicopter", []] call ALIVE_fnc_hashSet;
-                                [_profilesFactionVehicleType, "Plane", []] call ALIVE_fnc_hashSet;
-                                [_profilesFactionVehicleType, "StaticWeapon", []] call ALIVE_fnc_hashSet;
-                                [_profilesFactionVehicleType, "Vehicle", []] call ALIVE_fnc_hashSet;
-
-                                [_profilesByFactionByVehicleType, _profileFaction, _profilesFactionVehicleType] call ALIVE_fnc_hashSet;
-                            };
-
-                            _profilesFaction pushback _profileID;
-
-                            _profileFactionType = [_profilesFactionType, _profileType] call ALIVE_fnc_hashGet;
-                            _profileFactionType pushback _profileID;
-
-                            // store active state on active or inactive array
-                            _profileActive = [_profile, "active"] call ALIVE_fnc_hashGet;
-
-                            if(_profileActive) then {
-                                _profilesActive pushback _profileID;
-
-                                // store profile on side hash
-                                _profilesActiveSide = [_profilesActiveBySide, _profileSide] call ALIVE_fnc_hashGet;
-                                [_profilesActiveSide, _profileID, _profile] call ALIVE_fnc_hashSet;
-
-                                if(_profileType == "entity") then {
-                                    _entityProfilesActive pushback _profileID;
-                                };
-                            }else{
-                                _profilesInActive pushback _profileID;
-
-                                // store profile on side hash
-                                _profilesInActiveSide = [_profilesInActiveBySide, _profileSide] call ALIVE_fnc_hashGet;
-                                [_profilesInActiveSide, _profileID, _profile] call ALIVE_fnc_hashSet;
-
-                                if(_profileType == "entity") then {
-                                    _entityProfilesInActive pushback _profileID;
-                                };
-                            };
-
-                            if!(_profileType == "vehicle") then {
-
-                                // if player entity
-                                if(_profileIsPlayer) then {
-                                    [_playerEntities, _profileID, _profile] call ALIVE_fnc_hashSet;
-                                };
-
-                                // if company id is set
-                                _profileCompany = [_profile, "companyID"] call ALIVE_fnc_hashGet;
-                                if!(_profileCompany == "") then {
-                                    if!([_profilesByCompany, _profileCompany] call CBA_fnc_hashHasKey) then {
-                                        _profleByCompanyArray = [_profileID];
-                                        [_profilesByCompany, _profileCompany, _profleByCompanyArray] call ALIVE_fnc_hashSet;
-                                    } else {
-                                        _profleByCompanyArray = [_profilesByCompany, _profileCompany] call ALIVE_fnc_hashGet;
-                                        _profleByCompanyArray pushback _profileID;
-                                    };
-                                };
-                            }else{
-                                // vehicle type
-                                _profilesVehicleType = [_profilesByVehicleType,_profileVehicleType] call ALIVE_fnc_hashGet;
-                                _profilesVehicleType pushback _profileID;
-
-                                _profileFactionVehicleType = [_profilesFactionVehicleType,_profileVehicleType] call ALIVE_fnc_hashGet;
-                                _profileFactionVehicleType pushback _profileID;
-
-                                _profilesCatagorisedVehicleType = [_profilesCatagorisedVehicleTypes, _profileVehicleType] call ALIVE_fnc_hashGet;
-                                _profilesCatagorisedVehicleType pushback _profileID;
-                            };
-                        };
-                };
-        };
-        case "unregisterProfile": {
-                private["_profile","_profileID","_profiles","_profilesByType","_profilesBySide","_profilesByFaction","_profilesByFaction","_profilesByFactionByType",
-                "_profilesByFactionByVehicleType","_profilesByVehicleType","_profilesActive","_profilesInActive","_entityProfilesActive","_profilesActiveBySide",
-                "_profilesInActiveBySide","_entityProfilesInActive","_profilesByCompany","_profileType","_profilesType","_profileSide",
-                "_profileFaction","_profilesSide","_profilesFaction","_profileActive","_profleByCompanyArray","_profileVehicleType",
-                "_profilesVehicleType","_profilesCatagorised","_profilesCatagorisedSide","_profilesCatagorisedTypes","_profilesCatagorisedVehicleTypes",
-                "_profilesCatagorisedType","_profilesCatagorisedVehicleType","_profilePositions","_profilesBySideFull","_profilesSideFull","_profilesActiveSide","_profilesInActiveSide",
-                "_playerEntities","_profileIsPlayer","_profilesFactionType","_profilesFactionVehicleType","_profileFactionType","_vehicle","_units","_profileCompany","_profilesFactionVehicleType"];
-
-                if(typeName _args == "STRING") then {_args = [_logic,"getProfile",_args] call MAINCLASS};
-
-                if(typeName _args == "ARRAY") then {
-                        _profile = _args;
-
-                        _profiles = [_logic, "profiles"] call ALIVE_fnc_hashGet;
-                        _profilesBySideFull = [_logic, "profilesBySideFull"] call ALIVE_fnc_hashGet;
-                        _profilesByType = [_logic, "profilesByType"] call ALIVE_fnc_hashGet;
-                        _profilesBySide = [_logic, "profilesBySide"] call ALIVE_fnc_hashGet;
-                        _profilesByFaction = [_logic, "profilesByFaction"] call ALIVE_fnc_hashGet;
-                        _profilesByFactionByType = [_logic,"profilesByFactionByType"] call ALIVE_fnc_hashGet;
-                        _profilesByFactionByVehicleType = [_logic,"profilesByFactionByVehicleType"] call ALIVE_fnc_hashGet;
-                        _profilesByVehicleType = [_logic, "profilesByVehicleType"] call ALIVE_fnc_hashGet;
-                        _profilesActive = [_logic, "profilesActive"] call ALIVE_fnc_hashGet;
-                        _profilesInActive = [_logic, "profilesInActive"] call ALIVE_fnc_hashGet;
-                        _entityProfilesActive = [_logic, "entitiesActive"] call ALIVE_fnc_hashGet;
-                        _entityProfilesInActive = [_logic, "entitiesInActive"] call ALIVE_fnc_hashGet;
-                        _profilesActiveBySide = [_logic, "profilesActiveBySide"] call ALIVE_fnc_hashGet;
-                        _profilesInActiveBySide = [_logic, "profilesInActiveBySide"] call ALIVE_fnc_hashGet;
-                        _profilesByCompany = [_logic, "profilesByCompany"] call ALIVE_fnc_hashGet;
-                        _profilesCatagorised = [_logic, "profilesCatagorised"] call ALIVE_fnc_hashGet;
-                        _profilePositions = [_logic, "profilePositions"] call ALIVE_fnc_hashGet;
-                        _playerEntities = [_logic, "playerEntities"] call ALIVE_fnc_hashGet;
-
-                        _profileSide = [_profile, "side"] call ALIVE_fnc_hashGet;
-                        _profileFaction = [_profile, "faction"] call ALIVE_fnc_hashGet;
-                        _profileID = [_profile, "profileID"] call ALIVE_fnc_hashGet;
-                        _profileType = [_profile, "type"] call ALIVE_fnc_hashGet;
-                        _profileVehicleType = [_profile, "objectType"] call ALIVE_fnc_hashGet;
-                        _profileIsPlayer = [_profile, "isPlayer"] call ALIVE_fnc_hashGet;
-                        _profilePosition = [_profile, "position"] call ALIVE_fnc_hashGet;
-
-                        // remove from spacial grid
-                        private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
-                        [_spacialGrid,"remove", [_profilePosition,_profile]] call ALiVE_fnc_spacialGrid;
-
-                        _profilesCatagorisedSide = [_profilesCatagorised, _profileSide] call ALIVE_fnc_hashGet;
-                        _profilesCatagorisedTypes = [_profilesCatagorisedSide, "type"] call ALIVE_fnc_hashGet;
-                        _profilesCatagorisedVehicleTypes = [_profilesCatagorisedSide, "vehicleType"] call ALIVE_fnc_hashGet;
-
-                        // remove on main profiles hash
-                        [_profiles, _profileID] call ALIVE_fnc_hashRem;
-
-                        // remove from position index
-                        [_profilePositions, _profileID] call ALIVE_fnc_hashRem;
-
-                        // remove reference to main profile on by type hash
-                        _profilesType = [_profilesByType, _profileType] call ALIVE_fnc_hashGet;
-                        _profilesType = _profilesType - [_profileID];
-                        [_profilesByType, _profileType, _profilesType] call ALIVE_fnc_hashSet;
-
-                        // remove reference to main profile on by catagorised type hash
-                        _profilesCatagorisedType = [_profilesCatagorisedTypes, _profileType] call ALIVE_fnc_hashGet;
-                        _profilesCatagorisedType = _profilesCatagorisedType - [_profileID];
-                        [_profilesCatagorisedTypes, _profileType, _profilesCatagorisedType] call ALIVE_fnc_hashSet;
-
-                        // disable debugging on the profile
-                        if([_profile, "debug"] call ALIVE_fnc_hashGet) then {
-                            switch(_profileType) do {
-                                case "entity": {
-                                    _result = [_profile, "debug", false] call ALIVE_fnc_profileEntity;
-                                };
-                                case "civ": {
-                                    _result = [_profile, "debug", false] call ALIVE_fnc_profileCiv;
-                                };
-                                case "vehicle": {
-                                    _result = [_profile, "debug", false] call ALIVE_fnc_profileVehicle;
-                                };
-                            };
-                        };
-
-                        // DEBUG -------------------------------------------------------------------------------------
-                        if([_logic,"debug"] call ALIVE_fnc_hashGet) then {
-                            ["ALIVE Profile Handler - Un-Register Profile [%1]",_profileID] call ALIVE_fnc_dump;
-                            //_profile call ALIVE_fnc_inspectHash;
-                        };
-                        // DEBUG -------------------------------------------------------------------------------------
-
-
-                        if(_profileType == "entity" || _profileType == "mil" || _profileType == "vehicle") then {
-
-                            // remove reference to main profile on by side hash
-                            _profilesSide = [_profilesBySide, _profileSide] call ALIVE_fnc_hashGet;
-                            _profilesSide = _profilesSide - [_profileID];
-                            [_profilesBySide, _profileSide, _profilesSide] call ALIVE_fnc_hashSet;
-
-                            // remove profile on full side hash
-                            _profilesSide = [_profilesBySideFull, _profileSide] call ALIVE_fnc_hashGet;
-                            [_profilesSide, _profileID] call ALIVE_fnc_hashRem;
-                            [_profilesBySideFull, _profileSide, _profilesSide] call ALIVE_fnc_hashSet;
-
-                            // remove reference to main profile on by faction hash
-                            _profilesFaction = [_profilesByFaction, _profileFaction] call ALIVE_fnc_hashGet;
-                            _profilesFaction = _profilesFaction - [_profileID];
-                            [_profilesByFaction, _profileFaction, _profilesFaction] call ALIVE_fnc_hashSet;
-
-                            _profilesFactionType = [_profilesByFactionByType, _profileFaction] call ALIVE_fnc_hashGet;
-                            _profileFactionType = [_profilesFactionType, _profileType] call ALIVE_fnc_hashGet;
-                            _profileFactionType = _profileFactionType - [_profileID];
-                            [_profilesFactionType, _profileType, _profileFactionType] call ALIVE_fnc_hashSet;
-                            //[_profilesByFactionByType, _profileFaction, _profileFactionType] call ALIVE_fnc_hashSet;
-
-                            _profilesFactionVehicleType = [_profilesByFactionByVehicleType, _profileFaction] call ALIVE_fnc_hashGet;
-
-                            // remove active state on active or inactive array
-                            _profileActive = [_profile, "active"] call ALIVE_fnc_hashGet;
-
-                            if(_profileActive) then {
-
-                                // Remove ProfileID if any units are left
-                                _vehicle = [_profile,"vehicle"] call ALIVE_fnc_hashGet; if !(isnil "_vehicle") then {_vehicle setvariable ["ProfileID",nil]};
-                                _units = [_profile,"units",[]] call ALIVE_fnc_hashGet; if (count _units > 0) then {{_x setVariable ["ProfileID",nil]} foreach (units group (_units select 0))};
-
-                                _profilesActive = _profilesActive - [_profileID];
-                                [_logic, "profilesActive", _profilesActive] call ALIVE_fnc_hashSet;
-
-                                _profilesActiveSide = [_profilesActiveBySide, _profileSide] call ALIVE_fnc_hashGet;
-                                [_profilesActiveSide, _profileID] call ALIVE_fnc_hashRem;
-                                [_profilesActiveBySide, _profileSide, _profilesActiveSide] call ALIVE_fnc_hashSet;
-
-                                if(_profileType == "entity") then {
-                                    _entityProfilesActive = _entityProfilesActive - [_profileID];
-                                    [_logic, "entitiesActive", _entityProfilesActive] call ALIVE_fnc_hashSet;
-                                };
-                            }else{
-                                _profilesInActive = _profilesInActive - [_profileID];
-                                [_logic, "profilesInActive", _profilesInActive] call ALIVE_fnc_hashSet;
-
-                                _profilesInActiveSide = [_profilesInActiveBySide, _profileSide] call ALIVE_fnc_hashGet;
-                                [_profilesInActiveSide, _profileID] call ALIVE_fnc_hashRem;
-                                [_profilesInActiveBySide, _profileSide, _profilesInActiveSide] call ALIVE_fnc_hashSet;
-
-                                if(_profileType == "entity") then {
-                                    _entityProfilesInActive = _entityProfilesInActive - [_profileID];
-                                    [_logic, "entitiesInActive", _entityProfilesInActive] call ALIVE_fnc_hashSet;
-                                };
-                            };
-
-                            if!(_profileType == "vehicle") then {
-                                if(_profileIsPlayer) then {
-                                    [_playerEntities, _profileID] call ALIVE_fnc_hashRem;
-                                };
-
-                                // if company id is set
-                                _profileCompany = [_profile, "companyID"] call ALIVE_fnc_hashGet;
-                                if!(_profileCompany == "") then {
-                                    _profleByCompanyArray = [_profilesByCompany, _profileCompany] call ALIVE_fnc_hashGet;
-                                    _profleByCompanyArray = _profleByCompanyArray - [_profileID];
-                                    [_profilesByCompany, _profileCompany, _profleByCompanyArray] call ALIVE_fnc_hashSet;
-                                };
-                            }else{
-                                // vehicle type
-                                _profilesVehicleType = [_profilesByVehicleType, _profileVehicleType] call ALIVE_fnc_hashGet;
-                                _profilesVehicleType = _profilesVehicleType - [_profileID];
-                                [_profilesByVehicleType, _profileVehicleType, _profilesVehicleType] call ALIVE_fnc_hashSet;
-
-                                _profilesFactionVehicleType = [_profilesByFactionByVehicleType, _profileFaction] call ALIVE_fnc_hashGet;
-                                _profileFactionVehicleType = [_profilesFactionVehicleType, _profileVehicleType] call ALIVE_fnc_hashGet;
-                                _profileFactionVehicleType = _profileFactionVehicleType - [_profileID];
-                                [_profilesFactionVehicleType, _profileVehicleType, _profileFactionVehicleType] call ALIVE_fnc_hashSet;
-
-                                _profilesCatagorisedVehicleType = [_profilesCatagorisedVehicleTypes, _profileVehicleType] call ALIVE_fnc_hashGet;
-                                _profilesCatagorisedVehicleType = _profilesCatagorisedVehicleType - [_profileID];
-                                [_profilesCatagorisedVehicleTypes, _profileVehicleType, _profilesCatagorisedVehicleType] call ALIVE_fnc_hashSet;
-                            };
-                        };
-                };
-        };
-        case "setActive": {
-                private["_profileID","_side","_profile","_profilesInActive","_profilesActive","_profilesActiveBySide","_profilesInActiveBySide","_profilesInActiveSide","_profilesActiveSide"];
-
-                _profileID = _args select 0;
-                _side = _args select 1;
-                _profile = _args select 2;
-
-                _profilesInActive = [_logic, "profilesInActive"] call ALIVE_fnc_hashGet;
-                _profilesActive = [_logic, "profilesActive"] call ALIVE_fnc_hashGet;
-
-                if(_profileID in _profilesInActive) then {
-                    _profilesInActive = _profilesInActive - [_profileID];
-                };
-
-                _profilesActive pushback _profileID;
-
-                _profilesInActive = [_logic, "profilesInActive",_profilesInActive] call ALIVE_fnc_hashSet;
-                _profilesActive = [_logic, "profilesActive", _profilesActive] call ALIVE_fnc_hashSet;
-
-
-                _profilesActiveBySide = [_logic, "profilesActiveBySide"] call ALIVE_fnc_hashGet;
-                _profilesInActiveBySide = [_logic, "profilesInActiveBySide"] call ALIVE_fnc_hashGet;
-
-                _profilesInActiveSide = [_profilesInActiveBySide, _side] call ALIVE_fnc_hashGet;
-
-                if(_profileID in (_profilesInActiveSide select 1)) then {
-                    [_profilesInActiveSide, _profileID] call ALIVE_fnc_hashRem;
-                    [_profilesInActiveBySide, _side, _profilesInActiveSide] call ALIVE_fnc_hashSet;
-                };
-
-                _profilesActiveSide = [_profilesActiveBySide, _side] call ALIVE_fnc_hashGet;
-                [_profilesActiveSide, _profileID, _profile] call ALIVE_fnc_hashSet;
-                [_profilesActiveBySide, _side, _profilesActiveSide] call ALIVE_fnc_hashSet;
-        };
-        case "setInActive": {
-                private["_profileID","_side","_profile","_profilesInActive","_profilesActive","_profilesActiveBySide","_profilesInActiveBySide","_profilesInActiveSide","_profilesActiveSide"];
-
-                _profileID = _args select 0;
-                _side = _args select 1;
-                _profile = _args select 2;
-
-                _profilesInActive = [_logic, "profilesInActive"] call ALIVE_fnc_hashGet;
-                _profilesActive = [_logic, "profilesActive"] call ALIVE_fnc_hashGet;
-
-                if(_profileID in _profilesActive) then {
-                    _profilesActive = _profilesActive - [_profileID];
-                };
-
-                _profilesInActive pushback _profileID;
-
-                _profilesInActive = [_logic, "profilesInActive",_profilesInActive] call ALIVE_fnc_hashSet;
-                _profilesActive = [_logic, "profilesActive", _profilesActive] call ALIVE_fnc_hashSet;
-
-
-                _profilesActiveBySide = [_logic, "profilesActiveBySide"] call ALIVE_fnc_hashGet;
-                _profilesInActiveBySide = [_logic, "profilesInActiveBySide"] call ALIVE_fnc_hashGet;
-
-                _profilesActiveSide = [_profilesActiveBySide, _side] call ALIVE_fnc_hashGet;
-
-                if(_profileID in (_profilesActiveSide select 1)) then {
-                    [_profilesActiveSide, _profileID] call ALIVE_fnc_hashRem;
-                    [_profilesActiveBySide, _side, _profilesActiveSide] call ALIVE_fnc_hashSet;
-                };
-
-                _profilesInActiveSide = [_profilesInActiveBySide, _side] call ALIVE_fnc_hashGet;
-                [_profilesInActiveSide, _profileID, _profile] call ALIVE_fnc_hashSet;
-                [_profilesInActiveBySide, _side, _profilesInActiveSide] call ALIVE_fnc_hashSet;
-        };
-        case "getPlayerEntities": {
-                _result = [_logic, "playerEntities"] call ALIVE_fnc_hashGet;
-        };
-        case "getPlayerIndex": {
-                _result = [_logic, "playerIndex"] call ALIVE_fnc_hashGet;
-        };
-        case "getActive": {
-                _result = [_logic, "profilesActive"] call ALIVE_fnc_hashGet;
-        };
-        case "getInActive": {
-                _result = [_logic, "profilesInActive"] call ALIVE_fnc_hashGet;
-        };
-        case "getActiveBySide": {
-                private["_side","_profilesActiveBySide"];
-
-                _side = _args;
-
-                _profilesActiveBySide = [_logic, "profilesActiveBySide"] call ALIVE_fnc_hashGet;
-                _result = [_profilesActiveBySide, _side] call ALIVE_fnc_hashGet;
-        };
-        case "getInActiveBySide": {
-                private["_side","_profilesInActiveSide"];
-
-                _side = _args;
-
-                _profilesInActiveSide = [_logic, "profilesInActiveBySide"] call ALIVE_fnc_hashGet;
-                _result = [_profilesInActiveSide, _side] call ALIVE_fnc_hashGet;
-        };
-        case "setEntityActive": {
-                private["_profileID","_entityProfilesInActive","_entityProfilesActive"];
-
-                _profileID = _args;
-                _entityProfilesActive = [_logic, "entitiesActive"] call ALIVE_fnc_hashGet;
-                _entityProfilesInActive = [_logic, "entitiesInActive"] call ALIVE_fnc_hashGet;
-
-                if(_profileID in _entityProfilesInActive) then {
-                    _entityProfilesInActive = _entityProfilesInActive - [_profileID];
-                };
-
-                _entityProfilesActive pushback _profileID;
-
-                _entityProfilesInActive = [_logic, "entitiesInActive",_entityProfilesInActive] call ALIVE_fnc_hashSet;
-                _entityProfilesActive = [_logic, "entitiesActive", _entityProfilesActive] call ALIVE_fnc_hashSet;
-        };
-        case "setEntityInActive": {
-                private["_profileID","_entityProfilesInActive","_entityProfilesActive"];
-
-                _profileID = _args;
-                _entityProfilesActive = [_logic, "entitiesActive"] call ALIVE_fnc_hashGet;
-                _entityProfilesInActive = [_logic, "entitiesInActive"] call ALIVE_fnc_hashGet;
-
-                if(_profileID in _entityProfilesActive) then {
-                    _entityProfilesActive = _entityProfilesActive - [_profileID];
-                };
-
-                _entityProfilesInActive pushback _profileID;
-
-                _entityProfilesInActive = [_logic, "entitiesInActive",_entityProfilesInActive] call ALIVE_fnc_hashSet;
-                _entityProfilesActive = [_logic, "entitiesActive", _entityProfilesActive] call ALIVE_fnc_hashSet;
-        };
-        case "getActiveEntities": {
-                _result = [_logic, "entitiesActive"] call ALIVE_fnc_hashGet;
-        };
-        case "getInActiveEntities": {
-                _result = [_logic, "entitiesInActive"] call ALIVE_fnc_hashGet;
-        };
-        case "getInActiveEntitiesForMarking": {
-                private["_entities","_profile","_position","_side"];
-
-                _entities = [_logic, "entitiesInActive"] call ALIVE_fnc_hashGet;
-                _result = [];
-
-                {
-                    _profile = [ALIVE_profileHandler, "getProfile", _x] call ALIVE_fnc_profileHandler;
-
-                    if !(isNil "_profile") then {
-                        _position = _profile select 2 select 2;
-                        _side = _profile select 2 select 3;
-
-                        _result pushback [_position,_side];
-                    };
-                } forEach _entities;
-        };
-        case "setPosition": {
-                private["_profileID","_position","_profilePositions"];
-
-                _profileID = _args select 0;
-                _position = _args select 1;
-
-                _profilePositions = [_logic, "profilePositions"] call ALIVE_fnc_hashGet;
-                [_profilePositions, _profileID, _position] call ALIVE_fnc_hashSet;
-
-        };
-        case "getProfile": {
-                if (_args isEqualType "") then {
-                    _profiles = [_logic, "profiles"] call ALIVE_fnc_hashGet;
-
-                    private _index = (_profiles select 1) find _args;
-
-                    if (_index != -1) then {
-                        _result = (_profiles select 2) select _index;
-                    };
-                };
-        };
-        case "getProfiles": {
-                _result = [_logic, "profiles"] call ALIVE_fnc_hashGet;
-        };
-        case "getProfilesByType": {
-                private["_type","_profilesByType"];
-
-                if(typeName _args == "STRING") then {
-                    _type = _args;
-
-                    _profilesByType = [_logic, "profilesByType"] call ALIVE_fnc_hashGet;
-
-                    _result = [_profilesByType, _type] call ALIVE_fnc_hashGet;
-                };
-        };
-        case "getProfilesBySide": {
-                private["_side","_profilesBySide"];
-
-                if(typeName _args == "STRING") then {
-                    _side = _args;
-
-                    _profilesBySide = [_logic, "profilesBySide"] call ALIVE_fnc_hashGet;
-
-                    _result = [_profilesBySide, _side] call ALIVE_fnc_hashGet;
-                };
-        };
-        case "getProfilesBySideFull": {
-                private["_side","_profilesBySideFull"];
-
-                if(typeName _args == "STRING") then {
-                    _side = _args;
-
-                    _profilesBySideFull = [_logic, "profilesBySideFull"] call ALIVE_fnc_hashGet;
-
-                    _result = [_profilesBySideFull, _side] call ALIVE_fnc_hashGet;
-                };
-        };
-        case "getProfilesByFaction": {
-                private["_faction","_profilesByFaction"];
-
-                if(typeName _args == "STRING") then {
-                    _faction = _args;
-
-                    _profilesByFaction = [_logic, "profilesByFaction"] call ALIVE_fnc_hashGet;
-
-                    _result = [_profilesByFaction, _faction,[]] call ALIVE_fnc_hashGet;
-                };
-        };
-        case "getProfilesByFactionByType": {
-                private["_faction","_profilesByFactionByType","_profilesFactionType","_type"];
-
-                _faction = _args select 0;
-                _type = _args select 1;
-
-                _profilesByFactionByType = [_logic, "profilesByFactionByType"] call ALIVE_fnc_hashGet;
-                _profilesFactionType = [_profilesByFactionByType, _faction] call ALIVE_fnc_hashGet;
-
-                _result = [_profilesFactionType, _type] call ALIVE_fnc_hashGet;
-        };
-        case "getProfilesByFactionByVehicleType": {
-                private["_faction","_profilesByFactionByVehicleType","_profilesFactionType","_type"];
-
-                _faction = _args select 0;
-                _type = _args select 1;
-
-                _profilesByFactionByVehicleType = [_logic, "profilesByFactionByVehicleType"] call ALIVE_fnc_hashGet;
-                _profilesFactionType = [_profilesByFactionByVehicleType, _faction] call ALIVE_fnc_hashGet;
-
-                _result = [_profilesFactionType, _type] call ALIVE_fnc_hashGet;
-        };
-        case "getFactionBreakdown": {
-                private["_faction","_factionProfiles","_factionEntityProfiles","_factionVehicleProfiles","_factionVehicleCars","_factionVehicleTanks","_factionVehicleArmoured",
-                "_factionVehicleTruck","_factionVehicleShips","_factionVehicleHelicopters","_factionVehiclePlane","_breakdown","_factionVehicleArmored"];
-
-                if(typeName _args == "STRING") then {
-                    _faction = _args;
-
-                    _factionProfiles = [ALIVE_profileHandler, "getProfilesByFaction", _faction] call ALIVE_fnc_profileHandler;
-
-                    _factionEntityProfiles = [ALIVE_profileHandler, "getProfilesByFactionByType", [_faction,'entity']] call ALIVE_fnc_profileHandler;
-                    _factionVehicleProfiles = [ALIVE_profileHandler, "getProfilesByFactionByType", [_faction,'vehicle']] call ALIVE_fnc_profileHandler;
-
-                    _factionVehicleCars = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Car']] call ALIVE_fnc_profileHandler;
-                    _factionVehicleTanks = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Tank']] call ALIVE_fnc_profileHandler;
-                    _factionVehicleArmored = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Armored']] call ALIVE_fnc_profileHandler;
-                    _factionVehicleTruck = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Truck']] call ALIVE_fnc_profileHandler;
-                    _factionVehicleShips = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Ship']] call ALIVE_fnc_profileHandler;
-                    _factionVehicleHelicopters = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Helicopter']] call ALIVE_fnc_profileHandler;
-                    _factionVehiclePlane = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Plane']] call ALIVE_fnc_profileHandler;
-
-                    _breakdown = [] call ALIVE_fnc_hashCreate;
-                    [_breakdown, "total", count _factionProfiles] call ALIVE_fnc_hashSet;
-                    [_breakdown, "entity", count _factionEntityProfiles] call ALIVE_fnc_hashSet;
-                    [_breakdown, "vehicle", count _factionVehicleProfiles] call ALIVE_fnc_hashSet;
-                    [_breakdown, "car", count _factionVehicleCars] call ALIVE_fnc_hashSet;
-                    [_breakdown, "tank", count _factionVehicleTanks] call ALIVE_fnc_hashSet;
-                    [_breakdown, "armor", count _factionVehicleArmored] call ALIVE_fnc_hashSet;
-                    [_breakdown, "truck", count _factionVehicleTruck] call ALIVE_fnc_hashSet;
-                    [_breakdown, "ship", count _factionVehicleShips] call ALIVE_fnc_hashSet;
-                    [_breakdown, "helicopters", count _factionVehicleHelicopters] call ALIVE_fnc_hashSet;
-                    [_breakdown, "plane", count _factionVehiclePlane] call ALIVE_fnc_hashSet;
-
-                    _result = _breakdown;
-                };
-        };
-        case "getProfilesByVehicleType": {
-                private["_type","_profilesByVehicleType"];
-
-                if(typeName _args == "STRING") then {
-                    _type = _args;
-
-                    _profilesByVehicleType = [_logic, "profilesByVehicleType"] call ALIVE_fnc_hashGet;
-
-                    _result = [_profilesByVehicleType, _type] call ALIVE_fnc_hashGet;
-                };
-        };
-        case "getProfilesByCompany": {
-                private["_company","_profilesByCompany"];
-
-                if(typeName _args == "STRING") then {
-                    _company = _args;
-
-                    _profilesByCompany = [_logic, "profilesByCompany"] call ALIVE_fnc_hashGet;
-
-                    _result = [_profilesByCompany, _company] call ALIVE_fnc_hashGet;
-                };
-        };
-        case "getProfilesByCategory": {
-                private["_side","_type","_vehicleType","_profilesCatagorised"];
-
-                _side = _args select 0;
-                _type = _args select 1;
-                _vehicleType = if(count _args > 2) then {_args select 2} else {"none"};
-
-                _profilesCatagorised = [_logic, "profilesCatagorised"] call ALIVE_fnc_hashGet;
-
-                if(_vehicleType == "none") then {
-                    // return the sides type
-                    _result = [[[_profilesCatagorised, _side] call ALIVE_fnc_hashGet, "type"] call ALIVE_fnc_hashGet, _type] call ALIVE_fnc_hashGet;
-                }else{
-                    // return the sides vehicle type
-                    _result = [[[_profilesCatagorised, _side] call ALIVE_fnc_hashGet, "vehicleType"] call ALIVE_fnc_hashGet, _vehicleType] call ALIVE_fnc_hashGet;
-                };
-        };
-        case "getNextInsertID": {
-            private["_profiles","_profileCount"];
-
-            _profileCount = [_logic, "profileCount"] call ALIVE_fnc_hashGet;
-            _result = _profileCount;
-
-            _profileCount = _profileCount + 1;
-            [_logic, "profileCount", _profileCount] call ALIVE_fnc_hashSet;
-        };
-        case "getNextInsertEntityID": {
-            private["_entityCount"];
-
-            _entityCount = [_logic, "profileEntityCount"] call ALIVE_fnc_hashGet;
-            _result = format["entity_%1",_entityCount];
-            _entityCount = _entityCount + 1;
-            [_logic, "profileEntityCount", _entityCount] call ALIVE_fnc_hashSet;
-        };
-        case "getNextInsertVehicleID": {
-            private["_vehicleCount"];
-
-            _vehicleCount = [_logic, "profileVehicleCount"] call ALIVE_fnc_hashGet;
-            _result = format["vehicle_%1",_vehicleCount];
-            _vehicleCount = _vehicleCount + 1;
-            [_logic, "profileVehicleCount", _vehicleCount] call ALIVE_fnc_hashSet;
-        };
-        case "getUnitCount": {
-            private["_unitCount","_profiles","_profileType","_entities","_entity","_count"];
-            _unitCount = 0;
-            _profiles = [_logic, "profiles"] call ALIVE_fnc_hashGet;
-
+        if !(_profiles isEqualTo []) then {
             {
-                _profileType = _x select 2 select 5; //[_profile,"type"] call ALIVE_fnc_hashGet;
-                if(_profileType == "entity") then {
-                    _count = [_x, "unitCount"] call ALIVE_fnc_profileEntity;
-                    _unitCount = _unitCount + _count;
-                }
+                switch([_x,"type"] call ALIVE_fnc_hashGet) do {
+                    case "entity": {
+                        [_x,"debug", false] call ALIVE_fnc_profileEntity;
+                    };
+                    case "vehicle": {
+                        [_x,"debug", false] call ALIVE_fnc_profileVehicle;
+                    };
+                };
             } forEach (_profiles select 2);
 
-            _result = _unitCount;
+            if (_args) then {
+                {
+                    switch([_x, "type"] call ALIVE_fnc_hashGet) do {
+                        case "entity": {
+                            [_x,"debug", true] call ALIVE_fnc_profileEntity;
+                        };
+                        case "vehicle": {
+                            [_x,"debug", true] call ALIVE_fnc_profileVehicle;
+                        };
+                    };
+                } forEach (_profiles select 2);
+
+                // DEBUG -------------------------------------------------------------------------------------
+                //["----------------------------------------------------------------------------------------"] call ALIVE_fnc_dump;
+                //["ALIVE Profile Handler State"] call ALIVE_fnc_dump;
+                //_state = [_logic, "state"] call MAINCLASS;
+                //_state call ALIVE_fnc_inspectHash;
+                // DEBUG -------------------------------------------------------------------------------------
+            };
         };
-        case "getVehicleCount": {
-            private["_unitCount","_vehicles"];
-            _vehicles = [_logic, "getProfilesByType", "vehicle"] call MAINCLASS;
-            _result = count _vehicles;
-        };
 
-        case "reset": {
+        _result = _args;
+    };
 
-             private["_profiles","_profileIndex","_profile","_profileID","_profileType","_isPlayer","_state"];
+    case "state": {
+        if !(_args isEqualTo []) then {
+            // Save state
 
-            _profiles = [_logic, "getProfiles"] call MAINCLASS;
+            private _state = [] call ALIVE_fnc_hashCreate;
 
-            _profileIndex = [];
-            _profileIndex =+ _profiles select 1;
-
+            // loop the class hash and set vars on the state hash
             {
-                _profile = [_profiles, _x] call ALIVE_fnc_hashGet;
+                if(!(_x == "super") && !(_x == "class")) then {
+                    [_state,_x,[_logic,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                };
+            } forEach (_logic select 1);
 
+            _result = _state;
+        } else {
+            ASSERT_TRUE(typeName _args == "ARRAY",str typeName _args);
+
+            // Restore state
+
+            // loop the passed hash and set vars on the class hash
+            {
+                [_logic,_x,[_args,_x] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+            } forEach (_args select 1);
+        };
+    };
+
+    case "registerProfile": {
+        if (_args isEqualType []) then {
+            private _profile = _args;
+
+            private _profiles = [_logic,"profiles"] call ALIVE_fnc_hashGet;
+            private _profilesByType = [_logic,"profilesByType"] call ALIVE_fnc_hashGet;
+            private _profilesCatagorised = [_logic,"profilesCatagorised"] call ALIVE_fnc_hashGet;
+            private _profilePositions = [_logic,"profilePositions"] call ALIVE_fnc_hashGet;
+
+            private _profileSide = [_profile,"side"] call ALIVE_fnc_hashGet;
+            private _profileID = [_profile,"profileID"] call ALIVE_fnc_hashGet;
+            private _profileType = [_profile,"type"] call ALIVE_fnc_hashGet;
+            private _profilePosition = [_profile,"position"] call ALIVE_fnc_hashGet;
+
+            // insert into spacial grid
+            private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
+            [_spacialGrid,"insert", [[_profilePosition,_profile]]] call ALiVE_fnc_spacialGrid;
+
+            private _profilesCatagorisedSide = [_profilesCatagorised, _profileSide] call ALIVE_fnc_hashGet;
+
+            if (isnil "_profilesCatagorisedSide") exitwith {["ALIVE Error on detecting correct side #hash for profile %1",_profileID] call ALiVE_fnc_Dump};
+
+            // store on main profiles hash
+            [_profiles, _profileID, _profile] call ALIVE_fnc_hashSet;
+
+            // store the position in the position index
+            [_profilePositions, _profileID, _profilePosition] call ALIVE_fnc_hashSet;
+
+            // store reference to main profile on by type hash
+            _profilesType = [_profilesByType, _profileType] call ALIVE_fnc_hashGet;
+            _profilesType pushback _profileID;
+
+            // store reference to main profile on by catagorised type hash
+            private _profilesCatagorisedTypes = [_profilesCatagorisedSide, "type"] call ALIVE_fnc_hashGet;
+            _profilesCatagorisedType = [_profilesCatagorisedTypes, _profileType] call ALIVE_fnc_hashGet;
+            _profilesCatagorisedType pushback _profileID;
+
+
+            // DEBUG -------------------------------------------------------------------------------------
+            if([_logic,"debug"] call ALIVE_fnc_hashGet) then {
+                switch(_profileType) do {
+                    case "entity": {
+                        [_profile,"debug", true] call ALIVE_fnc_profileEntity;
+                    };
+                    case "vehicle": {
+                        [_profile,"debug", true] call ALIVE_fnc_profileVehicle;
+                    };
+                };
+                ["ALIVE Profile Handler - Register Profile [%1]",_profileID] call ALIVE_fnc_dump;
                 //_profile call ALIVE_fnc_inspectHash;
+            };
+            // DEBUG -------------------------------------------------------------------------------------
 
-                _profileID = _profile select 2 select 4;
-                _profileType = _profile select 2 select 5;
-                _isPlayer = false;
 
-                if(_profileType == "entity") then {
-                    _isPlayer = _profile select 2 select 30;
+            if (_profileType in ["entity","vehicle","civ"]) then {
+
+                // store reference to main profile on by side hash
+                private _profilesBySide = [_logic,"profilesBySide"] call ALIVE_fnc_hashGet;
+                private _profilesSide = [_profilesBySide, _profileSide] call ALIVE_fnc_hashGet;
+                _profilesSide pushback _profileID;
+
+                // store profile on side hash
+                private _profilesBySideFull = [_logic,"profilesBySideFull"] call ALIVE_fnc_hashGet;
+                private _profilesSideFull = [_profilesBySideFull, _profileSide] call ALIVE_fnc_hashGet;
+                [_profilesSideFull, _profileID, _profile] call ALIVE_fnc_hashSet;
+
+                private ["_profilesFactionType","_profilesFactionVehicleType"];
+
+                // store reference to main profile on by faction hash
+
+                private _profileFaction = [_profile,"faction"] call ALIVE_fnc_hashGet;
+
+                private _profilesByFaction = [_logic,"profilesByFaction"] call ALIVE_fnc_hashGet;
+                private _profilesFaction = [_profilesByFaction, _profileFaction] call ALIVE_fnc_hashGet;
+
+                private _profilesByFactionByType = [_logic,"profilesByFactionByType"] call ALIVE_fnc_hashGet;
+                private _profilesByFactionByVehicleType = [_logic,"profilesByFactionByVehicleType"] call ALIVE_fnc_hashGet;
+
+                if (!isnil "_profilesFaction") then {
+                    _profilesFactionType = [_profilesByFactionByType, _profileFaction] call ALIVE_fnc_hashGet;
+                    _profilesFactionVehicleType = [_profilesByFactionByVehicleType, _profileFaction] call ALIVE_fnc_hashGet;
+                } else {
+                    _profilesFaction = [];
+                    [_profilesByFaction, _profileFaction, _profilesFaction] call ALIVE_fnc_hashSet;
+
+                    _profilesFactionType = [
+                        [
+                            ["entity", []],
+                            ["vehicle", []]
+                        ]
+                    ] call ALIVE_fnc_hashCreate;
+                    [_profilesByFactionByType, _profileFaction, _profilesFactionType] call ALIVE_fnc_hashSet;
+
+                    _profilesFactionVehicleType = [
+                        [
+                            ["Car", []],
+                            ["Tank", []],
+                            ["Armored", []],
+                            ["Truck", []],
+                            ["Ship", []],
+                            ["Helicopter", []],
+                            ["Plane", []],
+                            ["StaticWeapon", []],
+                            ["Vehicle", []]
+                        ]
+                    ] call ALIVE_fnc_hashCreate;
+                    [_profilesByFactionByVehicleType, _profileFaction, _profilesFactionVehicleType] call ALIVE_fnc_hashSet;
                 };
 
-                if!(_isPlayer) then {
-                    if(_profileType == "entity") then {
-                        [_profile, "destroy"] call ALIVE_fnc_profileEntity;
-                    }else{
-                        [_profile, "destroy"] call ALIVE_fnc_profileVehicle;
+                _profilesFaction pushback _profileID;
+
+                private _profileFactionType = [_profilesFactionType, _profileType] call ALIVE_fnc_hashGet;
+                _profileFactionType pushback _profileID;
+
+                if ([_profile, "active"] call ALIVE_fnc_hashGet) then {
+                    private _profilesActive = [_logic,"profilesActive"] call ALIVE_fnc_hashGet;
+                    _profilesActive pushback _profileID;
+
+                    // store profile on side hash
+                    private _profilesActiveBySide = [_logic,"profilesActiveBySide"] call ALIVE_fnc_hashGet;
+                    private _profilesActiveSide = [_profilesActiveBySide, _profileSide] call ALIVE_fnc_hashGet;
+                    [_profilesActiveSide, _profileID, _profile] call ALIVE_fnc_hashSet;
+
+                    if (_profileType == "entity") then {
+                        private _entityProfilesActive = [_logic,"entitiesActive"] call ALIVE_fnc_hashGet;
+                        _entityProfilesActive pushback _profileID;
+                    };
+                } else {
+                    private _profilesInActive = [_logic,"profilesInActive"] call ALIVE_fnc_hashGet;
+                    _profilesInActive pushback _profileID;
+
+                    // store profile on side hash
+                    private _profilesInActiveBySide = [_logic,"profilesInActiveBySide"] call ALIVE_fnc_hashGet;
+                    private _profilesInActiveSide = [_profilesInActiveBySide, _profileSide] call ALIVE_fnc_hashGet;
+                    [_profilesInActiveSide, _profileID, _profile] call ALIVE_fnc_hashSet;
+
+                    if (_profileType == "entity") then {
+                        private _entityProfilesInActive = [_logic,"entitiesInActive"] call ALIVE_fnc_hashGet;
+                        _entityProfilesInActive pushback _profileID;
                     };
                 };
 
-            } forEach _profileIndex;
+                if (_profileType != "vehicle") then {
 
-            _state = [_logic, "state"] call MAINCLASS;
-            _state call ALIVE_fnc_inspectHash;
+                    // if player entity
+                    if ([_profile,"isPlayer"] call ALIVE_fnc_hashGet) then {
+                        private _playerEntities = [_logic,"playerEntities"] call ALIVE_fnc_hashGet;
+                        [_playerEntities, _profileID, _profile] call ALIVE_fnc_hashSet;
+                    };
+
+                    // if company id is set
+                    private _profileCompany = [_profile,"companyID"] call ALIVE_fnc_hashGet;
+                    if (_profileCompany != "") then {
+                        private _profilesByCompany = [_logic,"profilesByCompany"] call ALIVE_fnc_hashGet;
+                        private _profleByCompanyArray = [_profilesByCompany, _profileCompany] call ALIVE_fnc_hashGet;
+
+                        if (isnil "_profleByCompanyArray") then {
+                            [_profilesByCompany, _profileCompany, [_profileID]] call ALIVE_fnc_hashSet;
+                        } else {
+                            _profleByCompanyArray pushback _profileID;
+                        };
+                    };
+                } else {
+                    private _profileVehicleType = [_profile,"objectType"] call ALIVE_fnc_hashGet;
+
+                    // vehicle type
+                    private _profilesByVehicleType = [_logic,"profilesByVehicleType"] call ALIVE_fnc_hashGet;
+                    private _profilesVehicleType = [_profilesByVehicleType,_profileVehicleType] call ALIVE_fnc_hashGet;
+                    _profilesVehicleType pushback _profileID;
+
+                    private _profileFactionVehicleType = [_profilesFactionVehicleType,_profileVehicleType] call ALIVE_fnc_hashGet;
+                    _profileFactionVehicleType pushback _profileID;
+
+                    private _profilesCatagorisedVehicleTypes = [_profilesCatagorisedSide,"vehicleType"] call ALIVE_fnc_hashGet;
+                    private _profilesCatagorisedVehicleType = [_profilesCatagorisedVehicleTypes, _profileVehicleType] call ALIVE_fnc_hashGet;
+                    _profilesCatagorisedVehicleType pushback _profileID;
+                };
+            };
         };
-        case "saveProfileData": {
+    };
 
-            private ["_message","_messages","_saveResult","_datahandler","_exportProfiles","_async","_missionName","_message"];
+    case "unregisterProfile": {
+        if (_args isEqualType "") then {_args = [_logic,"getProfile", _args] call MAINCLASS};
 
-            _result = [false,[]];
+        if (_args isEqualType []) then {
+            private _profile = _args;
 
-            _exportProfiles = [_logic, "exportProfileData"] call MAINCLASS;
+            private _profiles = [_logic,"profiles"] call ALIVE_fnc_hashGet;
+            private _profilesByType = [_logic,"profilesByType"] call ALIVE_fnc_hashGet;
+            private _profilesCatagorised = [_logic,"profilesCatagorised"] call ALIVE_fnc_hashGet;
+            private _profilePositions = [_logic,"profilePositions"] call ALIVE_fnc_hashGet;
 
-            if(isNil"ALIVE_profileDatahandler") then {
+            private _profileSide = [_profile,"side"] call ALIVE_fnc_hashGet;
+            private _profileID = [_profile,"profileID"] call ALIVE_fnc_hashGet;
+            private _profileType = [_profile,"type"] call ALIVE_fnc_hashGet;
+            private _profilePosition = [_profile,"position"] call ALIVE_fnc_hashGet;
 
-                if(ALiVE_SYS_DATA_DEBUG_ON) then {
-                    ["ALiVE SYS PROFILE - SAVE PROFILE, CREATE DATA HANDLER - NO!"] call ALIVE_fnc_dump;
+            // remove from spacial grid
+            private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
+            [_spacialGrid,"remove", [_profilePosition,_profile]] call ALiVE_fnc_spacialGrid;
+
+            private _profilesCatagorisedSide = [_profilesCatagorised, _profileSide] call ALIVE_fnc_hashGet;
+            private _profilesCatagorisedTypes = [_profilesCatagorisedSide, "type"] call ALIVE_fnc_hashGet;
+            private _profilesCatagorisedVehicleTypes = [_profilesCatagorisedSide, "vehicleType"] call ALIVE_fnc_hashGet;
+
+            // remove on main profiles hash
+            [_profiles, _profileID] call ALIVE_fnc_hashRem;
+
+            // remove from position index
+            [_profilePositions, _profileID] call ALIVE_fnc_hashRem;
+
+            // remove reference to main profile on by type hash
+            private _profilesType = [_profilesByType, _profileType] call ALIVE_fnc_hashGet;
+            _profilesType deleteat (_profilesType find _profileID);
+
+            // remove reference to main profile on by catagorised type hash
+            private _profilesCatagorisedType = [_profilesCatagorisedTypes, _profileType] call ALIVE_fnc_hashGet;
+            _profilesCatagorisedType deleteat (_profilesCatagorisedType find _profileID);
+
+            // disable debugging on the profile
+            if([_profile, "debug"] call ALIVE_fnc_hashGet) then {
+                switch(_profileType) do {
+                    case "entity": {
+                        _result = [_profile,"debug", false] call ALIVE_fnc_profileEntity;
+                    };
+                    case "civ": {
+                        _result = [_profile,"debug", false] call ALIVE_fnc_profileCiv;
+                    };
+                    case "vehicle": {
+                        _result = [_profile,"debug", false] call ALIVE_fnc_profileVehicle;
+                    };
+                };
+            };
+
+            // DEBUG -------------------------------------------------------------------------------------
+            if([_logic,"debug"] call ALIVE_fnc_hashGet) then {
+                ["ALIVE Profile Handler - Un-Register Profile [%1]",_profileID] call ALIVE_fnc_dump;
+                //_profile call ALIVE_fnc_inspectHash;
+            };
+            // DEBUG -------------------------------------------------------------------------------------
+
+            if (_profileType in ["entity","vehicle","mil"]) then {
+                private _profileFaction = [_profile,"faction"] call ALIVE_fnc_hashGet;
+                private _profilesBySide = [_logic,"profilesBySide"] call ALIVE_fnc_hashGet;
+
+                // remove reference to main profile on by side hash
+                private _profilesSide = [_profilesBySide, _profileSide] call ALIVE_fnc_hashGet;
+                _profilesSide deleteat (_profilesSide find _profileID);
+
+                // remove profile on full side hash
+                private _profilesBySideFull = [_logic,"profilesBySideFull"] call ALIVE_fnc_hashGet;
+                private _profilesSide = [_profilesBySideFull, _profileSide] call ALIVE_fnc_hashGet;
+                [_profilesSide, _profileID] call ALIVE_fnc_hashRem;
+
+                // remove reference to main profile on by faction hash
+                private _profilesByFaction = [_logic,"profilesByFaction"] call ALIVE_fnc_hashGet;
+                private _profilesFaction = [_profilesByFaction, _profileFaction] call ALIVE_fnc_hashGet;
+                _profilesFaction deleteat (_profilesFaction find _profileID);
+
+                private _profilesByFactionByType = [_logic,"profilesByFactionByType"] call ALIVE_fnc_hashGet;
+                private _profilesFactionType = [_profilesByFactionByType, _profileFaction] call ALIVE_fnc_hashGet;
+                private _profileFactionType = [_profilesFactionType, _profileType] call ALIVE_fnc_hashGet;
+                _profileFactionType deleteat (_profileFactionType find _profileID);
+
+                private _profilesByFactionByVehicleType = [_logic,"profilesByFactionByVehicleType"] call ALIVE_fnc_hashGet;
+                private _profilesFactionVehicleType = [_profilesByFactionByVehicleType, _profileFaction] call ALIVE_fnc_hashGet;
+
+                if ([_profile, "active"] call ALIVE_fnc_hashGet) then {
+                    // Remove ProfileID if any units are left
+                    private _vehicle = [_profile,"vehicle"] call ALIVE_fnc_hashGet;
+                    if !(isnil "_vehicle") then {_vehicle setvariable ["ProfileID",nil]};
+
+                    private _units = [_profile,"units",[]] call ALIVE_fnc_hashGet;
+                    if (count _units > 0) then {
+                        {_x setVariable ["ProfileID",nil];
+                    } foreach (units group (_units select 0))};
+
+                    private _profilesActive = [_logic,"profilesActive"] call ALIVE_fnc_hashGet;
+                    _profilesActive deleteat (_profilesActive find _profileID);
+
+                    private _profilesActiveBySide = [_logic,"profilesActiveBySide"] call ALIVE_fnc_hashGet;
+                    private _profilesActiveSide = [_profilesActiveBySide, _profileSide] call ALIVE_fnc_hashGet;
+                    [_profilesActiveSide, _profileID] call ALIVE_fnc_hashRem;
+
+                    if (_profileType == "entity") then {
+                        private _entityProfilesActive = [_logic,"entitiesActive"] call ALIVE_fnc_hashGet;
+                        _entityProfilesActive deleteat (_entityProfilesActive find _profileID);
+                    };
+                } else {
+                    private _profilesInActiveBySide = [_logic,"profilesInActiveBySide"] call ALIVE_fnc_hashGet;
+                    private _profilesInActive = [_logic,"profilesInActive"] call ALIVE_fnc_hashGet;
+
+                    _profilesInActive deleteat (_profilesInActive find _profileID);
+
+                    private _profilesInActiveSide = [_profilesInActiveBySide, _profileSide] call ALIVE_fnc_hashGet;
+                    [_profilesInActiveSide, _profileID] call ALIVE_fnc_hashRem;
+
+                    if (_profileType == "entity") then {
+                        private _entityProfilesInActive = [_logic,"entitiesInActive"] call ALIVE_fnc_hashGet;
+                        _entityProfilesInActive deleteat (_entityProfilesInActive find _profileID);
+                    };
                 };
 
-                ALIVE_profileDatahandler = [nil, "create"] call ALIVE_fnc_Data;
-                [ALIVE_profileDatahandler,"storeType",true] call ALIVE_fnc_Data;
+                if (_profileType != "vehicle") then {
+                    if([_profile,"isPlayer"] call ALIVE_fnc_hashGet) then {
+                        private _playerEntities = [_logic,"playerEntities"] call ALIVE_fnc_hashGet;
+                        [_playerEntities, _profileID] call ALIVE_fnc_hashRem;
+                    };
+
+                    // if company id is set
+                    private _profileCompany = [_profile,"companyID"] call ALIVE_fnc_hashGet;
+                    if (_profileCompany != "") then {
+                        private _profilesByCompany = [_logic,"profilesByCompany"] call ALIVE_fnc_hashGet;
+                        private _profleByCompanyArray = [_profilesByCompany, _profileCompany] call ALIVE_fnc_hashGet;
+                        _profleByCompanyArray deleteat (_profleByCompanyArray find _profileID);
+                    };
+                } else {
+                    private _profileVehicleType = [_profile,"objectType"] call ALIVE_fnc_hashGet;
+
+                    // vehicle type
+                    private _profilesByVehicleType = [_logic,"profilesByVehicleType"] call ALIVE_fnc_hashGet;
+                    private _profilesVehicleType = [_profilesByVehicleType, _profileVehicleType] call ALIVE_fnc_hashGet;
+                    _profilesVehicleType deleteat (_profilesVehicleType find _profileID);
+
+                    private _profilesFactionVehicleType = [_profilesByFactionByVehicleType, _profileFaction] call ALIVE_fnc_hashGet;
+                    _profileFactionVehicleType = [_profilesFactionVehicleType, _profileVehicleType] call ALIVE_fnc_hashGet;
+                    _profileFactionVehicleType deleteat (_profileFactionVehicleType find _profileID);
+
+                    private _profilesCatagorisedVehicleType = [_profilesCatagorisedVehicleTypes, _profileVehicleType] call ALIVE_fnc_hashGet;
+                    _profilesCatagorisedVehicleType deleteat (_profilesCatagorisedVehicleType find _profileID);
+                };
+            };
+        };
+    };
+
+    case "setActive": {
+        private _profileID = _args select 0;
+        private _side = _args select 1;
+        private _profile = _args select 2;
+
+        private _profilesInActive = [_logic, "profilesInActive"] call ALIVE_fnc_hashGet;
+        private _profilesActive = [_logic, "profilesActive"] call ALIVE_fnc_hashGet;
+
+        private _inactiveIndex = _profilesInActive find _profileID;
+        if (_inactiveIndex != -1) then {
+            _profilesInActive deleteat _inactiveIndex;
+        };
+
+        _profilesActive pushback _profileID;
+
+        private _profilesActiveBySide = [_logic, "profilesActiveBySide"] call ALIVE_fnc_hashGet;
+        private _profilesInActiveBySide = [_logic, "profilesInActiveBySide"] call ALIVE_fnc_hashGet;
+
+        private _profilesInActiveSide = [_profilesInActiveBySide, _side] call ALIVE_fnc_hashGet;
+
+        [_profilesInActiveSide, _profileID] call ALIVE_fnc_hashRem;
+
+        private _profilesActiveSide = [_profilesActiveBySide, _side] call ALIVE_fnc_hashGet;
+        [_profilesActiveSide, _profileID, _profile] call ALIVE_fnc_hashSet;
+    };
+
+    case "setInActive": {
+        private _profileID = _args select 0;
+        private _side = _args select 1;
+        private _profile = _args select 2;
+
+        private _profilesInActive = [_logic,"profilesInActive"] call ALIVE_fnc_hashGet;
+        private _profilesActive = [_logic,"profilesActive"] call ALIVE_fnc_hashGet;
+
+        private _activeIndex = _profilesActive find _profileID;
+        if(_activeIndex != -1) then {
+            _profilesActive deleteat _activeIndex;
+        };
+
+        _profilesInActive pushback _profileID;
+
+        private _profilesActiveBySide = [_logic,"profilesActiveBySide"] call ALIVE_fnc_hashGet;
+        private _profilesInActiveBySide = [_logic,"profilesInActiveBySide"] call ALIVE_fnc_hashGet;
+
+        private _profilesActiveSide = [_profilesActiveBySide, _side] call ALIVE_fnc_hashGet;
+
+        [_profilesActiveSide, _profileID] call ALIVE_fnc_hashRem;
+
+        private _profilesInActiveSide = [_profilesInActiveBySide, _side] call ALIVE_fnc_hashGet;
+        [_profilesInActiveSide, _profileID, _profile] call ALIVE_fnc_hashSet;
+    };
+
+    case "getPlayerEntities": {
+        _result = [_logic,"playerEntities"] call ALIVE_fnc_hashGet;
+    };
+
+    case "getPlayerIndex":{
+        _result = [_logic,"playerIndex"] call ALIVE_fnc_hashGet;
+    };
+
+    case "getActive": {
+        _result = [_logic,"profilesActive"] call ALIVE_fnc_hashGet;
+    };
+
+    case "getInActive": {
+        _result = [_logic,"profilesInActive"] call ALIVE_fnc_hashGet;
+    };
+
+    case "getActiveBySide": {
+        private _profilesActiveBySide = [_logic, "profilesActiveBySide"] call ALIVE_fnc_hashGet;
+        _result = [_profilesActiveBySide, _args] call ALIVE_fnc_hashGet;
+    };
+
+    case "getInActiveBySide": {
+        private _side = _args;
+
+        private _profilesInActiveSide = [_logic, "profilesInActiveBySide"] call ALIVE_fnc_hashGet;
+        _result = [_profilesInActiveSide, _side] call ALIVE_fnc_hashGet;
+    };
+
+    case "setEntityActive": {
+        private _profileID = _args;
+
+        private _entityProfilesActive = [_logic, "entitiesActive"] call ALIVE_fnc_hashGet;
+        private _entityProfilesInActive = [_logic, "entitiesInActive"] call ALIVE_fnc_hashGet;
+
+        private _inactiveIndex = _entityProfilesInActive find _profileID;
+        if (_inactiveIndex != -1) then {
+            _entityProfilesInActive deleteat _inactiveIndex;
+        };
+
+        _entityProfilesActive pushback _profileID;
+    };
+
+    case "setEntityInActive": {
+        private _profileID = _args;
+
+        private _entityProfilesActive = [_logic,"entitiesActive"] call ALIVE_fnc_hashGet;
+        private _entityProfilesInActive = [_logic,"entitiesInActive"] call ALIVE_fnc_hashGet;
+
+        private _activeIndex = _entityProfilesActive find _profileID;
+        if (_activeIndex != -1) then {
+            _entityProfilesActive deleteat _activeIndex;
+        };
+
+        _entityProfilesInActive pushback _profileID;
+    };
+
+    case "getActiveEntities": {
+        _result = [_logic, "entitiesActive"] call ALIVE_fnc_hashGet;
+    };
+
+    case "getInActiveEntities": {
+        _result = [_logic, "entitiesInActive"] call ALIVE_fnc_hashGet;
+    };
+
+    case "getInActiveEntitiesForMarking": {
+        private _entities = [_logic, "entitiesInActive"] call ALIVE_fnc_hashGet;
+        _result = [];
+
+        {
+            private _profile = [ALIVE_profileHandler,"getProfile", _x] call ALIVE_fnc_profileHandler;
+
+            if !(isNil "_profile") then {
+                private _position = _profile select 2 select 2;
+                private _side = _profile select 2 select 3;
+
+                _result pushback [_position,_side];
+            };
+        } forEach _entities;
+    };
+
+    case "setPosition": {
+        private _profileID = _args select 0;
+        private _position = _args select 1;
+
+        private _profilePositions = [_logic,"profilePositions"] call ALIVE_fnc_hashGet;
+        [_profilePositions, _profileID, _position] call ALIVE_fnc_hashSet;
+    };
+
+    case "getProfile": {
+        if (_args isEqualType "") then {
+            _profiles = [_logic, "profiles"] call ALIVE_fnc_hashGet;
+
+            private _index = (_profiles select 1) find _args;
+
+            if (_index != -1) then {
+                _result = (_profiles select 2) select _index;
+            };
+        };
+    };
+
+    case "getProfiles": {
+        _result = [_logic, "profiles"] call ALIVE_fnc_hashGet;
+    };
+
+    case "getProfilesByType": {
+        if (_args isEqualType "") then {
+            private _profilesByType = [_logic, "profilesByType"] call ALIVE_fnc_hashGet;
+
+            _result = [_profilesByType, _args] call ALIVE_fnc_hashGet;
+        };
+
+    };
+
+    case "getProfilesBySide": {
+        if (_args isEqualType "") then {
+            private _profilesBySide = [_logic, "profilesBySide"] call ALIVE_fnc_hashGet;
+
+            _result = [_profilesBySide, _args] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "getProfilesBySideFull": {
+        if (_args isEqualType "") then {
+            private _profilesBySideFull = [_logic, "profilesBySideFull"] call ALIVE_fnc_hashGet;
+
+            _result = [_profilesBySideFull, _args] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "getProfilesByFaction": {
+        if (_args isEqualType "") then {
+            private _profilesByFaction = [_logic, "profilesByFaction"] call ALIVE_fnc_hashGet;
+
+            _result = [_profilesByFaction, _args, []] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "getProfilesByFactionByType": {
+        private _faction = _args select 0;
+        private _type = _args select 1;
+
+        private _profilesByFactionByType = [_logic, "profilesByFactionByType"] call ALIVE_fnc_hashGet;
+        private _profilesFactionType = [_profilesByFactionByType, _faction] call ALIVE_fnc_hashGet;
+
+        _result = [_profilesFactionType, _type] call ALIVE_fnc_hashGet;
+    };
+
+    case "getProfilesByFactionByVehicleType": {
+        private _faction = _args select 0;
+        private _type = _args select 1;
+
+        private _profilesByFactionByVehicleType = [_logic, "profilesByFactionByVehicleType"] call ALIVE_fnc_hashGet;
+        private _profilesFactionType = [_profilesByFactionByVehicleType, _faction] call ALIVE_fnc_hashGet;
+
+        _result = [_profilesFactionType, _type] call ALIVE_fnc_hashGet;
+    };
+
+    case "getFactionBreakdown": {
+        private["_faction","_factionProfiles","_factionEntityProfiles","_factionVehicleProfiles","_factionVehicleCars","_factionVehicleTanks","_factionVehicleArmoured",
+        "_factionVehicleTruck","_factionVehicleShips","_factionVehicleHelicopters","_factionVehiclePlane","_breakdown","_factionVehicleArmored"];
+
+        if (typeName _args == "STRING") then {
+            _faction = _args;
+
+            _factionProfiles = [ALIVE_profileHandler, "getProfilesByFaction", _faction] call ALIVE_fnc_profileHandler;
+
+            _factionEntityProfiles = [ALIVE_profileHandler, "getProfilesByFactionByType", [_faction,'entity']] call ALIVE_fnc_profileHandler;
+            _factionVehicleProfiles = [ALIVE_profileHandler, "getProfilesByFactionByType", [_faction,'vehicle']] call ALIVE_fnc_profileHandler;
+
+            _factionVehicleCars = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Car']] call ALIVE_fnc_profileHandler;
+            _factionVehicleTanks = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Tank']] call ALIVE_fnc_profileHandler;
+            _factionVehicleArmored = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Armored']] call ALIVE_fnc_profileHandler;
+            _factionVehicleTruck = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Truck']] call ALIVE_fnc_profileHandler;
+            _factionVehicleShips = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Ship']] call ALIVE_fnc_profileHandler;
+            _factionVehicleHelicopters = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Helicopter']] call ALIVE_fnc_profileHandler;
+            _factionVehiclePlane = [ALIVE_profileHandler, "getProfilesByFactionByVehicleType", [_faction,'Plane']] call ALIVE_fnc_profileHandler;
+
+            _breakdown = [] call ALIVE_fnc_hashCreate;
+            [_breakdown, "total", count _factionProfiles] call ALIVE_fnc_hashSet;
+            [_breakdown, "entity", count _factionEntityProfiles] call ALIVE_fnc_hashSet;
+            [_breakdown, "vehicle", count _factionVehicleProfiles] call ALIVE_fnc_hashSet;
+            [_breakdown, "car", count _factionVehicleCars] call ALIVE_fnc_hashSet;
+            [_breakdown, "tank", count _factionVehicleTanks] call ALIVE_fnc_hashSet;
+            [_breakdown, "armor", count _factionVehicleArmored] call ALIVE_fnc_hashSet;
+            [_breakdown, "truck", count _factionVehicleTruck] call ALIVE_fnc_hashSet;
+            [_breakdown, "ship", count _factionVehicleShips] call ALIVE_fnc_hashSet;
+            [_breakdown, "helicopters", count _factionVehicleHelicopters] call ALIVE_fnc_hashSet;
+            [_breakdown, "plane", count _factionVehiclePlane] call ALIVE_fnc_hashSet;
+
+            _result = _breakdown;
+        };
+    };
+
+    case "getProfilesByVehicleType": {
+        if (_args isEqualType "") then {
+            private _profilesByVehicleType = [_logic, "profilesByVehicleType"] call ALIVE_fnc_hashGet;
+
+            _result = [_profilesByVehicleType, _args] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "getProfilesByCompany": {
+        if (_args isEqualType "") then {
+            private _profilesByCompany = [_logic,"profilesByCompany"] call ALIVE_fnc_hashGet;
+
+            _result = [_profilesByCompany, _args] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "getProfilesByCategory": {
+        private _side = _args select 0;
+        private _type = _args select 1;
+        private _vehicleType = param [2, "none"];
+
+        private _profilesCatagorised = [_logic,"profilesCatagorised"] call ALIVE_fnc_hashGet;
+
+        if (_vehicleType == "none") then {
+            // return the sides type
+            _result = [[[_profilesCatagorised, _side] call ALIVE_fnc_hashGet,"type"] call ALIVE_fnc_hashGet, _type] call ALIVE_fnc_hashGet;
+        }else{
+            // return the sides vehicle type
+            _result = [[[_profilesCatagorised, _side] call ALIVE_fnc_hashGet,"vehicleType"] call ALIVE_fnc_hashGet, _vehicleType] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "getNextInsertID": {
+        private _profileCount = [_logic,"profileCount"] call ALIVE_fnc_hashGet;
+        _result = _profileCount;
+
+        _profileCount = _profileCount + 1;
+        [_logic,"profileCount", _profileCount] call ALIVE_fnc_hashSet;
+    };
+
+    case "getNextInsertEntityID": {
+        private _entityCount = [_logic,"profileEntityCount"] call ALIVE_fnc_hashGet;
+        _result = format["entity_%1", _entityCount];
+
+        _entityCount = _entityCount + 1;
+        [_logic,"profileEntityCount", _entityCount] call ALIVE_fnc_hashSet;
+    };
+
+    case "getNextInsertVehicleID": {
+        private _vehicleCount = [_logic,"profileVehicleCount"] call ALIVE_fnc_hashGet;
+        _result = format["vehicle_%1", _vehicleCount];
+
+        _vehicleCount = _vehicleCount + 1;
+        [_logic,"profileVehicleCount", _vehicleCount] call ALIVE_fnc_hashSet;
+    };
+
+    case "getUnitCount": {
+        private _unitCount = 0;
+
+        {
+            if((_x select 2 select 5) == "entity") then {
+                _unitCount = _unitCount + ([_x,"unitCount"] call ALIVE_fnc_profileEntity);
+            }
+        } forEach (([_logic,"profiles"] call ALIVE_fnc_hashGet) select 2);
+
+        _result = _unitCount;
+    };
+
+    case "getVehicleCount": {
+        private _vehicles = [_logic,"getProfilesByType", "vehicle"] call MAINCLASS;
+        _result = count _vehicles;
+    };
+
+    case "reset": {
+        private _profiles = [_logic, "getProfiles"] call MAINCLASS;
+
+        {
+            _profile = [_profiles, _x] call ALIVE_fnc_hashGet;
+
+            //_profile call ALIVE_fnc_inspectHash;
+
+            _profileID = _profile select 2 select 4;
+            _profileType = _profile select 2 select 5;
+            _isPlayer = false;
+
+            if (_profileType == "entity") then {
+                _isPlayer = _profile select 2 select 30;
             };
 
-            _message = format["ALiVE Profile System - Preparing to save %1 profiles..",count(_exportProfiles select 1)];
-            _messages = _result select 1;
-            _messages pushback _message;
+            if!(_isPlayer) then {
+                if(_profileType == "entity") then {
+                    [_profile, "destroy"] call ALIVE_fnc_profileEntity;
+                }else{
+                    [_profile, "destroy"] call ALIVE_fnc_profileVehicle;
+                };
+            };
 
+        } forEach (_profiles select 1);
 
-            _async = false; // Wait for response from server
-            _missionName = [missionName, "%20", "-"] call CBA_fnc_replace;
-            _missionName = format["%1_%2", ALIVE_sys_data_GROUP_ID, _missionName]; // must include group_id to ensure mission reference is unique across groups
+        private _state = [_logic, "state"] call MAINCLASS;
+        _state call ALIVE_fnc_inspectHash;
+    };
 
-            _saveResult = [ALIVE_profileDatahandler, "bulkSave", ["sys_profile", _exportProfiles, _missionName, _async]] call ALIVE_fnc_Data;
+    case "saveProfileData": {
 
-            _result set [0,_saveResult];
+        private ["_message","_messages","_saveResult","_datahandler","_exportProfiles","_async","_missionName","_message"];
 
-            _message = format["ALiVE Profile System - Save Result: %1",_saveResult];
-            _messages = _result select 1;
-            _messages pushback _message;
+        _result = [false,[]];
+
+        _exportProfiles = [_logic, "exportProfileData"] call MAINCLASS;
+
+        if(isNil"ALIVE_profileDatahandler") then {
 
             if(ALiVE_SYS_DATA_DEBUG_ON) then {
-                ["ALiVE SYS PROFILE - SAVE PROFILE DATA RESULT: %1",_saveResult] call ALIVE_fnc_dump;
+                ["ALiVE SYS PROFILE - SAVE PROFILE, CREATE DATA HANDLER - NO!"] call ALIVE_fnc_dump;
             };
 
+            ALIVE_profileDatahandler = [nil, "create"] call ALIVE_fnc_Data;
+            [ALIVE_profileDatahandler,"storeType",true] call ALIVE_fnc_Data;
         };
-        case "loadProfileData": {
 
-            private ["_datahandler","_importProfiles","_async","_missionName"];
+        _message = format["ALiVE Profile System - Preparing to save %1 profiles..",count(_exportProfiles select 1)];
+        _messages = _result select 1;
+        _messages pushback _message;
 
-            if(isNil"ALIVE_profileDatahandler") then {
 
-                if(ALiVE_SYS_DATA_DEBUG_ON) then {
-                    ["LOAD PROFILE, CREATE DATA HANDLER"] call ALIVE_fnc_dump;
+        _async = false; // Wait for response from server
+        _missionName = [missionName, "%20", "-"] call CBA_fnc_replace;
+        _missionName = format["%1_%2", ALIVE_sys_data_GROUP_ID, _missionName]; // must include group_id to ensure mission reference is unique across groups
+
+        _saveResult = [ALIVE_profileDatahandler, "bulkSave", ["sys_profile", _exportProfiles, _missionName, _async]] call ALIVE_fnc_Data;
+
+        _result set [0,_saveResult];
+
+        _message = format["ALiVE Profile System - Save Result: %1",_saveResult];
+        _messages = _result select 1;
+        _messages pushback _message;
+
+        if(ALiVE_SYS_DATA_DEBUG_ON) then {
+            ["ALiVE SYS PROFILE - SAVE PROFILE DATA RESULT: %1",_saveResult] call ALIVE_fnc_dump;
+        };
+
+    };
+
+    case "loadProfileData": {
+
+        private ["_datahandler","_importProfiles","_async","_missionName"];
+
+        if(isNil"ALIVE_profileDatahandler") then {
+
+            if(ALiVE_SYS_DATA_DEBUG_ON) then {
+                ["LOAD PROFILE, CREATE DATA HANDLER"] call ALIVE_fnc_dump;
+            };
+
+            ALIVE_profileDatahandler = [nil, "create"] call ALIVE_fnc_Data;
+            [ALIVE_profileDatahandler,"storeType",true] call ALIVE_fnc_Data;
+        };
+
+        _async = false; // Wait for response from server
+        _missionName = [missionName, "%20", "-"] call CBA_fnc_replace;
+        _missionName = format["%1_%2", ALIVE_sys_data_GROUP_ID, _missionName]; // must include group_id to ensure mission reference is unique across groups
+
+        if(ALiVE_SYS_DATA_DEBUG_ON) then {
+            ["ALiVE SYS PROFILE - LOAD PROFILE DATA NOW - MISSION NAME: %1! PLEASE WAIT...",_missionName] call ALIVE_fnc_dump;
+        };
+
+        _result = [ALIVE_profileDatahandler, "bulkLoad", ["sys_profile", _missionName, _async]] call ALIVE_fnc_Data;
+
+        if(ALiVE_SYS_DATA_DEBUG_ON) then {
+            ["ALiVE SYS PROFILE - LOAD PROFILE DATA RESULT: %1",_result] call ALIVE_fnc_dump;
+        };
+
+    };
+
+    case "exportProfileData": {
+        private["_profiles","_exportProfiles","_profile","_profileID","_profileType","_isPlayer","_exportProfile","_isPlayer","_vehicleAssignments","_assignmentKeys",
+        "_assignmentValues","_ranks","_side","_spawnType","_entitiesInCommandOf","_entitiesInCargoOf","_vehiclesInCommandOf","_vehiclesInCargoOf","_ranksMap",
+        "_exportRanks","_classes","_exportClasses","_rankMap"];
+
+        if(ALiVE_SYS_DATA_DEBUG_ON) then {
+            ["ALiVE SYS PROFILE - EXPORT PROFILE DATA..."] call ALIVE_fnc_dump;
+        };
+
+        _profiles = [_logic, "getProfiles"] call MAINCLASS;
+        _exportProfiles = [] call ALIVE_fnc_hashCreate;
+
+        _ranksMap = [] call ALIVE_fnc_hashCreate;
+        [_ranksMap, "PRIVATE", 0] call ALIVE_fnc_hashSet;
+        [_ranksMap, "CORPORAL", 1] call ALIVE_fnc_hashSet;
+        [_ranksMap, "SERGEANT", 2] call ALIVE_fnc_hashSet;
+        [_ranksMap, "LIEUTENANT", 3] call ALIVE_fnc_hashSet;
+        [_ranksMap, "CAPTAIN", 4] call ALIVE_fnc_hashSet;
+        [_ranksMap, "MAJOR", 5] call ALIVE_fnc_hashSet;
+        [_ranksMap, "COLONEL", 6] call ALIVE_fnc_hashSet;
+
+        {
+            _profile = _x;
+            _profileID = _profile select 2 select 4;
+            _profileType = _profile select 2 select 5;
+            _isPlayer = false;
+
+            if(_profileType == "entity") then {
+                _isPlayer = _profile select 2 select 30;
+            };
+
+            if!(_isPlayer) then {
+
+                _vehicleAssignments = _profile select 2 select 7;
+                _assignmentKeys = _vehicleAssignments select 1;
+                _assignmentValues = _vehicleAssignments select 2;
+
+                if(_profileType == "entity") then {
+
+                    _exportProfile = [_profile, [], [
+                        "debug",
+                        "active",
+                        "leader",
+                        "group",
+                        "cargo",
+                        "busy",
+                        "companyID",
+                        "groupID",
+                        "waypoints",
+                        "waypointsCompleted",
+                        "units",
+                        /*"hasSimulated",*/
+                        "isCycling",
+                        /*"activeCommands",*/
+                        "inactiveCommands",
+                        "debugMarkers",
+                        "speedPerSecond",
+                        /*"despawnPosition",*/
+                        "vehicleAssignments",
+                        "markers",
+                        "damages",
+                        "positions",
+                        "isPlayer",
+                        "objectType",
+                        "unitCount",
+                        "ranks",
+                        "side"
+                    ]] call ALIVE_fnc_hashCopy;
+
+                    [_exportProfile, "type", 1] call ALIVE_fnc_hashSet;
+
+                    _ranks = _profile select 2 select 20;
+                    _exportRanks = [];
+
+                    {
+                        if(!isNil "_x") then {
+                            if(typeName _x == "STRING") then {
+                                _rankMap = [_ranksMap, toUpper(_x),"PRIVATE"] call ALIVE_fnc_hashGet;
+
+                                if(typeName _rankMap == "SCALAR") then {
+                                    _exportRanks pushback _rankMap;
+                                }else{
+                                    _exportRanks pushback 0;
+                                };
+                            }else{
+                                 _exportRanks pushback 0;
+                             };
+                        }else{
+                            _exportRanks pushback 0;
+                        };
+                    } forEach _ranks;
+
+                    [_exportProfile, "ranks", _exportRanks] call ALIVE_fnc_hashSet;
+
+                    _classes = _profile select 2 select 11;
+                    _exportClasses = [];
+
+                    {
+                        if!(isNil "_x") then {
+                            if(typeName _x == "STRING") then {
+                                _exportClasses pushback _x;
+                            };
+                        };
+                    } forEach _classes;
+
+                    [_exportProfile, "unitClasses", _exportClasses] call ALIVE_fnc_hashSet;
+
+                    _side = _profile select 2 select 3;
+
+                    [_exportProfile, "side", [_side] call ALIVE_fnc_sideTextToNumber] call ALIVE_fnc_hashSet;
+
+                    _vehiclesInCommandOf = [_exportProfile, "vehiclesInCommandOf"] call ALIVE_fnc_hashGet;
+                    if(count _vehiclesInCommandOf == 0) then {
+                        [_exportProfile, "vehiclesInCommandOf"] call ALIVE_fnc_hashRem;
+                    };
+
+                    _vehiclesInCargoOf = [_exportProfile, "vehiclesInCargoOf"] call ALIVE_fnc_hashGet;
+                    if(count _vehiclesInCargoOf == 0) then {
+                        [_exportProfile, "vehiclesInCargoOf"] call ALIVE_fnc_hashRem;
+                    };
+
+                }else{
+
+                    _exportProfile = [_profile, [], [
+                        "debug",
+                        "active",
+                        "vehicle",
+                        /*"hasSimulated",*/
+                        "debugMarkers",
+                        "speedPerSecond",
+                        /*"despawnPosition",*/
+                        "vehicleAssignments",
+                        "ammo",
+                        "canMove",
+                        "canFire",
+                        "needReload",
+                        "fuel",
+                        "damage",
+                        "side"
+                    ]] call ALIVE_fnc_hashCopy;
+
+                    [_exportProfile, "type", 2] call ALIVE_fnc_hashSet;
+
+                    _side = _profile select 2 select 3;
+                    [_exportProfile, "side", [_side] call ALIVE_fnc_sideTextToNumber] call ALIVE_fnc_hashSet;
+
+                    _entitiesInCommandOf = [_exportProfile, "entitiesInCommandOf"] call ALIVE_fnc_hashGet;
+                    if(count _entitiesInCommandOf == 0) then {
+                        [_exportProfile, "entitiesInCommandOf"] call ALIVE_fnc_hashRem;
+                    };
+
+                    _entitiesInCargoOf = [_exportProfile, "entitiesInCargoOf"] call ALIVE_fnc_hashGet;
+                    if(count _entitiesInCargoOf == 0) then {
+                        [_exportProfile, "entitiesInCargoOf"] call ALIVE_fnc_hashRem;
+                    };
+
                 };
 
-                ALIVE_profileDatahandler = [nil, "create"] call ALIVE_fnc_Data;
-                [ALIVE_profileDatahandler,"storeType",true] call ALIVE_fnc_Data;
+                if([_exportProfile, "_rev"] call ALIVE_fnc_hashGet == "") then {
+                    [_exportProfile, "_rev"] call ALIVE_fnc_hashRem;
+                };
+
+                if([_exportProfile, "_id"] call ALIVE_fnc_hashGet == "") then {
+                    [_exportProfile, "_id"] call ALIVE_fnc_hashRem;
+                };
+
+                _spawnType = [_exportProfile, "spawnType"] call ALIVE_fnc_hashGet;
+                if(count _spawnType == 0) then {
+                    [_exportProfile, "spawnType"] call ALIVE_fnc_hashRem;
+                };
+
+                if(count _assignmentKeys > 0) then {
+                    [_exportProfile, "vehicleAssignmentKeys", _assignmentKeys] call ALIVE_fnc_hashSet;
+                };
+
+                if(count _assignmentValues > 0) then {
+                    [_exportProfile, "vehicleAssignmentValues", _assignmentValues] call ALIVE_fnc_hashSet;
+                };
+
+                [_exportProfiles, _profileID, _exportProfile] call ALIVE_fnc_hashSet;
+
+                if(ALiVE_SYS_DATA_DEBUG_ON) then {
+                    ["ALiVE SYS PROFILE - EXPORT READY PROFILE:"] call ALIVE_fnc_dump;
+                    _exportProfile call ALIVE_fnc_inspectHash;
+                };
+
             };
 
-            _async = false; // Wait for response from server
-            _missionName = [missionName, "%20", "-"] call CBA_fnc_replace;
-            _missionName = format["%1_%2", ALIVE_sys_data_GROUP_ID, _missionName]; // must include group_id to ensure mission reference is unique across groups
+        } forEach (_profiles select 2);
+
+        _result = _exportProfiles;
+
+    };
+
+    case "importProfileData": {
+        private["_profiles","_profile","_profileType","_vehicleAssignmentKeys","_vehicleAssignmentValues","_key","_value","_assignments","_assignment","_rebuiltHash",
+        "_position","_entities","_vehicles","_total","_index","_damages","_damage","_ranks","_importRanks","_side","_ranksMap","_unitClasses","_side","_profileEntity","_profileVehicle","_boat"];
+
+        if(typeName _args == "ARRAY") then {
 
             if(ALiVE_SYS_DATA_DEBUG_ON) then {
-                ["ALiVE SYS PROFILE - LOAD PROFILE DATA NOW - MISSION NAME: %1! PLEASE WAIT...",_missionName] call ALIVE_fnc_dump;
+                ["ALiVE SYS PROFILE - IMPORT PROFILE DATA..."] call ALIVE_fnc_dump;
             };
-
-            _result = [ALIVE_profileDatahandler, "bulkLoad", ["sys_profile", _missionName, _async]] call ALIVE_fnc_Data;
-
-            if(ALiVE_SYS_DATA_DEBUG_ON) then {
-                ["ALiVE SYS PROFILE - LOAD PROFILE DATA RESULT: %1",_result] call ALIVE_fnc_dump;
-            };
-
-        };
-        case "exportProfileData": {
-            private["_profiles","_exportProfiles","_profile","_profileID","_profileType","_isPlayer","_exportProfile","_isPlayer","_vehicleAssignments","_assignmentKeys",
-            "_assignmentValues","_ranks","_side","_spawnType","_entitiesInCommandOf","_entitiesInCargoOf","_vehiclesInCommandOf","_vehiclesInCargoOf","_ranksMap",
-            "_exportRanks","_classes","_exportClasses","_rankMap"];
-
-            if(ALiVE_SYS_DATA_DEBUG_ON) then {
-                ["ALiVE SYS PROFILE - EXPORT PROFILE DATA..."] call ALIVE_fnc_dump;
-            };
-
-            _profiles = [_logic, "getProfiles"] call MAINCLASS;
-            _exportProfiles = [] call ALIVE_fnc_hashCreate;
 
             _ranksMap = [] call ALIVE_fnc_hashCreate;
-            [_ranksMap, "PRIVATE", 0] call ALIVE_fnc_hashSet;
-            [_ranksMap, "CORPORAL", 1] call ALIVE_fnc_hashSet;
-            [_ranksMap, "SERGEANT", 2] call ALIVE_fnc_hashSet;
-            [_ranksMap, "LIEUTENANT", 3] call ALIVE_fnc_hashSet;
-            [_ranksMap, "CAPTAIN", 4] call ALIVE_fnc_hashSet;
-            [_ranksMap, "MAJOR", 5] call ALIVE_fnc_hashSet;
-            [_ranksMap, "COLONEL", 6] call ALIVE_fnc_hashSet;
+            [_ranksMap, 0, "PRIVATE"] call ALIVE_fnc_hashSet;
+            [_ranksMap, 1, "CORPORAL"] call ALIVE_fnc_hashSet;
+            [_ranksMap, 2, "SERGEANT"] call ALIVE_fnc_hashSet;
+            [_ranksMap, 3, "LIEUTENANT"] call ALIVE_fnc_hashSet;
+            [_ranksMap, 4, "CAPTAIN"] call ALIVE_fnc_hashSet;
+            [_ranksMap, 5, "MAJOR"] call ALIVE_fnc_hashSet;
+            [_ranksMap, 6, "COLONEL"] call ALIVE_fnc_hashSet;
+
+            _profiles = _args;
+
+            _entities = [];
+            _vehicles = [];
+            _total = [_logic,"profileCount",0] call ALIVE_fnc_hashGet;
 
             {
                 _profile = _x;
-                _profileID = _profile select 2 select 4;
-                _profileType = _profile select 2 select 5;
-                _isPlayer = false;
+                _profileType = [_profile,"type"] call ALIVE_fnc_hashGet;
 
-                if(_profileType == "entity") then {
-                    _isPlayer = _profile select 2 select 30;
+                if("vehicleAssignmentKeys" in (_profile select 1)) then {
+                    _vehicleAssignmentKeys = [_profile,"vehicleAssignmentKeys"] call ALIVE_fnc_hashGet;
+                    _vehicleAssignmentValues = [_profile,"vehicleAssignmentValues"] call ALIVE_fnc_hashGet;
+
+                    _rebuiltHash = [] call ALIVE_fnc_hashCreate;
+
+                    {
+                        _key = _x;
+                        _value = _vehicleAssignmentValues select _forEachIndex;
+                        _assignments = _value select 2;
+
+                        if(count _assignments < 6) then {
+                            _assignments pushBack [];
+                            _value set [2,_assignments];
+                        };
+
+                        [_rebuiltHash, _key, _value] call ALIVE_fnc_hashSet;
+                    } forEach _vehicleAssignmentKeys;
+
                 };
 
-                if!(_isPlayer) then {
+                //_profile call ALIVE_fnc_inspectHash;
 
-                    _vehicleAssignments = _profile select 2 select 7;
-                    _assignmentKeys = _vehicleAssignments select 1;
-                    _assignmentValues = _vehicleAssignments select 2;
+                _total = _total + 1;
 
-                    if(_profileType == "entity") then {
+                if(_profileType == 1) then {
 
-                        _exportProfile = [_profile, [], [
-                            "debug",
-                            "active",
-                            "leader",
-                            "group",
-                            "cargo",
-                            "busy",
-                            "companyID",
-                            "groupID",
-                            "waypoints",
-                            "waypointsCompleted",
-                            "units",
-                            /*"hasSimulated",*/
-                            "isCycling",
-                            /*"activeCommands",*/
-                            "inactiveCommands",
-                            "debugMarkers",
-                            "speedPerSecond",
-                            /*"despawnPosition",*/
-                            "vehicleAssignments",
-                            "markers",
-                            "damages",
-                            "positions",
-                            "isPlayer",
-                            "objectType",
-                            "unitCount",
-                            "ranks",
-                            "side"
-                        ]] call ALIVE_fnc_hashCopy;
+                    _profileEntity = [nil, "create"] call ALIVE_fnc_profileEntity;
+                    [_profileEntity, "init"] call ALIVE_fnc_profileEntity;
+                    [_profileEntity, "profileID", [_profile,"profileID"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
+                    [_profileEntity, "unitClasses", [_profile,"unitClasses"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
+                    [_profileEntity, "position", [_profile,"position"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
+                    [_profileEntity, "faction", [_profile,"faction"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
+                    [_profileEntity, "_rev", [_profile,"_rev"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                    [_profileEntity, "_id", [_profile,"_id"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
 
-                        [_exportProfile, "type", 1] call ALIVE_fnc_hashSet;
+                    [_profileEntity, "hasSimulated", [_profile,"hasSimulated"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                    [_profileEntity, "despawnPosition", [_profile,"despawnPosition"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
 
-                        _ranks = _profile select 2 select 20;
-                        _exportRanks = [];
+                    /*
+                    [_profileEntity, "objectType", [_profile,"objectType"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
+                    [_profileEntity, "unitCount", [_profile,"unitCount"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                    [_profileEntity, "positions", [_profile,"positions"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
+                    [_profileEntity, "damages", [_profile,"damages"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
+                    */
 
-                        {
-                            if(!isNil "_x") then {
-                                if(typeName _x == "STRING") then {
-                                    _rankMap = [_ranksMap, toUpper(_x),"PRIVATE"] call ALIVE_fnc_hashGet;
+                    if("vehicleAssignmentKeys" in (_profile select 1)) then {
+                        [_profileEntity, "vehicleAssignments", _rebuiltHash] call ALIVE_fnc_hashSet;
+                    };
 
-                                    if(typeName _rankMap == "SCALAR") then {
-                                        _exportRanks pushback _rankMap;
-                                    }else{
-                                        _exportRanks pushback 0;
-                                    };
-                                }else{
-                                     _exportRanks pushback 0;
-                                 };
-                            }else{
-                                _exportRanks pushback 0;
-                            };
-                        } forEach _ranks;
+                    if("vehiclesInCommandOf" in (_profile select 1)) then {
+                        [_profileEntity, "vehiclesInCommandOf", [_profile,"vehiclesInCommandOf"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                    };
 
-                        [_exportProfile, "ranks", _exportRanks] call ALIVE_fnc_hashSet;
+                    if("vehiclesInCargoOf" in (_profile select 1)) then {
+                        [_profileEntity, "vehiclesInCargoOf", [_profile,"vehiclesInCargoOf"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                    };
 
-                        _classes = _profile select 2 select 11;
-                        _exportClasses = [];
+                    if("spawnType" in (_profile select 1)) then {
+                        [_profileEntity, "spawnType", [_profile,"spawnType"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                    };
 
-                        {
-                            if!(isNil "_x") then {
-                                if(typeName _x == "STRING") then {
-                                    _exportClasses pushback _x;
-                                };
-                            };
-                        } forEach _classes;
+                    _ranks = [_profile,"ranks"] call ALIVE_fnc_hashGet;
+                    _importRanks = [];
 
-                        [_exportProfile, "unitClasses", _exportClasses] call ALIVE_fnc_hashSet;
+                    {
+                        _importRanks pushback ([_ranksMap, _x] call ALIVE_fnc_hashGet);
+                    } forEach _ranks;
 
-                        _side = _profile select 2 select 3;
+                    [_profileEntity, "ranks", _importRanks] call ALIVE_fnc_hashSet;
 
-                        [_exportProfile, "side", [_side] call ALIVE_fnc_sideTextToNumber] call ALIVE_fnc_hashSet;
+                    _side = [_profile,"side"] call ALIVE_fnc_hashGet;
+                    if(typeName _side == "SCALAR") then {
+                        _side = [_side] call ALIVE_fnc_sideNumberToText;
+                    };
+                    [_profileEntity, "side", _side] call ALIVE_fnc_profileEntity;
 
-                        _vehiclesInCommandOf = [_exportProfile, "vehiclesInCommandOf"] call ALIVE_fnc_hashGet;
-                        if(count _vehiclesInCommandOf == 0) then {
-                            [_exportProfile, "vehiclesInCommandOf"] call ALIVE_fnc_hashRem;
+                    _unitClasses = [_profile,"unitClasses"] call ALIVE_fnc_hashGet;
+                    _damages = [];
+                    {
+                        if !(isnil "_x") then {
+                            _damages pushback 0;
                         };
+                    } forEach _unitClasses;
 
-                        _vehiclesInCargoOf = [_exportProfile, "vehiclesInCargoOf"] call ALIVE_fnc_hashGet;
-                        if(count _vehiclesInCargoOf == 0) then {
-                            [_exportProfile, "vehiclesInCargoOf"] call ALIVE_fnc_hashRem;
-                        };
+                    [_profileEntity, "damages", _damages] call ALIVE_fnc_profileEntity;
 
-                    }else{
-
-                        _exportProfile = [_profile, [], [
-                            "debug",
-                            "active",
-                            "vehicle",
-                            /*"hasSimulated",*/
-                            "debugMarkers",
-                            "speedPerSecond",
-                            /*"despawnPosition",*/
-                            "vehicleAssignments",
-                            "ammo",
-                            "canMove",
-                            "canFire",
-                            "needReload",
-                            "fuel",
-                            "damage",
-                            "side"
-                        ]] call ALIVE_fnc_hashCopy;
-
-                        [_exportProfile, "type", 2] call ALIVE_fnc_hashSet;
-
-                        _side = _profile select 2 select 3;
-                        [_exportProfile, "side", [_side] call ALIVE_fnc_sideTextToNumber] call ALIVE_fnc_hashSet;
-
-                        _entitiesInCommandOf = [_exportProfile, "entitiesInCommandOf"] call ALIVE_fnc_hashGet;
-                        if(count _entitiesInCommandOf == 0) then {
-                            [_exportProfile, "entitiesInCommandOf"] call ALIVE_fnc_hashRem;
-                        };
-
-                        _entitiesInCargoOf = [_exportProfile, "entitiesInCargoOf"] call ALIVE_fnc_hashGet;
-                        if(count _entitiesInCargoOf == 0) then {
-                            [_exportProfile, "entitiesInCargoOf"] call ALIVE_fnc_hashRem;
-                        };
-
+                    if("activeCommands" in (_profile select 1)) then {
+                        [_profileEntity, "activeCommands", [_profile,"activeCommands"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
                     };
 
-                    if([_exportProfile, "_rev"] call ALIVE_fnc_hashGet == "") then {
-                        [_exportProfile, "_rev"] call ALIVE_fnc_hashRem;
+                    if("boat" in (_profile select 1)) then {
+                        [_profileEntity, "boat", [_profile,"boat"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
                     };
-
-                    if([_exportProfile, "_id"] call ALIVE_fnc_hashGet == "") then {
-                        [_exportProfile, "_id"] call ALIVE_fnc_hashRem;
-                    };
-
-                    _spawnType = [_exportProfile, "spawnType"] call ALIVE_fnc_hashGet;
-                    if(count _spawnType == 0) then {
-                        [_exportProfile, "spawnType"] call ALIVE_fnc_hashRem;
-                    };
-
-                    if(count _assignmentKeys > 0) then {
-                        [_exportProfile, "vehicleAssignmentKeys", _assignmentKeys] call ALIVE_fnc_hashSet;
-                    };
-
-                    if(count _assignmentValues > 0) then {
-                        [_exportProfile, "vehicleAssignmentValues", _assignmentValues] call ALIVE_fnc_hashSet;
-                    };
-
-                    [_exportProfiles, _profileID, _exportProfile] call ALIVE_fnc_hashSet;
 
                     if(ALiVE_SYS_DATA_DEBUG_ON) then {
-                        ["ALiVE SYS PROFILE - EXPORT READY PROFILE:"] call ALIVE_fnc_dump;
-                        _exportProfile call ALIVE_fnc_inspectHash;
+                        ["ALiVE SYS PROFILE - RECREATED PROFILE ENTITY:"] call ALIVE_fnc_dump;
+                        _profileEntity call ALIVE_fnc_inspectHash;
                     };
 
+                    [ALIVE_profileHandler, "registerProfile", _profileEntity] call ALIVE_fnc_profileHandler;
+
+                    //Collect the index-number of the entity id
+                    _index = [[_profileEntity,"profileID","entity_0"] call ALIVE_fnc_hashGet, "_"] call CBA_fnc_split;
+                    if (count _index > 0) then {
+                        _index sort true;
+                        _index = parseNumber (_index select 0); // will fallback to 0 if a wrong input is given
+
+                        _entities pushback _index;
+                    };
+                }else{
+
+                    _profileVehicle = [nil, "create"] call ALIVE_fnc_profileVehicle;
+                    [_profileVehicle, "init"] call ALIVE_fnc_profileVehicle;
+                    [_profileVehicle, "profileID", [_profile,"profileID"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+                    [_profileVehicle, "objectType", [_profile,"objectType"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+                    [_profileVehicle, "vehicleClass", [_profile,"vehicleClass"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+                    [_profileVehicle, "position", [_profile,"position"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+                    [_profileVehicle, "direction", [_profile,"direction"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+                    [_profileVehicle, "faction", [_profile,"faction"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+                    [_profileVehicle, "engineOn", [_profile,"engineOn"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+                    [_profileVehicle, "_rev", [_profile,"_rev"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                    [_profileVehicle, "_id", [_profile,"_id"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+
+                    [_profileVehicle, "hasSimulated", [_profile,"hasSimulated"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                    [_profileVehicle, "despawnPosition", [_profile,"despawnPosition"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+
+                    /*
+                    [_profileVehicle, "damage", [_profile,"damage"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+                    [_profileVehicle, "ammo", [_profile,"ammo"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+                    [_profileVehicle, "fuel", [_profile,"fuel"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+                    */
+
+                    if("vehicleAssignmentKeys" in (_profile select 1)) then {
+                        [_profileVehicle, "vehicleAssignments", _rebuiltHash] call ALIVE_fnc_hashSet;
+                    };
+
+                    if("entitiesInCommandOf" in (_profile select 1)) then {
+                        [_profileVehicle, "entitiesInCommandOf", [_profile,"entitiesInCommandOf"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                    };
+
+                    if("entitiesInCargoOf" in (_profile select 1)) then {
+                        [_profileVehicle, "entitiesInCargoOf", [_profile,"entitiesInCargoOf"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+                    };
+
+                    if("spawnType" in (_profile select 1)) then {
+                        [_profileVehicle, "spawnType", [_profile,"spawnType"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+                    };
+
+                    _side = [_profile,"side"] call ALIVE_fnc_hashGet;
+                    if(typeName _side == "SCALAR") then {
+                        _side = [_side] call ALIVE_fnc_sideNumberToText;
+                    };
+                    [_profileVehicle, "side", _side] call ALIVE_fnc_profileVehicle;
+
+                    if(ALiVE_SYS_DATA_DEBUG_ON) then {
+                        ["ALiVE SYS PROFILE - RECREATED PROFILE VEHICLE:"] call ALIVE_fnc_dump;
+                        _profileVehicle call ALIVE_fnc_inspectHash;
+                    };
+
+
+                    [ALIVE_profileHandler, "registerProfile", _profileVehicle] call ALIVE_fnc_profileHandler;
+
+                    //Collect the index-number of the vehicle id
+                    _index = [[_profileVehicle,"profileID","vehicle_0"] call ALIVE_fnc_hashGet, "_"] call CBA_fnc_split;
+                    if (count _index > 0) then {
+                        _index sort true;
+                        _index = parseNumber (_index select 0); // will fallback to 0 if a wrong input is given
+
+                        _vehicles pushback _index;
+                    };
                 };
 
             } forEach (_profiles select 2);
 
-            _result = _exportProfiles;
+            //Sort collected index-numbers to get the highest one
+            _vehicles sort false;
+            _entities sort false;
 
+            //Validating
+            _entities = if (count _entities > 0 && {typeName (_entities select 0) == "SCALAR"}) then {_entities select 0} else {0};
+            _vehicles = if (count _vehicles > 0 && {typeName (_vehicles select 0) == "SCALAR"}) then {_vehicles select 0} else {0};
+
+            //Set highest index-number on the profiles-counters in order to let objects created lateron have correct unique IDs
+            [_logic,"profileVehicleCount", _vehicles] call ALIVE_fnc_hashSet;
+            [_logic,"profileEntityCount", _entities] call ALIVE_fnc_hashSet;
+            [_logic,"profileCount", _total] call ALIVE_fnc_hashSet;
         };
-        case "importProfileData": {
-            private["_profiles","_profile","_profileType","_vehicleAssignmentKeys","_vehicleAssignmentValues","_key","_value","_assignments","_assignment","_rebuiltHash",
-            "_position","_entities","_vehicles","_total","_index","_damages","_damage","_ranks","_importRanks","_side","_ranksMap","_unitClasses","_side","_profileEntity","_profileVehicle","_boat"];
+    };
 
-            if(typeName _args == "ARRAY") then {
+    default {
+        _result = [_logic, _operation, _args] call SUPERCLASS;
+    };
 
-                if(ALiVE_SYS_DATA_DEBUG_ON) then {
-                    ["ALiVE SYS PROFILE - IMPORT PROFILE DATA..."] call ALIVE_fnc_dump;
-                };
-
-                _ranksMap = [] call ALIVE_fnc_hashCreate;
-                [_ranksMap, 0, "PRIVATE"] call ALIVE_fnc_hashSet;
-                [_ranksMap, 1, "CORPORAL"] call ALIVE_fnc_hashSet;
-                [_ranksMap, 2, "SERGEANT"] call ALIVE_fnc_hashSet;
-                [_ranksMap, 3, "LIEUTENANT"] call ALIVE_fnc_hashSet;
-                [_ranksMap, 4, "CAPTAIN"] call ALIVE_fnc_hashSet;
-                [_ranksMap, 5, "MAJOR"] call ALIVE_fnc_hashSet;
-                [_ranksMap, 6, "COLONEL"] call ALIVE_fnc_hashSet;
-
-                _profiles = _args;
-
-                _entities = [];
-                _vehicles = [];
-                _total = [_logic,"profileCount",0] call ALIVE_fnc_hashGet;
-
-                {
-                    _profile = _x;
-                    _profileType = [_profile,"type"] call ALIVE_fnc_hashGet;
-
-                    if("vehicleAssignmentKeys" in (_profile select 1)) then {
-                        _vehicleAssignmentKeys = [_profile,"vehicleAssignmentKeys"] call ALIVE_fnc_hashGet;
-                        _vehicleAssignmentValues = [_profile,"vehicleAssignmentValues"] call ALIVE_fnc_hashGet;
-
-                        _rebuiltHash = [] call ALIVE_fnc_hashCreate;
-
-                        {
-                            _key = _x;
-                            _value = _vehicleAssignmentValues select _forEachIndex;
-                            _assignments = _value select 2;
-
-                            if(count _assignments < 6) then {
-                                _assignments pushBack [];
-                                _value set [2,_assignments];
-                            };
-
-                            [_rebuiltHash, _key, _value] call ALIVE_fnc_hashSet;
-                        } forEach _vehicleAssignmentKeys;
-
-                    };
-
-                    //_profile call ALIVE_fnc_inspectHash;
-
-                    _total = _total + 1;
-
-                    if(_profileType == 1) then {
-
-                        _profileEntity = [nil, "create"] call ALIVE_fnc_profileEntity;
-                        [_profileEntity, "init"] call ALIVE_fnc_profileEntity;
-                        [_profileEntity, "profileID", [_profile,"profileID"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
-                        [_profileEntity, "unitClasses", [_profile,"unitClasses"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
-                        [_profileEntity, "position", [_profile,"position"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
-                        [_profileEntity, "faction", [_profile,"faction"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
-                        [_profileEntity, "_rev", [_profile,"_rev"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        [_profileEntity, "_id", [_profile,"_id"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-
-                        [_profileEntity, "hasSimulated", [_profile,"hasSimulated"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        [_profileEntity, "despawnPosition", [_profile,"despawnPosition"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-
-                        /*
-                        [_profileEntity, "objectType", [_profile,"objectType"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
-                        [_profileEntity, "unitCount", [_profile,"unitCount"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        [_profileEntity, "positions", [_profile,"positions"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
-                        [_profileEntity, "damages", [_profile,"damages"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileEntity;
-                        */
-
-                        if("vehicleAssignmentKeys" in (_profile select 1)) then {
-                            [_profileEntity, "vehicleAssignments", _rebuiltHash] call ALIVE_fnc_hashSet;
-                        };
-
-                        if("vehiclesInCommandOf" in (_profile select 1)) then {
-                            [_profileEntity, "vehiclesInCommandOf", [_profile,"vehiclesInCommandOf"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        };
-
-                        if("vehiclesInCargoOf" in (_profile select 1)) then {
-                            [_profileEntity, "vehiclesInCargoOf", [_profile,"vehiclesInCargoOf"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        };
-
-                        if("spawnType" in (_profile select 1)) then {
-                            [_profileEntity, "spawnType", [_profile,"spawnType"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        };
-
-                        _ranks = [_profile,"ranks"] call ALIVE_fnc_hashGet;
-                        _importRanks = [];
-
-                        {
-                            _importRanks pushback ([_ranksMap, _x] call ALIVE_fnc_hashGet);
-                        } forEach _ranks;
-
-                        [_profileEntity, "ranks", _importRanks] call ALIVE_fnc_hashSet;
-
-                        _side = [_profile,"side"] call ALIVE_fnc_hashGet;
-                        if(typeName _side == "SCALAR") then {
-                            _side = [_side] call ALIVE_fnc_sideNumberToText;
-                        };
-                        [_profileEntity, "side", _side] call ALIVE_fnc_profileEntity;
-
-                        _unitClasses = [_profile,"unitClasses"] call ALIVE_fnc_hashGet;
-                        _damages = [];
-                        {
-                            if !(isnil "_x") then {
-                                _damages pushback 0;
-                            };
-                        } forEach _unitClasses;
-
-                        [_profileEntity, "damages", _damages] call ALIVE_fnc_profileEntity;
-
-                        if("activeCommands" in (_profile select 1)) then {
-                            [_profileEntity, "activeCommands", [_profile,"activeCommands"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        };
-
-                        if("boat" in (_profile select 1)) then {
-                            [_profileEntity, "boat", [_profile,"boat"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        };
-
-                        if(ALiVE_SYS_DATA_DEBUG_ON) then {
-                            ["ALiVE SYS PROFILE - RECREATED PROFILE ENTITY:"] call ALIVE_fnc_dump;
-                            _profileEntity call ALIVE_fnc_inspectHash;
-                        };
-
-                        [ALIVE_profileHandler, "registerProfile", _profileEntity] call ALIVE_fnc_profileHandler;
-
-                        //Collect the index-number of the entity id
-                        _index = [[_profileEntity,"profileID","entity_0"] call ALIVE_fnc_hashGet, "_"] call CBA_fnc_split;
-                        if (count _index > 0) then {
-                            _index sort true;
-                            _index = parseNumber (_index select 0); // will fallback to 0 if a wrong input is given
-
-                            _entities pushback _index;
-                        };
-                    }else{
-
-                        _profileVehicle = [nil, "create"] call ALIVE_fnc_profileVehicle;
-                        [_profileVehicle, "init"] call ALIVE_fnc_profileVehicle;
-                        [_profileVehicle, "profileID", [_profile,"profileID"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
-                        [_profileVehicle, "objectType", [_profile,"objectType"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
-                        [_profileVehicle, "vehicleClass", [_profile,"vehicleClass"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
-                        [_profileVehicle, "position", [_profile,"position"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
-                        [_profileVehicle, "direction", [_profile,"direction"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
-                        [_profileVehicle, "faction", [_profile,"faction"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
-                        [_profileVehicle, "engineOn", [_profile,"engineOn"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
-                        [_profileVehicle, "_rev", [_profile,"_rev"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        [_profileVehicle, "_id", [_profile,"_id"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-
-                        [_profileVehicle, "hasSimulated", [_profile,"hasSimulated"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        [_profileVehicle, "despawnPosition", [_profile,"despawnPosition"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-
-                        /*
-                        [_profileVehicle, "damage", [_profile,"damage"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
-                        [_profileVehicle, "ammo", [_profile,"ammo"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
-                        [_profileVehicle, "fuel", [_profile,"fuel"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
-                        */
-
-                        if("vehicleAssignmentKeys" in (_profile select 1)) then {
-                            [_profileVehicle, "vehicleAssignments", _rebuiltHash] call ALIVE_fnc_hashSet;
-                        };
-
-                        if("entitiesInCommandOf" in (_profile select 1)) then {
-                            [_profileVehicle, "entitiesInCommandOf", [_profile,"entitiesInCommandOf"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        };
-
-                        if("entitiesInCargoOf" in (_profile select 1)) then {
-                            [_profileVehicle, "entitiesInCargoOf", [_profile,"entitiesInCargoOf"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-                        };
-
-                        if("spawnType" in (_profile select 1)) then {
-                            [_profileVehicle, "spawnType", [_profile,"spawnType"] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
-                        };
-
-                        _side = [_profile,"side"] call ALIVE_fnc_hashGet;
-                        if(typeName _side == "SCALAR") then {
-                            _side = [_side] call ALIVE_fnc_sideNumberToText;
-                        };
-                        [_profileVehicle, "side", _side] call ALIVE_fnc_profileVehicle;
-
-                        if(ALiVE_SYS_DATA_DEBUG_ON) then {
-                            ["ALiVE SYS PROFILE - RECREATED PROFILE VEHICLE:"] call ALIVE_fnc_dump;
-                            _profileVehicle call ALIVE_fnc_inspectHash;
-                        };
-
-
-                        [ALIVE_profileHandler, "registerProfile", _profileVehicle] call ALIVE_fnc_profileHandler;
-
-                        //Collect the index-number of the vehicle id
-                        _index = [[_profileVehicle,"profileID","vehicle_0"] call ALIVE_fnc_hashGet, "_"] call CBA_fnc_split;
-                        if (count _index > 0) then {
-                            _index sort true;
-                            _index = parseNumber (_index select 0); // will fallback to 0 if a wrong input is given
-
-                            _vehicles pushback _index;
-                        };
-                    };
-
-                } forEach (_profiles select 2);
-
-                //Sort collected index-numbers to get the highest one
-                _vehicles sort false;
-                _entities sort false;
-
-                //Validating
-                _entities = if (count _entities > 0 && {typeName (_entities select 0) == "SCALAR"}) then {_entities select 0} else {0};
-                _vehicles = if (count _vehicles > 0 && {typeName (_vehicles select 0) == "SCALAR"}) then {_vehicles select 0} else {0};
-
-                //Set highest index-number on the profiles-counters in order to let objects created lateron have correct unique IDs
-                [_logic, "profileVehicleCount", _vehicles] call ALIVE_fnc_hashSet;
-                [_logic, "profileEntityCount", _entities] call ALIVE_fnc_hashSet;
-                [_logic, "profileCount", _total] call ALIVE_fnc_hashSet;
-            };
-        };
-        default {
-                _result = [_logic, _operation, _args] call SUPERCLASS;
-        };
 };
+
 TRACE_1("profileHandler - output",_result);
 
 if !(isnil "_result") then {_result} else {nil};

--- a/addons/sys_profile/fnc_profileHandler.sqf
+++ b/addons/sys_profile/fnc_profileHandler.sqf
@@ -878,16 +878,13 @@ switch(_operation) do {
 
         };
         case "getProfile": {
-                private["_profileID","_profiles","_profileIndex"];
-
-                if(typeName _args == "STRING") then {
-                    _profileID = _args;
+                if (_args isEqualType "") then {
                     _profiles = [_logic, "profiles"] call ALIVE_fnc_hashGet;
-                    _profileIndex = _profiles select 1;
-                    if(_profileID in _profileIndex) then {
-                        _result = [_profiles, _profileID] call ALIVE_fnc_hashGet;
-                    }else{
-                        _result = nil;
+
+                    private _index = (_profiles select 1) find _args;
+
+                    if (_index != -1) then {
+                        _result = (_profiles select 2) select _index;
                     };
                 };
         };

--- a/addons/sys_profile/fnc_profileSimulator.sqf
+++ b/addons/sys_profile/fnc_profileSimulator.sqf
@@ -145,7 +145,7 @@ if (!_simAttacks) then {
                         // find and attack enemy profiles in-range
                         // only attack non-player, inactive entities
 
-                        private _nearEnemies = [_profilePosition, _combatRange, [_sidesEnemy,"entity", "none", {!(_x select 2 select 1) && !(_x select 2 select 30)}], true] call ALiVE_fnc_getNearProfiles;
+                        private _nearEnemies = [_profilePosition, _combatRange, [_sidesEnemy,"entity","none", {!(_x select 2 select 1) && !(_x select 2 select 30)}], true] call ALiVE_fnc_getNearProfiles;
                         _nearEnemies = _nearEnemies apply {_x select 2 select 4};
 
                         if !(_nearEnemies isEqualTo []) then {

--- a/addons/sys_profile/fnc_profileSimulator.sqf
+++ b/addons/sys_profile/fnc_profileSimulator.sqf
@@ -134,9 +134,9 @@ if (!_simAttacks) then {
                     if (_sideObj getfriend resistance < 0.6) then {_sidesEnemy pushback "GUER"};
 
                     // find and attack enemy profiles in-range
+                    // only attack non-player, inactive entities
 
-                    private _nearEnemies = [_profilePosition, _combatRange, [_sidesEnemy,"entity"], true] call ALiVE_fnc_getNearProfiles;
-                    _nearEnemies = _nearEnemies select {!(_x select 2 select 30)}; // filter out players
+                    private _nearEnemies = [_profilePosition, _combatRange, [_sidesEnemy,"entity", "none", {!(_x select 2 select 1) && !(_x select 2 select 30)}], true] call ALiVE_fnc_getNearProfiles;
                     _nearEnemies = _nearEnemies apply {_x select 2 select 4};
 
                     if !(_nearEnemies isEqualTo []) then {
@@ -871,7 +871,7 @@ if (!_simAttacks) then {
 
             private _vehAssignment = [_vehAssignments,_vehicleID] call ALiVE_fnc_hashGet;
             private _unitAssignments = +(_vehAssignment param [2, [], [[]]]);
-            
+
             reverse _unitAssignments; // must remove in reverse order
 
             {

--- a/addons/sys_profile/fnc_profileSimulator.sqf
+++ b/addons/sys_profile/fnc_profileSimulator.sqf
@@ -1,11 +1,21 @@
-#include <\x\alive\addons\sys_profile\script_component.hpp>
+#include <\x\ALiVE\addons\sys_profile\script_component.hpp>
 SCRIPT(profileSimulator);
 
 /* ----------------------------------------------------------------------------
-Function: ALIVE_fnc_profileSimulator
+Function: ALiVE_fnc_profileSimulator
 
 Description:
-Simulates movement of profiles that have waypoints set
+Simulates profile movement and combat
+
+Notes:
+    - Simulate up to 4 profiles per frame
+    - Once all profiles have been simulated once, simulation will shift to profile attacks
+    - Simulate up to 3 attacks per frame
+    - Once all profile attacks have been simulated once, simulation will shift back to profile movement
+
+    - Each profile and attack will store it's time of last simulation
+    - To simulate profiles regardless of time passed between simulations, subtract the time of last simulation from the current time
+    - Multiply the resulting value by any anything that relates to time, such as distance moved or damage dealt
 
 Parameters:
 
@@ -13,988 +23,892 @@ Returns:
 
 Examples:
 (begin example)
-_result = [] call ALIVE_fnc_profileSimulator;
+[] call ALiVE_fnc_profileSimulator;
 (end)
 
 See Also:
-nothing yet
+profileHandler
+profileCombatHandler
+profileAttack
 
 Author:
 ARJay
 Highhead
+SpyderBlack723
 ---------------------------------------------------------------------------- */
 
-private _id = time;
-// private _time = time;
-//[true, "ALiVE Profile Simulation starting!", format["profileSimTotal_%1",_id]] call ALIVE_fnc_timer;
+// parse CBA perFrameHandler arguments
+//_this = _this select 0;
 
-private ["_leader"]; // TODO
 
-params ["_markers","_cycleTime",["_debug", false]];
-
-private _speedModifier = [ALiVE_profileSystem,"speedModifier",1] call ALiVE_fnc_HashGet;
-private _boatsEnabled = [ALiVE_profileSystem,"seaTransport",false] call ALiVE_fnc_HashGet;
+private _debug = [MOD(profileSystem),"debug"] call ALiVE_fnc_hashGet;
 private _combatRange = [MOD(profileCombatHandler),"combatRange"] call ALiVE_fnc_hashGet;
+private _profilesToSim = [MOD(profileSystem),"profilesToSim"] call ALiVE_fnc_hashGet;
+private _simAttacks = [MOD(profileSystem),"simulatingAttacks"] call ALiVE_fnc_hashGet;
 
-private _moveDistModifier = _cycleTime * _speedModifier;
+if (_profilesToSim isEqualTo []) then {
+    private _profilesByType = [MOD(profileHandler),"profilesByType"] call ALiVE_fnc_hashGet;
+    private _entities = [_profilesByType,"entity"] call ALiVE_fnc_hashGet;
+    _profilesToSim append _entities;
 
-private _profiles = [ALIVE_profileHandler, "profiles"] call ALIVE_fnc_hashGet;
-// private _profileBlock = [ALIVE_arrayBlockHandler,"getNextBlock", ["simulation",_profiles select 2,50]] call ALIVE_fnc_arrayBlockHandler;
+    _simAttacks = true;
+    [MOD(profileSystem),"simulatingAttacks", true] call ALiVE_fnc_hashSet;
 
-private _totalEntities = 0;
+};
 
-//[true, "ALiVE Profiles Movement starting", format["profileCheck_%1",_id]] call ALIVE_fnc_timer;
-{
-//{
-    //[true, "ALiVE Profile starts...", format["profileSim1_%1",_id]] call ALIVE_fnc_timer;
+if (!_simAttacks) then {
 
-    private _entityProfile = _x;
-    private _profileType = _entityProfile select 2 select 5; //[_profile,"type"] call ALIVE_fnc_hashGet;
+    private _speedModifier = [MOD(profileSystem),"speedModifier", 1] call ALiVE_fnc_HashGet;
+    private _boatsEnabled = [MOD(profileSystem),"seaTransport", false] call ALiVE_fnc_HashGet;
 
-    if(_profileType == "entity") then {
+    // find profile to sim
+    // sim up to 4 profiles per frame
 
-        _totalEntities = _totalEntities + 1;
+    for "_i" from 0 to 3 do {
 
-        //[true, "ALiVE entity inits...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
+        if (_profilesToSim isEqualTo []) exitwith {};
 
-        private _profileID = _entityProfile select 2 select 4;              // [_profile,"profileID"] call ALIVE_fnc_hashGet;
-        private _active = _entityProfile select 2 select 1;                 // [_profile, "active"] call ALIVE_fnc_hashGet;
-        private _waypoints = _entityProfile select 2 select 16;             // [_entityProfile,"waypoints"] call ALIVE_fnc_hashGet;
-        private _waypointsCompleted = _entityProfile select 2 select 17;    // [_entityProfile,"waypointsCompleted",[]] call ALIVE_fnc_hashGet;
-        private _currentPosition = _entityProfile select 2 select 2;        // [_entityProfile,"position"] call ALIVE_fnc_hashGet;
-        private _vehiclesInCommandOf = _entityProfile select 2 select 8;    // [_entityProfile,"vehiclesInCommandOf"] call ALIVE_fnc_hashGet;
-        private _vehiclesInCargoOf = _entityProfile select 2 select 9;      // [_entityProfile,"vehiclesInCargoOf"] call ALIVE_fnc_hashGet;
-        private _speedPerSecondArray = _entityProfile select 2 select 22;   // [_entityProfile, "speedPerSecond"] call ALIVE_fnc_hashGet;
-        private _isCycling = _entityProfile select 2 select 25;             // [_entityProfile, "speedPerSecond"] call ALIVE_fnc_hashGet;
-        private _side = _entityProfile select 2 select 3;                   // [_entityProfile, "side"] call ALIVE_fnc_hashGet;
-        private _positions = _entityProfile select 2 select 18;             // [_entityProfile, "positions"] call ALIVE_fnc_hashGet;
-        private _isPlayer = _entityProfile select 2 select 30;              // [_entityProfile, "isPlayer"] call ALIVE_fnc_hashGet;
-        private _faction = [_entityProfile, "faction"] call ALIVE_fnc_hashGet;
-        private _locked = [_entityProfile, "locked",false] call ALIVE_fnc_HashGet;
-        private _combat = [_entityProfile, "combat",false] call ALIVE_fnc_HashGet;
+        private "_profile";
 
-        if (!_locked && {!_combat}) then {
+        while {isnil "_profile" && !(_profilesToSim isEqualTo [])} do {
+            _profile = [MOD(profileHandler),"getProfile", _profilesToSim select 0] call ALiVE_fnc_profileHandler;
+            _profilesToSim deleteat 0;
+        };
 
-            private _vehicleCommander = false;
-            private _vehicleCargo = false;
-            private _collected = false;
-            private _isAir = false;
+        if (!isnil "_profile") then {
+            // begin sim
 
-            // if entity is commanding a vehicle/s
-            if(count _vehiclesInCommandOf > 0) then {
-                _vehicleCommander = true;
+            private _locked = [_profile,"locked", false] call ALiVE_fnc_HashGet;
+            private _combat = [_profile,"combat", false] call ALiVE_fnc_HashGet;
 
-                // check if moving air unit
-                {
-                    private _entry = [ALiVE_ProfileHandler,"getProfile",_x] call ALiVE_fnc_ProfileHandler;
+            // only sim if profile is not locked or in combat
+            // locked entities could be spawning/despawning or other
 
-                    if !(isNil "_entry") then {
-                        if (
-                            [_entry,"engineOn",false] call ALiVE_fnc_HashGet &&
-                            {([_entry,"vehicleClass",""] call ALiVE_fnc_HashGet) isKindOf "Air"}
-                        ) then {
+            if (!_locked && !_combat) then {
+
+                private _timeLastSim = [_profile,"timeLastSim", diag_tickTime - 0.001] call ALiVE_fnc_hashGet;
+                private _simModifier = diag_tickTime - _timeLastSim;
+
+                // gather info on this profile
+
+                private _profilePosition = _profile select 2 select 2;
+                private _isPlayer = _profile select 2 select 30;
+
+                // determine if entity occupies a vehicle
+                private _vehiclesInCommandOf = _profile select 2 select 8;
+                private _vehiclesInCargoOf = _profile select 2 select 9;
+
+                private _vehicleCommander = false;
+                private _isAir = false;
+
+                if !(_vehiclesInCommandOf isEqualTo []) then {
+                    _vehicleCommander = true;
+
+                    // determine if vehicles is a moving air unit
+                    {
+                        private _vehicle = [MOD(ProfileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
+
+                        // if engineOn and vehicleClass is air vehicle
+                        if (!isnil "_vehicle" && {(_vehicle select 2 select 15)} && {(_vehicle select 2 select 11) isKindOf "Air"}) then {
                             _isAir = true;
                         };
-                    };
-                } foreach _vehiclesInCommandOf;
-            };
-
-            // if entity is cargo of vehicle/s
-            if(count _vehiclesInCargoOf > 0) then {
-                _vehicleCargo = true;
-            };
-
-            //[false, "ALiVE entity init ended...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
-
-            // Combat
-
-            if (!_vehicleCargo && {!_isPlayer} && {!_isAir} && {!_combat}) then {
-
-                // Find and attack enemy profiles in-range
-
-                private _nearEnemies = [];
-                [{
-                    private _posInt = _x select 2 select 2;
-                    private _typeInt = _x select 2 select 5;
-                    private _isPlayerInt = [_x,"isPlayer",false] call ALiVE_fnc_hashGet;
-
-                    if (
-                        (_typeInt == "entity") &&
-                        {_posInt distance2D _currentPosition <= _combatRange} &&
-                        {!_isPlayerInt}
-                    ) then {
-
-                        private _sideObj = [_side] call ALiVE_fnc_sideTextToObject;
-                        private _sideInt = _x select 2 select 3;
-                        private _enemySides = [];
-
-                        if (_sideObj getfriend east < 0.6) then {_enemySides pushback "EAST"};
-                        if (_sideObj getfriend west < 0.6) then {_enemySides pushback "WEST"};
-                        if (_sideObj getfriend resistance < 0.6) then {_enemySides pushback "GUER"};
-
-                        if (_sideInt in _enemySides) then {
-                            private _profileIDInt = _x select 2 select 4;
-                            _nearEnemies pushback _profileIDInt;
-                        };
-                    };
-
-                },_profiles select 2,2] call ALiVE_fnc_ArrayFrameSplitter;
-
-
-                if !(_nearEnemies isEqualTo []) then {
-
-                    private _profileAttack = [nil,"create"] call ALiVE_fnc_profileAttack;
-                    [_profileAttack,"init"] call ALiVE_fnc_profileAttack;
-                    [_profileAttack,"position", _currentPosition] call ALiVE_fnc_hashSet;
-                    [_profileAttack,"attacker", _profileID] call ALiVE_fnc_hashSet;
-                    [_profileAttack,"targets", _nearEnemies] call ALiVE_fnc_hashSet;
-                    [_profileAttack,"attackerSide", _side] call ALiVE_fnc_hashSet;
-
-                    private _attackID = [MOD(profileCombatHandler),"addAttack", _profileAttack] call ALiVE_fnc_profileCombatHandler;
-
-                    if !(isNil "_attackID") then {
-
-	                    _combat = true;
-	                    [_entityProfile,"combat", _combat] call ALIVE_fnc_HashSet;
-	                    [_entityProfile,"attackID", _attackID] call ALIVE_fnc_HashSet;
-
-	                    _collected = true;
-
-	                    //["ALiVE Profile Simulation - Profile %1 begins attacking profiles %2!",_profileID,_nearEnemies] call ALIVE_fnc_dump;
-	                };
+                    } foreach _vehiclesInCommandOf;
                 };
-            };
 
-            // entity has waypoints assigned and entity is not in cargo of a vehicle
-            if (count _waypoints > 0 && {!_vehicleCargo} && {!_isPlayer}) then {
+                // determine if entity is cargo of vehicle
 
-                // entity is not spawned, simulate
-                if!(_active) then {
+                private _vehicleCargo = false;
+                if !(_vehiclesInCargoOf isEqualTo []) then {
+                    _vehicleCargo = true;
+                };
 
-                    //[true, "ALiVE entity movement phase 1 start...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
 
-                    private _activeWaypoint = _waypoints select 0;
-                    private _type = [_activeWaypoint,"type"] call ALIVE_fnc_hashGet;
-                    private _speed = [_activeWaypoint,"speed"] call ALIVE_fnc_hashGet;
-                    private _destination = [_activeWaypoint,"position"] call ALIVE_fnc_hashGet;
-                    private _statements = [_activeWaypoint,"statements"] call ALIVE_fnc_hashGet;
-                    private _distance = _currentPosition distance _destination;
+                // check for combat opportunities
+                if (!_vehicleCargo && !_isPlayer && !_isAir && !_combat) then {
+                    // get enemy sides
+                    private _side = _profile select 2 select 3;
+                    private _sideObj = [_side] call ALiVE_fnc_sideTextToObject;
+                    private _sidesEnemy = [];
+                    if (_sideObj getfriend east < 0.6) then {_sidesEnemy pushback "EAST"};
+                    if (_sideObj getfriend west < 0.6) then {_sidesEnemy pushback "WEST"};
+                    if (_sideObj getfriend resistance < 0.6) then {_sidesEnemy pushback "GUER"};
 
-                    private ["_speedPerSecond"];
+                    // find and attack enemy profiles in-range
 
-                    switch(_speed) do {
-                        case "LIMITED": {_speedPerSecond = _speedPerSecondArray select 0};
-                        case "NORMAL": {_speedPerSecond = _speedPerSecondArray select 1};
-                        case "FULL": {_speedPerSecond = _speedPerSecondArray select 2};
-                        case default {_speedPerSecond = _speedPerSecondArray select 1};
-                    };
+                    private _nearEnemies = [_profilePosition, _combatRange, [_sidesEnemy,"entity"], true] call ALiVE_fnc_getNearProfiles;
+                    _nearEnemies = _nearEnemies select {!(_x select 2 select 30)}; // filter out players
+                    _nearEnemies = _nearEnemies apply {_x select 2 select 4};
 
-                    private _moveDistance = floor(_speedPerSecond * _moveDistModifier);
-                    private _direction = 0;
+                    if !(_nearEnemies isEqualTo []) then {
 
-                    // DEBUG -------------------------------------------------------------------------------------
-                    if(_debug) then {
-                        //["----------------------------------------------------------------------------------------"] call ALIVE_fnc_dump;
-                        //["ALIVE Simulated profile movement Profile: [%1] WPType: [%2] WPSpeed: [%3] Distance: [%4] MoveSpeed: [%5] SpeedArray: %6",_profileID,_type,_speed,_distance,_speedPerSecond,_speedPerSecondArray] call ALIVE_fnc_dump;
-                        //[_entityProfile,_activeWaypoint] call _createMarker;
-                    };
-                    // DEBUG -------------------------------------------------------------------------------------
+                        private _profileID = _profile select 2 select 4;
 
-                    //[false, "ALiVE entity movement phase 1 end...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
+                        private _profileAttack = [nil,"create", [_profilePosition,_profileID,_nearEnemies,_side]] call ALiVE_fnc_profileAttack;
+                        private _attackID = [MOD(profileCombatHandler),"addAttack", _profileAttack] call ALiVE_fnc_profileCombatHandler;
 
-                    if (!_collected && {!(isnil "_currentPosition")} && {count _currentPosition > 0} && {!(isnil "_destination")} && {count _destination > 0}) then {
-
-                        //[true, "ALiVE entity movement phase 2 virtual start...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
-
-                        //else simulate them
-                        //Match 2D since some profiles dont have a _pos select 2 defined
-                        _currentPosition set [2,0];
-                        _destination set [2,0];
-                        private _executeStatements = false;
-
-                        private ["_newPosition","_handleWPcomplete"];
-
-                        switch (_type) do {
-                            case "MOVE" : {
-                                _direction = _currentPosition getDir _destination;
-                                _newPosition = _currentPosition getPos [_moveDistance, _direction];
-                                _handleWPcomplete = {};
-                            };
-                            case "CYCLE" : {
-                                _direction = _currentPosition getDir _destination;
-                                _newPosition = _currentPosition getPos [_moveDistance, _direction];
-                                _handleWPcomplete = {
-                                    _waypoints = _waypoints + _waypointsCompleted;
-                                    _waypointsCompleted = [];
-                                };
-                            };
-                            default {
-                                _newPosition = _currentPosition;
-                                _handleWPcomplete = {};
-                            };
+                        if (!isnil "_attackID") then {
+                            //["%1 begins attacking %2", _profileID, _nearEnemies] call ALiVE_fnc_Dump;
+                            _combat = true;
+                            [_profile,"combat", true] call ALiVE_fnc_HashSet;
+                            [_profile,"attackID", _attackID] call ALiVE_fnc_HashSet;
                         };
+                    };
+                };
 
-                        // distance to wp destination within completion radius
-                        if(_distance <= (_moveDistance * 2)) then {
 
-                            if(_isCycling) then {
-                                _waypointsCompleted pushback _activeWaypoint;
+                private _waypoints = _profile select 2 select 16;
+
+                if (!_isPlayer && !_vehicleCargo && !_combat) then {
+                    if (!(_waypoints isEqualTo [])) then {
+                        // profile has waypoints
+
+                        private _active = _profile select 2 select 1;
+                        if (!_active) then {
+
+                            // profile is not spawned, simulate movement
+
+                            private _activeWaypoint = _waypoints select 0;
+                            private _destination = [_activeWaypoint,"position"] call ALiVE_fnc_hashGet;
+                            private _distanceToWaypoint = _profilePosition distance _destination;
+
+                            private _speedPerSecondArray = _profile select 2 select 22;
+                            private _speedPerSecond = _speedPerSecondArray select 1;
+
+                            switch ([_activeWaypoint,"speed"] call ALiVE_fnc_hashGet) do {
+                                case "LIMITED": {_speedPerSecond = _speedPerSecondArray select 0};
+                                case "NORMAL":  {_speedPerSecond = _speedPerSecondArray select 1};
+                                case "FULL":    {_speedPerSecond = _speedPerSecondArray select 2};
                             };
 
-                            _waypoints set [0,objNull];
-                            _waypoints = _waypoints - [objNull];
+                            private _moveDistance = _speedPerSecond * _simModifier * _speedModifier * accTime;
+                            private _direction = 0;
 
-                            [] call _handleWPcomplete; _executeStatements = true;
+                            if (!isnil "_profilePosition" && {!(_profilePosition isEqualTo [])} && {!isnil "_destination"}) then {
 
-                            [_entityProfile,"waypoints",_waypoints] call ALIVE_fnc_hashSet;
+                                // add z-index since some profiles dont one defined
+                                _profilePosition set [2,0];
+                                _destination set [2,0];
 
-                            if(_isCycling) then {
-                                [_entityProfile,"waypointsCompleted",_waypointsCompleted] call ALIVE_fnc_hashSet;
-                            };
-                        };
+                                private _executeStatements = false;
 
-                        private ["_boatProfileID","_boatProfile"];
+                                private _newPosition = _profilePosition;
+                                private _handleWPcomplete = {};
 
-                        if(_vehicleCommander) then {
-                            // if entity is in command of a vehicle (not cargo)
-                            [_entityProfile,"hasSimulated",true] call ALIVE_fnc_hashSet;
-                            {
-                                private _vehicleProfile = [ALiVE_ProfileHandler,"getProfile",_x] call ALiVE_fnc_ProfileHandler;
-
-                                if !(isnil "_vehicleProfile") then {
-
-                                    // turn engineOn virtually
-                                    // move all entities within the vehicle
-                                    // set the vehicle position and merge all assigned entities positions
-
-                                    //["PROFILE SIM SIMMED ENTITY %1 IN COMMAND OF %2 SET VEHICLE POS: %3",_entityProfile select 2 select 4,_vehicleProfile select 2 select 4,_newPosition] call ALIVE_fnc_dump;
-
-                                    [_vehicleProfile,"hasSimulated",true] call ALIVE_fnc_hashSet;
-                                    [_vehicleProfile,"engineOn",true] call ALIVE_fnc_profileVehicle;
-                                    [_vehicleProfile,"position",_newPosition] call ALIVE_fnc_profileVehicle;
-                                    [_vehicleProfile,"direction",_direction] call ALIVE_fnc_profileVehicle;
-                                    [_vehicleProfile,"mergePositions"] call ALIVE_fnc_profileVehicle;
-
-                                    // Remove any boat if not on water anymore
-	                                if (_boatsEnabled && {!isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}} && {!surfaceIsWater _currentPosition}) then {
-
-										_boatProfileID = ([_entityProfile,"boat"] call ALIVE_fnc_hashGet) select 0;
-                                        _boatProfile = [ALiVE_ProfileHandler,"getProfile",_boatProfileID] call ALiVE_fnc_ProfileHandler;
-
-                                        if (isNil "_boatProfile") then {
-                                            ["ALiVE Profile Simulator _boatProfile is nil _entityProfile is %1",_entityProfile] call ALiVE_fnc_DumpR;
-
-                                            [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
-                                        } else {
-	                                    	_profileID = [_entityProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
-	                                        _boatID = [_boatProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
-
-											if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatID,_profileID] call ALiVE_fnc_Dump};
-
-	                                        if (count _waypoints > 1) then {_waypoints deleteAt 0};
-
-		                                    [_entityProfile,_boatProfile] call ALIVE_fnc_removeProfileVehicleAssignment;
-		                                    [ALIVE_profileHandler, "unregisterProfile", _boatProfile] call ALIVE_fnc_profileHandler;
-
-		                                    [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
-
+                                switch ([_activeWaypoint,"type"] call ALiVE_fnc_hashGet) do {
+                                    case "MOVE" : {
+                                        _direction = _profilePosition getDir _destination;
+                                        _newPosition = _profilePosition getPos [_moveDistance, _direction];
+                                        _handleWPcomplete = {};
+                                    };
+                                    case "CYCLE" : {
+                                        _direction = _profilePosition getDir _destination;
+                                        _newPosition = _profilePosition getPos [_moveDistance, _direction];
+                                        _handleWPcomplete = {
+                                            _waypoints append _waypointsCompleted;
+                                            _waypointsCompleted = [];
                                         };
-	                                };
-                                };
-                            } forEach _vehiclesInCommandOf;
-                        }else{
-
-                            //["PROFILE SIM SIMMED ENTITY %1 NOT IN COMMAND SET ENTITY POS: %2",_entityProfile select 2 select 4,_newPosition] call ALIVE_fnc_dump;
-
-                            // Assign a boat to entities if on water
-							if (_boatsEnabled && {surfaceIsWater _currentPosition} && {surfaceIsWater _newPosition}) then {
-                                if (isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}) then {
-
-									if (_debug) then {["ALiVE Profile Simulator is adding a boat to entity profile %1",_profileID] call ALiVE_fnc_Dump};
-
-									private _boatTypes = [(count _positions)-1, [_faction],"SHIP"] call ALiVE_fnc_findVehicleType;
-                                    private _boatType = if (count _boatTypes > 0) then {selectRandom _boatTypes} else {"C_Boat_Transport_02_F"};
-
-									_boatProfile = [_boatType,_side,_faction,_newPosition,0,false,_faction,[]] call ALIVE_fnc_createProfileVehicle;
-                                    [_entityProfile,_boatProfile] call ALIVE_fnc_createProfileVehicleAssignment;
-
-									private _shore = [_newPosition,_destination] call ALiVE_fnc_findNearestShore;
-
-                                    if !(_shore isEqualTo [0,0,0]) then {
-	                                    _shoreWaypoint = [_shore, 10] call ALIVE_fnc_createProfileWaypoint;
-	                                    [_entityProfile,"insertWaypoint",_shoreWaypoint] call ALIVE_fnc_profileEntity;
-									};
-
-									[_entityProfile,"boat",[[_boatProfile,"profileID"] call ALiVE_fnc_HashGet,_newPosition]] call ALIVE_fnc_hashSet;
-                                };
-
-                            } else {
-                                // Remove boat if not on water anymore (failsafe, will be handled by _vehicleCommander case above)
-                                if (_boatsEnabled && {!isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}}) then {
-
-									_boatProfileID = ([_entityProfile,"boat"] call ALIVE_fnc_hashGet) select 0;
-                                    _boatProfile = [ALiVE_ProfileHandler,"getProfile",_boatProfileID] call ALiVE_fnc_ProfileHandler;
-
-                                    if (isNil "_boatProfile") then {
-                                        ["ALiVE Profile Simulator _boatProfile is nil _entityProfile is %1",_entityProfile] call ALiVE_fnc_DumpR;
-
-                                        [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
-                                    } else {
-	                                	_profileID = [_entityProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
-	                                    _boatID = [_boatProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
-
-										if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatID,_profileID] call ALiVE_fnc_Dump};
-
-	                                    if (count _waypoints > 1) then {_waypoints deleteAt 0};
-
-	                                    [_entityProfile,_boatProfile] call ALIVE_fnc_removeProfileVehicleAssignment;
-	                                    [ALIVE_profileHandler, "unregisterProfile", _boatProfile] call ALIVE_fnc_profileHandler;
-
-	                                    [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
                                     };
                                 };
-                            };
 
-                            // set the entity position and merge all unit positions to group position
-                            [_entityProfile,"hasSimulated",true] call ALIVE_fnc_hashSet;
-                            [_entityProfile,"position",_newPosition] call ALIVE_fnc_profileEntity;
-                            [_entityProfile,"mergePositions"] call ALIVE_fnc_profileEntity;
-                        };
+                                // if distance to wp destination is within completion radius
+                                // mark waypoint as complete
+                                if (_distanceToWaypoint <= (_moveDistance * 2)) then {
+                                    private _isCycling = _profile select 2 select 25;
+                                    private _waypointsCompleted = _profile select 2 select 17;
 
-                        // Execute statements at the end, needs review of any variables in hashes
-                        if (_executeStatements) then {if ((typeName _statements == "ARRAY") && {call compile (_statements select 0)}) then {call compile (_statements select 1)}};
-
-                        //[false, "ALiVE entity movement phase 2 virtual end...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
-                    } else {
-                        if (_debug) then {["ALiVE Profile-Simulator profile movement stopped for profile %1: currentPosition: %2 destination: %3 combat: %4",_profileID,_currentPosition,_destination,_collected] call ALIVE_fnc_dump};
-                    };
-
-                // entity is spawned, update positions
-                } else {
-
-                    //[true, "ALiVE entity movement phase 2 live start...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
-
-                    private _group = _entityProfile select 2 select 13;
-                    private _position = _entityProfile select 2 select 2; //_leader = [_profile,"position"] call ALIVE_fnc_hashGet;
-                    private _leader = leader _group; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
-                    private _newPosition = getPosATL _leader;
-
-                    private _activeWaypoint = _waypoints select 0;
-                    private _type = [_activeWaypoint,"type"] call ALIVE_fnc_hashGet;
-                    private _speed = [_activeWaypoint,"speed"] call ALIVE_fnc_hashGet;
-                    private _destination = [_activeWaypoint,"position"] call ALIVE_fnc_hashGet;
-
-                    if (!(isnil "_newPosition") && {count _newPosition > 0} && {!(isnil "_position")} && {count _position > 0}) then {
-
-                        private _moveDistance = _newPosition distance _position;
-                        private _nearDestination = _newPosition distance _destination < 100;
-
-                        if (_moveDistance > 10 || {_nearDestination}) then {
-
-                            if(_vehicleCommander) then {
-                                // if in command of vehicle move all entities within the vehicle
-                                // set the vehicle position and merge all assigned entities positions
-
-                                //_leader = _entityProfile select 2 select 10; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
-
-                                private _newPosition = getPosATL vehicle _leader;
-
-                                {
-                                    private _vehicleProfile = [ALiVE_ProfileHandler,"getProfile",_x] call ALiVE_fnc_ProfileHandler;
-
-                                    //["PROFILE SIM SPAWNED ENTITY %1 IN COMMAND OF %2 SET VEHICLE POS: %3",_entityProfile select 2 select 4,_vehicleProfile select 2 select 4,_newPosition] call ALIVE_fnc_dump;
-
-                                    if !(isnil "_vehicleProfile") then {
-                                        [_vehicleProfile,"position",_newPosition] call ALIVE_fnc_profileVehicle;
-                                        [_vehicleProfile,"mergePositions"] call ALIVE_fnc_profileVehicle;
+                                    if (_isCycling) then {
+                                        _waypointsCompleted pushback _activeWaypoint;
                                     };
-                                } forEach _vehiclesInCommandOf;
 
-					            // Remove any boat if not on water anymore
-					            //if (_boatsEnabled && {_shallow} && {!isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}} && {!(([_newPosition,0,50,0,0,0.5,1,[],[[0,0,0]]] call BIS_fnc_findSafePos) isEqualto [0,0,0])}) then {...};
-								if (_boatsEnabled && {((_newPosition) select 2) < 4} && {_nearDestination} && {!isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}}) then {
+                                    _waypoints deleteat 0;
 
-                                    _boatProfileID = ([_entityProfile,"boat"] call ALIVE_fnc_hashGet) select 0;
-                                    _creation = ([_entityProfile,"boat"] call ALIVE_fnc_hashGet) select 1;
-                                    _boatProfile = [ALiVE_ProfileHandler,"getProfile",_boatProfileID] call ALiVE_fnc_ProfileHandler;
+                                    call _handleWPcomplete;
+                                    _executeStatements = true;
+                                };
 
-                                    if (isNil "_boatProfile") then {
-                                        ["ALiVE Profile Simulator _boatProfile is nil _entityProfile is %1",_entityProfile] call ALiVE_fnc_DumpR;
-
-                                        [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
-                                    } else {
-	                                    if (_newPosition distance _creation > 100) then {
-
-		                                	_profileID = [_entityProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
-
-											if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2 (LIVE)",_boatProfileID,_profileID] call ALiVE_fnc_Dump};
-
-	                                        // deletevehicle
-	                                        [ALiVE_SYS_GC,"trashIt",vehicle _leader] call ALiVE_fnc_GC;
-
-							                [_entityProfile,_boatProfile] call ALIVE_fnc_removeProfileVehicleAssignment;
-							                [ALIVE_profileHandler, "unregisterProfile", _boatProfile] call ALIVE_fnc_profileHandler;
-
-		                                    if (count _waypoints > 1) then {
-		                                        _waypoints deleteAt 0;
-
-		                                        [_waypoints, _group] call ALIVE_fnc_profileWaypointsToWaypoints;
-		                                    };
-
-							                [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
-	                                    };
-                                    };
-					            };
-
-                            } else {
-                                //_leader = _entityProfile select 2 select 10; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
-                                _newPosition = getPosATL _leader;
-                                _newPositionASL = ATLtoASL _newPosition;
-
-                                private _deepEnough = (_newPositionASL select 2) < 1 && {_newPosition select 2 > 4};
-
-	                            // Assign a boat to entities if on water
-								if (_boatsEnabled && {surfaceIsWater _position} && {surfaceIsWater _newPosition} && {_deepEnough} && {[_position,_destination] call ALiVE_fnc_crossesSea}) then {
-	                                if (isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}) then {
-
-										if (_debug) then {["ALiVE Profile Simulator is adding a boat to entity profile (LIVE) %1",_profileID] call ALiVE_fnc_Dump};
-
-										private _boatTypes = [(count _positions)-1, [_faction],"SHIP"] call ALiVE_fnc_findVehicleType;
-	                                    private _boatType = if (count _boatTypes > 0) then {selectRandom _boatTypes} else {"C_Boat_Transport_02_F"};
-
-										_boatProfile = [_boatType,_side,_faction,_newPosition,0,false,_faction,[]] call ALIVE_fnc_createProfileVehicle;
-                                        [_entityProfile,_boatProfile] call ALIVE_fnc_createProfileVehicleAssignment;
-
-                                        _vehicleAssignments = [_entityProfile,"vehicleAssignments"] call ALiVE_fnc_hashGet;
-                                        [_vehicleAssignments, _entityProfile, true] call ALIVE_fnc_profileVehicleAssignmentsToVehicleAssignments;
-
-										private _shore = [_newPosition,_destination] call ALiVE_fnc_findNearestShore;
-
-	                                    if !(_shore isEqualTo [0,0,0]) then {
-		                                    _shoreWaypoint = [_shore, 10] call ALIVE_fnc_createProfileWaypoint;
-		                                    [_entityProfile,"insertWaypoint",_shoreWaypoint] call ALIVE_fnc_profileEntity;
-										};
-
-										[_entityProfile,"boat",[[_boatProfile,"profileID"] call ALiVE_fnc_HashGet,_newPosition]] call ALIVE_fnc_hashSet;
-	                                };
-	                            };
-
-                                //["PROFILE SIM SPAWNED ENTITY %1 NOT IN COMMAND SET ENTITY POS: %2",_entityProfile select 2 select 4,_newPosition] call ALIVE_fnc_dump;
-
-                                // set the entity position and merge all unit positions to group position
-                                [_entityProfile,"position",_newPosition] call ALIVE_fnc_profileEntity;
-                                [_entityProfile,"mergePositions"] call ALIVE_fnc_profileEntity;
-                            };
-                        };
-                    } else {
-                        ["Profile-Simulator corrupted spawned profile detected %1: _newPosition %2 _position %3",_profileID,_newPosition,_position] call ALIVE_fnc_dump;
-                    };
-
-                    //[false, "ALiVE entity movement phase 2 live end...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
-                };
-            } else {
-
-                // the profile has no waypoints
-                if(!(_vehicleCargo) && !(_isPlayer)) then {
-
-                    //[true, "ALiVE entity no-movement starts...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
-
-                    // but the profile has waypoints set, but not by ALiVE
-                    // eg Zeus
-
-                    //_group = group _leader;
-                    private _group = _entityProfile select 2 select 13; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
-                    private _leader = _entityProfile select 2 select 10; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
-
-                    if((!isNull _group) && {currentWaypoint _group < count waypoints _group && currentWaypoint _group > 0}) then {
-                        //["S1: %1 %2", currentWaypoint _group, count waypoints _group] call ALIVE_fnc_dump;
-
-						private _leader = leader _group;
-                        private _newPosition = getPosATL _leader;
-                        private _position = _entityProfile select 2 select 2; //_position = [_profile,"position"] call ALIVE_fnc_hashGet;
-
-                        if (!(isnil "_newPosition") && {count _newPosition > 0} && {!(isnil "_position")} && {count _position > 0}) then {
-
-                            private _moveDistance = _newPosition distance _position;
-
-                            if(_moveDistance > 10) then {
-
-                                if(_vehicleCommander) then {
-                                    // if in command of vehicle move all entities within the vehicle
-                                    // set the vehicle position and merge all assigned entities positions
-
-                                    //_leader = _entityProfile select 2 select 10; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
-
-                                    _leader = leader _group;
-
-                                    _newPosition = getPosATL vehicle _leader;
+                                if (_vehicleCommander) then {
+                                    // move vehicles that profile is in
+                                    [_profile,"hasSimulated", true] call ALiVE_fnc_hashSet;
 
                                     {
-                                        private _vehicleProfile = [ALiVE_ProfileHandler,"getProfile",_x] call ALiVE_fnc_ProfileHandler;
+                                        private _vehicleProfile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
 
-                                        //["PROFILE SIM SPAWNED NO WAYPOINTS ENTITY %1 IN COMMAND OF %2 SET VEHICLE POS: %3",_entityProfile select 2 select 4,_vehicleProfile select 2 select 4,_newPosition] call ALIVE_fnc_dump;
+                                        if (!isnil "_vehicleProfile") then {
+                                            // turn engineOn virtually
+                                            // move all entities within the vehicle
+                                            // set the vehicle position and merge all assigned entities positions
 
-                                        if !(isnil "_vehicleProfile") then {
-                                            [_vehicleProfile,"position",_newPosition] call ALIVE_fnc_profileVehicle;
-                                            [_vehicleProfile,"mergePositions"] call ALIVE_fnc_profileVehicle;
+                                            //["PROFILE SIM SIMMED ENTITY %1 IN COMMAND OF %2 SET VEHICLE POS: %3",_profile select 2 select 4,_vehicleProfile select 2 select 4,_newPosition] call ALiVE_fnc_dump;
+
+                                            [_vehicleProfile,"hasSimulated", true] call ALiVE_fnc_hashSet;
+                                            [_vehicleProfile,"engineOn", true] call ALiVE_fnc_profileVehicle;
+                                            [_vehicleProfile,"position", _newPosition] call ALiVE_fnc_profileVehicle;
+                                            [_vehicleProfile,"direction", _direction] call ALiVE_fnc_profileVehicle;
+                                            [_vehicleProfile,"mergePositions"] call ALiVE_fnc_profileVehicle;
+
+                                            // if profile is in boat, and is no longer on water
+                                            // remove boat
+
+                                            private _boat = [_profile,"boat"] call ALiVE_fnc_hashGet;
+                                            if (_boatsEnabled && {!isnil "_boat"} && {!surfaceIsWater _profilePosition}) then {
+                                                private _boatProfileID = _boat select 0;
+                                                private _boatProfile = [MOD(profileHandler),"getProfile", _boatProfileID] call ALiVE_fnc_ProfileHandler;
+
+                                                if (isnil "_boatProfile") then {
+                                                    if (_debug) then {["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR};
+                                                } else {
+                                                    private _profileID = [_profile,"profileID", "no-ID"] call ALiVE_fnc_hashGet;
+                                                    private _boatID = [_boatProfile,"profileID", "no-ID"] call ALiVE_fnc_hashGet;
+
+                                                    if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2", _boatID, _profileID] call ALiVE_fnc_Dump};
+
+                                                    if (count _waypoints > 1) then {_waypoints deleteAt 0};
+
+                                                    [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
+                                                    [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
+                                                };
+
+                                                [_profile,"boat"] call ALiVE_fnc_hashRem;
+                                            };
                                         };
                                     } forEach _vehiclesInCommandOf;
                                 } else {
+                                    // assign a boat to entities if on water
 
-                                    //_leader = _entityProfile select 2 select 10; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
+                                    if (_boatsEnabled && {surfaceIsWater _profilePosition} && {surfaceIsWater _newPosition}) then {
+                                        if (isnil {[_profile,"boat"] call ALiVE_fnc_hashGet}) then {
+                                            if (_debug) then {["ALiVE Profile Simulator is adding a boat to entity profile %1",_profileID] call ALiVE_fnc_Dump};
 
-                                    _leader = leader _group;
+                                            private _unitPositions = _profile select 2 select 18;
+                                            private _faction = [_profile, "faction"] call ALiVE_fnc_hashGet;
+                                            private _side = _profile select 2 select 3;
 
-                                    _newPosition = getPosATL _leader;
+                                            private _boatTypes = [(count _unitPositions) - 1, [_faction],"SHIP"] call ALiVE_fnc_findVehicleType;
+                                            private _boatType = if (count _boatTypes > 0) then {selectRandom _boatTypes} else {"C_Boat_Transport_02_F"};
 
-                                    //["PROFILE SIM SPAWNED NO WAYPOINTS ENTITY %1 NOT IN COMMAND SET ENTITY POS: %2",_entityProfile select 2 select 4,_newPosition] call ALIVE_fnc_dump;
+                                            private _boatProfile = [_boatType,_side,_faction,_newPosition,0,false,_faction,[]] call ALiVE_fnc_createProfileVehicle;
+                                            [_profile,_boatProfile] call ALiVE_fnc_createProfileVehicleAssignment;
 
-                                    // set the entity position and merge all unit positions to group position
-                                    [_entityProfile,"position",_newPosition] call ALIVE_fnc_profileEntity;
-                                    [_entityProfile,"mergePositions"] call ALIVE_fnc_profileEntity;
+                                            // create waypoint to nearest shore point
+                                            private _shore = [_newPosition,_destination] call ALiVE_fnc_findNearestShore;
+                                            if !(_shore isEqualTo [0,0,0]) then {
+                                                private _shoreWaypoint = [_shore, 10] call ALiVE_fnc_createProfileWaypoint;
+                                                [_profile,"insertWaypoint", _shoreWaypoint] call ALiVE_fnc_profileEntity;
+                                            };
+
+                                            [_profile, "boat", [[_boatProfile,"profileID"] call ALiVE_fnc_HashGet, _newPosition]] call ALiVE_fnc_hashSet;
+                                        };
+                                    } else {
+                                        // Remove boat if not on water anymore
+                                        // failsafe, will be handled by _vehicleCommander case above
+
+                                        private _boat = [_profile,"boat"] call ALiVE_fnc_hashGet;
+                                        if (_boatsEnabled && {!isnil "_boat"}) then {
+                                            private _boatProfileID = _boat select 0;
+                                            private _boatProfile = [MOD(profileHandler),"getProfile", _boatProfileID] call ALiVE_fnc_ProfileHandler;
+
+                                            if (isnil "_boatProfile") then {
+                                                if (_debug) then {["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR};
+                                            } else {
+                                                private _profileID = [_profile,"profileID","no-ID"] call ALiVE_fnc_hashGet;
+                                                private _boatID = [_boatProfile,"profileID","no-ID"] call ALiVE_fnc_hashGet;
+
+                                                if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatID,_profileID] call ALiVE_fnc_Dump};
+
+                                                if (count _waypoints > 1) then {_waypoints deleteAt 0};
+
+                                                [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
+                                                [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
+                                            };
+
+                                            [_profile,"boat"] call ALiVE_fnc_hashRem;
+                                        };
+                                    };
+
+                                    // set the profile position and merge all unit positions to group position
+                                    [_profile,"hasSimulated", true] call ALiVE_fnc_hashSet;
+                                    [_profile,"position", _newPosition] call ALiVE_fnc_profileEntity;
+                                    [_profile,"mergePositions"] call ALiVE_fnc_profileEntity;
+                                };
+
+                                // Execute statements at the end, needs review of any variables in hashes
+                                if (_executeStatements) then {
+                                    private _statements = [_activeWaypoint,"statements"] call ALiVE_fnc_hashGet;
+
+                                    if ((_statements isEqualType []) && {call compile (_statements select 0)}) then {
+                                        call compile (_statements select 1);
+                                    };
+                                };
+                            } else {
+                                if (_debug) then {["ALiVE Profile-Simulator profile movement stopped for profile %1: currentPosition: %2 destination: %3", [_profile,"profileID","no-ID"] call ALiVE_fnc_hashGet, _profilePosition, _destination] call ALiVE_fnc_dump};
+                            };
+
+                        } else {
+
+                            // profile is spawned, update positions
+
+                            private _group = _profile select 2 select 13;
+                            private _leader = leader _group;
+                            private _newPosition = getPosATL _leader;
+
+                            if (!isnil "_newPosition" && {!(_newPosition isEqualTo [])} && {!isnil "_profilePosition"} && {!(_profilePosition isEqualTo [])}) then {
+                                private _activeWaypoint = _waypoints select 0;
+                                private _type = [_activeWaypoint,"type"] call ALiVE_fnc_hashGet;
+                                private _speed = [_activeWaypoint,"speed"] call ALiVE_fnc_hashGet;
+                                private _destination = [_activeWaypoint,"position"] call ALiVE_fnc_hashGet;
+
+                                private _moveDistance = _newPosition distance _profilePosition;
+                                private _nearDestination = _newPosition distance _destination < 100;
+
+                                // handle waypoint completion
+
+                                if (_moveDistance > 10 || {_nearDestination}) then {
+                                    if (_vehicleCommander) then {
+
+                                        // move all entities within the vehicle
+                                        // set the vehicle position and merge all assigned entities positions
+
+                                        _newPosition = getPosATL vehicle _leader;
+
+                                        {
+                                            private _vehicleProfile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
+
+                                            if (!isnil "_vehicleProfile") then {
+                                                [_vehicleProfile,"position", _newPosition] call ALiVE_fnc_profileVehicle;
+                                                [_vehicleProfile,"mergePositions"] call ALiVE_fnc_profileVehicle;
+                                            };
+                                        } forEach _vehiclesInCommandOf;
+
+                                        // remove any boat if not on water anymore
+                                        // if (_boatsEnabled && {_shallow} && {!isnil {[_profile,"boat"] call ALiVE_fnc_hashGet}} && {!(([_newPosition,0,50,0,0,0.5,1,[],[[0,0,0]]] call BIS_fnc_findSafePos) isEqualto [0,0,0])}) then {...};
+
+                                        private _boat = [_profile,"boat"] call ALiVE_fnc_hashGet;
+                                        if (_boatsEnabled && {((_newPosition) select 2) < 4} && {_nearDestination} && {!isnil "_boat"}) then {
+                                            private _boatProfileID = _boat select 0;
+                                            private _creation = ([_profile,"boat"] call ALiVE_fnc_hashGet) select 1;
+                                            private _boatProfile = [MOD(profileHandler),"getProfile", _boatProfileID] call ALiVE_fnc_ProfileHandler;
+
+                                            if (isnil "_boatProfile") then {
+                                                if (_debug) then {["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR};
+                                            } else {
+                                                if (_newPosition distance _creation > 100) then {
+                                                    private _profileID = [_profile,"profileID", "no-ID"] call ALiVE_fnc_hashGet;
+
+                                                    if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2 (LIVE)",_boatProfileID,_profileID] call ALiVE_fnc_Dump};
+
+                                                    [MOD(SYS_GC),"trashIt", vehicle _leader] call ALiVE_fnc_GC;
+
+                                                    [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
+                                                    [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
+
+                                                    if (count _waypoints > 1) then {
+                                                        _waypoints deleteAt 0;
+                                                        [_waypoints, _group] call ALiVE_fnc_profileWaypointsToWaypoints;
+                                                    };
+                                                };
+                                            };
+
+                                            [_profile,"boat"] call ALiVE_fnc_hashRem;
+                                        };
+
+                                    } else {
+
+                                        private _deepEnough = ((ATLtoASL _newPosition) select 2) < 1 && {(_newPosition select 2) > 4};
+
+                                        // Assign a boat to entities if on water
+                                        if (_boatsEnabled && {surfaceIsWater _profilePosition} && {surfaceIsWater _newPosition} && {_deepEnough} && {[_position,_destination] call ALiVE_fnc_crossesSea}) then {
+                                            if (isnil {[_profile,"boat"] call ALiVE_fnc_hashGet}) then {
+
+                                                if (_debug) then {["ALiVE Profile Simulator is adding a boat to entity profile (LIVE) %1",_profileID] call ALiVE_fnc_Dump};
+
+                                                private _unitPositions = _profile select 2 select 18;
+                                                private _faction = [_profile, "faction"] call ALiVE_fnc_hashGet;
+                                                private _side = _profile select 2 select 3;
+
+                                                private _boatTypes = [(count _unitPositions) - 1, [_faction],"SHIP"] call ALiVE_fnc_findVehicleType;
+                                                private _boatType = if (count _boatTypes > 0) then {selectRandom _boatTypes} else {"C_Boat_Transport_02_F"};
+
+                                                private _boatProfile = [_boatType,_side,_faction,_newPosition,0,false,_faction,[]] call ALiVE_fnc_createProfileVehicle;
+                                                [_profile,_boatProfile] call ALiVE_fnc_createProfileVehicleAssignment;
+
+                                                private _vehicleAssignments = [_profile,"vehicleAssignments"] call ALiVE_fnc_hashGet;
+                                                [_vehicleAssignments,_profile, true] call ALiVE_fnc_profileVehicleAssignmentsToVehicleAssignments;
+
+                                                // create waypoint to nearest shore point
+                                                private _shore = [_newPosition,_destination] call ALiVE_fnc_findNearestShore;
+                                                if !(_shore isEqualTo [0,0,0]) then {
+                                                    private _shoreWaypoint = [_shore, 10] call ALiVE_fnc_createProfileWaypoint;
+                                                    [_profile,"insertWaypoint", _shoreWaypoint] call ALiVE_fnc_profileEntity;
+                                                };
+
+                                                [_profile,"boat", [[_boatProfile,"profileID"] call ALiVE_fnc_HashGet, _newPosition]] call ALiVE_fnc_hashSet;
+                                            };
+                                        };
+
+                                        // set the entity position and merge all unit positions to group position
+                                        [_profile,"position", _newPosition] call ALiVE_fnc_profileEntity;
+                                        [_profile,"mergePositions"] call ALiVE_fnc_profileEntity;
+
+                                    };
+                                };
+                            } else {
+                                if (_debug) then {["Profile-Simulator corrupted spawned profile detected %1: _newPosition %2 _position %3",_profileID,_newPosition,_position] call ALiVE_fnc_dump};
+                            };
+
+                        };
+                    } else {
+                        // profile has no waypoints
+
+                        private _active = _profile select 2 select 1;
+                        if (_active) then {
+                            private _group = _profile select 2 select 13;
+                            private _leader = _profile select 2 select 10;
+                            private _currentWaypoint = currentWaypoint _group;
+
+                            if ((_currentWaypoint < count waypoints _group) && (_currentWaypoint > 0)) then {
+                                _leader = leader _group;
+                                private _newPosition = getPosATL _leader;
+
+                                if (!isnil "_newPosition" && {!(_newPosition isEqualTo [])} && {!isnil "_profilePosition"} && {!(_profilePosition isEqualTo [])}) then {
+                                    private _moveDistance = _newPosition distance _profilePosition;
+
+                                    if (_moveDistance > 10) then {
+                                        if (_vehicleCommander) then {
+                                            // if in command of vehicle move all entities within the vehicle
+                                            // set the vehicle position and merge all assigned entities positions
+
+                                            _newPosition = getPosATL vehicle _leader;
+
+                                            {
+                                                private _vehicleProfile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
+                                                if (!isnil "_vehicleProfile") then {
+                                                    [_vehicleProfile,"position", _newPosition] call ALiVE_fnc_profileVehicle;
+                                                    [_vehicleProfile,"mergePositions"] call ALiVE_fnc_profileVehicle;
+                                                };
+                                            } forEach _vehiclesInCommandOf;
+                                        } else {
+                                            // set the entity position and merge all unit positions to group position
+                                            [_profile,"position", _newPosition] call ALiVE_fnc_profileEntity;
+                                            [_profile,"mergePositions"] call ALiVE_fnc_profileEntity;
+                                        };
+                                    };
+                                } else {
+                                    if (_debug) then {["Profile-Simulator corrupted profile detected %1: _newPosition %2 _profilePosition %3",_profileID,_newPosition,_profilePosition] call ALiVE_fnc_dump};
                                 };
                             };
-                        } else {
-                            ["Profile-Simulator corrupted profile detected %1: _newPosition %2 _position %3",_profileID,_newPosition,_position] call ALIVE_fnc_dump;
+                        };
+
+                        // remove any ambient sea transport if no waypoint is assigned (should not happen - failsafe)
+                        if (_boatsEnabled && {_vehicleCommander} && {!isnil {[_profile,"boat"] call ALiVE_fnc_hashGet}}) then {
+                            private _boatProfileID = ([_profile,"boat"] call ALiVE_fnc_hashGet) select 0;
+                            private _boatProfile = [ALiVE_ProfileHandler,"getProfile",_boatProfileID] call ALiVE_fnc_ProfileHandler;
+
+                            if (isnil "_boatProfile") then {
+                                ["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR;
+                            } else {
+                                private _profileID = [_profile,"profileID","no-ID"] call ALiVE_fnc_hashGet;
+
+                                if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatProfileID,_profileID] call ALiVE_fnc_Dump};
+
+                                [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
+
+                                [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
+                            };
+
+                            [_profile,"boat"] call ALiVE_fnc_hashRem;
                         };
                     };
-
-                    ///*
-                    // Remove any ambient sea transport if no waypoint is assigned (should not happen - failsafe)
-	                if (_boatsEnabled && {_vehicleCommander} && {!isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}}) then {
-
-						_boatProfileID = ([_entityProfile,"boat"] call ALIVE_fnc_hashGet) select 0;
-                        _boatProfile = [ALiVE_ProfileHandler,"getProfile",_boatProfileID] call ALiVE_fnc_ProfileHandler;
-
-                        if (isNil "_boatProfile") then {
-                        	["ALiVE Profile Simulator _boatProfile is nil _entityProfile is %1",_entityProfile] call ALiVE_fnc_DumpR;
-
-                            [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
-                        } else {
-		                	_profileID = [_entityProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
-
-							if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatProfileID,_profileID] call ALiVE_fnc_Dump};
-
-		                    [_entityProfile,_boatProfile] call ALIVE_fnc_removeProfileVehicleAssignment;
-
-		                    [ALIVE_profileHandler, "unregisterProfile", _boatProfile] call ALIVE_fnc_profileHandler;
-
-		                    [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
-                        };
-	                };
-                    //*/
-
-                    //[false, "ALiVE entity no-movement ends...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
                 };
 
-                // entity is player entity
-                if(_isPlayer) then {
-
-                    //[true, "ALiVE entity player starts...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
-
-                    private _leader = _entityProfile select 2 select 10;    //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
+                if (_isPlayer) then {
+                    private _leader = _profile select 2 select 10;
                     private _newPosition = getPosATL _leader;
-                    private _position = _entityProfile select 2 select 2;   //_leader = [_profile,"position"] call ALIVE_fnc_hashGet;
 
-                    //Positions are valid
-                    if (!(isnil "_newPosition") && {str(_newPosition) != "[0,0,0]"} && {!(isnil "_position")} && {str(_position) != "[0,0,0]"}) then {
+                    // verify that position is valid
 
-                        private _moveDistance = _newPosition distance _position;
+                    if (!isnil "_newPosition" && {str _newPosition != "[0,0,0]"} && {!isnil "_profilePosition"} && {str _profilePosition != "[0,0,0]"}) then {
+                        private _moveDistance = _newPosition distance _profilePosition;
 
-                        if(_moveDistance > 10) then {
-                            if(_vehicleCommander) then {
+                        if (_moveDistance > 10) then {
+                            if (_vehicleCommander) then {
                                 // if in command of vehicle move all entities within the vehicle
                                 // set the vehicle position and merge all assigned entities positions
 
-                                //_leader = _entityProfile select 2 select 10; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
+                                //_leader = _profile select 2 select 10; //_leader = [_profile,"leader"] call ALiVE_fnc_hashGet;
                                 _newPosition = getPosATL vehicle _leader;
 
                                 {
-                                    private _vehicleProfile = [ALiVE_ProfileHandler,"getProfile",_x] call ALiVE_fnc_ProfileHandler;
-
-                                    if !(isnil "_vehicleProfile") then {
-                                        [_vehicleProfile,"position",_newPosition] call ALIVE_fnc_profileVehicle;
-                                        [_vehicleProfile,"mergePositions"] call ALIVE_fnc_profileVehicle;
+                                    private _vehicleProfile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
+                                    if (!isnil "_vehicleProfile") then {
+                                        [_vehicleProfile,"position", _newPosition] call ALiVE_fnc_profileVehicle;
+                                        [_vehicleProfile,"mergePositions"] call ALiVE_fnc_profileVehicle;
                                     };
                                 } forEach _vehiclesInCommandOf;
                             } else {
-                                //_leader = _entityProfile select 2 select 10; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
                                 _newPosition = getPosATL _leader;
 
                                 // set the entity position and merge all unit positions to group position
-                                [_entityProfile,"position",_newPosition] call ALIVE_fnc_profileEntity;
-                                [_entityProfile,"mergePositions"] call ALIVE_fnc_profileEntity;
+                                [_profile,"position", _newPosition] call ALiVE_fnc_profileEntity;
+                                [_profile,"mergePositions"] call ALiVE_fnc_profileEntity;
                             };
                         };
-
-                        //Positions are invalid (due to missing player object or corrupted profile)
                     } else {
-                        ["DISCONNECT"] call ALIVE_fnc_createProfilesFromPlayers;
-                    };
+                        // position is invalid
+                        // (due to missing player object or corrupted profile)
 
-                    //[false, "ALiVE entity player ends...", format["profileSim_%1",_id]] call ALIVE_fnc_timer;
+                        ["DISCONNECT"] call ALiVE_fnc_createProfilesFromPlayers;
+                    };
                 };
             };
+
+            [_profile,"timeLastSim", diag_tickTime] call ALiVE_fnc_hashSet;
 
         };
     };
 
-    //[false, "ALiVE Profile stops...", format["profileSim1_%1",_id]] call ALIVE_fnc_timer;
-//} call CBA_fnc_directCall;
-} foreach (_profiles select 2);
-//[false, "ALiVE Profile Movement ending", format["profileCheck_%1",_id]] call ALIVE_fnc_timer;
+} else {
 
-//[true, "ALiVE Profile Battle Simulation starting", format["profileClash_%1",_id]] call ALIVE_fnc_timer;
+    // Simulate attacks
 
-// Simulate attacks
+    private _combatRate = [MOD(profileCombatHandler),"combatRate"] call ALiVE_fnc_hashGet;
+    private _attacksToSim = [MOD(profileSystem),"profileAttacksToSim"] call ALiVE_fnc_hashGet;
 
-private _combatRate = [MOD(profileCombatHandler),"combatRate"] call ALiVE_fnc_hashGet;
-private _profileAttacks = [MOD(profileCombatHandler),"attacksByID"] call ALiVE_fnc_hashGet;
-private _attacksToRemove = [];
-private _toBeUnassigned = [];
-private _toBeKilled = [];
+    if (_attacksToSim isEqualTo []) then {
 
-private _damageModifier = _cycleTime * _combatRate;
+        private _profileAttacks = [MOD(profileCombatHandler),"attacksByID"] call ALiVE_fnc_hashGet;
+        _attacksToSim append (_profileAttacks select 1);
 
-[{
-    private ["_attacker"];
+        [MOD(profileSystem),"simulatingAttacks", false] call ALiVE_fnc_hashSet;
 
-    private _attack = _x;
-    private _cyclesLeft = [_attack,"cyclesLeft"] call ALiVE_fnc_hashGet;
+    } else {
 
-    private _active = false;
+        private _attacksToRemove = [];
+        private _toBeUnassigned = [];
+        private _toBeKilled = [];
 
-    if (_cyclesLeft > 0) then {
-        [_attack,"cyclesLeft", _cyclesLeft - 1] call ALiVE_fnc_hashSet;
+        // sim 3 attack per frame
+        for "_i" from 0 to 2 do {
+            if (_attacksToSim isEqualTo []) exitwith {};
 
-        private _attackerID = [_attack,"attacker"] call ALiVE_fnc_hashGet;
-        private _targetIDs = [_attack,"targets"] call ALiVE_fnc_hashGet;
+            private ["_attacker"];
 
-        _attacker = [MOD(profileHandler),"getProfile", _attackerID] call ALiVE_fnc_profileHandler;
+            private _attack = [MOD(profileCombatHandler),"getAttack", _attacksToSim select 0] call ALiVE_fnc_profileCombatHandler;
+            _attacksToSim deleteat 0;
 
-        if (!isnil "_attacker") then {
-            if !(_attacker select 2 select 1) then {                    // [_attacker,"active", false] call ALiVE_fnc_hashGet
+            if (!isnil "_attack") then {
 
-                private _targetCount = count _targetIDs;
-                private _targetIndex = 0;
+                private _cyclesLeft = [_attack,"cyclesLeft"] call ALiVE_fnc_hashGet;
+                private _timeLastSim = [_attack,"timeLastSim", diag_tickTime - 0.001] call ALiVE_fnc_hashGet;
+                private _simModifier = diag_tickTime - _timeLastSim * accTime;
 
-                private _target = [MOD(profileHandler),"getProfile", _targetIDs select _targetIndex] call ALiVE_fnc_profileHandler;
-                private _targetNil = isnil "_target";
+                private _active = false;
 
-                while {(_targetNil || {_target select 2 select 1}) && {_targetIndex < _targetCount}} do {
-                    if (_targetNil) then {
-                        _targetIDs deleteAt _targetIndex;
-                        _targetCount = _targetCount - 1;
-                    } else {
-                        _targetIndex = _targetIndex + 1;
-                    };
+                if (_cyclesLeft > 0) then {
+                    [_attack,"cyclesLeft", _cyclesLeft - 1] call ALiVE_fnc_hashSet;
 
-                    _target = [MOD(profileHandler),"getProfile", _targetIDs select _targetIndex] call ALiVE_fnc_profileHandler;
-                    _targetNil = isnil "_target";
+                    private _attackerID = [_attack,"attacker"] call ALiVE_fnc_hashGet;
+                    private _targetIDs = [_attack,"targets"] call ALiVE_fnc_hashGet;
 
-                };
+                    _attacker = [MOD(profileHandler),"getProfile", _attackerID] call ALiVE_fnc_profileHandler;
 
-                if (!_targetNil && {_targetIndex != _targetCount}) then {
-                    if !(_target select 2 select 1) then {                                      // [_target,"active", false] call ALiVE_fnc_hashGet
-                        private _attackerType = _attacker select 2 select 5;                    // [_attacker,"type"] call ALiVE_fnc_hashGet;
-                        private _attackerVehiclesInCommandOf = _attacker select 2 select 8;;    // [_attacker,"vehiclesInCommandOf"] call ALiVE_fnc_hashGet;
-                        private _attackerPos = _attacker select 2 select 2;                     // [_attacker,"position"] call ALiVE_fnc_hashGet;
+                    if (!isnil "_attacker") then {
+                        private "_target";
+                        while {isnil "_target" && !(_targetIDs isEqualTo [])} do {
+                            _target = [MOD(profileHandler),"getProfile", _targetIDs select 0] call ALiVE_fnc_profileHandler;
 
-                        private _targetType = _target select 2 select 5;                        // [_target,"type"] call ALiVE_fnc_hashGet;
-                        private _targetVehiclesInCommandOf = _target select 2 select 8;         // [_target,"vehiclesInCommandOf"] call ALiVE_fnc_hashGet;
-                        private _targetPos = _target select 2 select 2;                         // [_target,"position"] call ALiVE_fnc_hashGet;
-
-                        private _maxEngagementRange = [_attack,"maxRange"] call ALiVE_fnc_hashGet;
-
-                        if (_attackerPos distance2D _targetPos <= _maxEngagementRange) then {
-
-                            // get profiles to attack with
-                            // vehicles entity commands, or just the entity
-
-                            private _profilesToAttackWith = [];
-
-                            {
-                                private _profileUnderCommand = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
-
-                                if (!isnil "_profileUnderCommand") then {
-                                    _profilesToAttackWith pushback _profileUnderCommand;
-                                };
-                            } foreach _attackerVehiclesInCommandOf;
-
-                            if (_profilesToAttackWith isEqualTo []) then {
-                                _profilesToAttackWith pushback _attacker; // entity shouldn't attack if it's inside vehicle(s)
+                            // if target is active, remove it
+                            if (isnil "_target" || {_target select 2 select 1}) then {
+                                _targetIDs deleteat 0;
+                                _target = nil;
                             };
+                        };
 
-                            // get targets to attack
+                        if (!isnil "_target") then {
+                            private _attackerPos = _attacker select 2 select 2;                     // [_attacker,"position"] call ALiVE_fnc_hashGet;
+                            private _targetPos = _target select 2 select 2;                         // [_target,"position"] call ALiVE_fnc_hashGet;
 
-                            private _targetsToAttack = [];
+                            private _maxEngagementRange = [_attack,"maxRange"] call ALiVE_fnc_hashGet;
 
-                            {
-                                private _targetToAttack = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
+                            if (_attackerPos distance2D _targetPos <= _maxEngagementRange) then {
+                                // get profiles to attack with
+                                // vehicles entity commands, or just the entity
 
-                                if (!isnil "_targetToAttack") then {
-                                    _targetsToAttack pushback _targetToAttack;
-                                };
-                            } foreach _targetVehiclesInCommandOf;
-
-                            if (_targetsToAttack isEqualTo []) then {
-                                _targetsToAttack pushback _target; // entity shouldn't be attacked separately if it's in a vehicle
-                            } else {
-                                reverse _targetsToAttack; // destroy vehicles in reverse order to avoid corrupting unit assignment indexes
-                            };
-
-                            if !(_targetsToAttack isEqualTo []) then {
-                                // attack each target profile individually
-                                // if vehicle is destroyed, unassigned it from it's entity
-
-                                private _targetToAttack = _targetsToAttack select 0;
-                                private _targetToAttackID = [_targetToAttack,"profileID"] call ALiVE_fnc_hashGet;
-                                private _targetToAttackType = _targetToAttack select 2 select 5;  // [_targetToAttack,"type"] call ALiVE_fnc_hashGet;
-
-                                private _profileToAttackHealth = [];
-                                private _damageToInflict = 0;
-
-                                if (_targetToAttackType == "entity") then {
-                                    _profileToAttackHealth = +([_targetToAttack,"damages"] call ALiVE_fnc_hashGet); // must be copied so that calling "removeUnit" doesn't alter the new damage array
-                                } else {
-                                    _profileToAttackHealth = [_targetToAttack,"damage"] call ALiVE_fnc_hashGet;
-
-                                    // if vehicle hasn't been spawned yet
-                                    // init hitpoint values
-
-                                    if (_profileToAttackHealth isEqualTo []) then {
-                                        private _vehicleClass = [_targetToAttack,"vehicleClass"] call ALiVE_fnc_hashGet;
-                                        private _totalHitpoints = _vehicleClass call ALiVE_fnc_configGetVehicleHitPoints;
-                                        if (_totalHitpoints isEqualTo []) then {
-                                            private _hp = [(configfile >> "CfgVehicles" >> _vehicleClass >> "HitPoints"),0] call BIS_fnc_returnChildren;
-                                            {_totalHitpoints pushBack (configName _x)} forEach _hp;
-                                        };
-                                        {_profileToAttackHealth pushback [_x,0]} foreach _totalHitpoints;
-                                    };
-                                };
-
-                                // get total damage that can be dealt this turn
-                                // damage is calculated from each vehicle the entity controls
-                                // if entity controls no vehicles, the entity itself attacks
+                                private _profilesToAttackWith = [];
+                                private _attackerVehiclesInCommandOf = _attacker select 2 select 8;
 
                                 {
-                                    _damageToInflict = _damageToInflict + (([_x,_targetToAttack] call ALiVE_fnc_profileGetDamageOutput) * _damageModifier);
-                                } foreach _profilesToAttackWith;
+                                    private _vehicleUnderCommand = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
 
-                                if (_damageToInflict > 0) then {
-                                    private _damageToInflictLeft = _damageToInflict;
+                                    if (!isnil "_vehicleUnderCommand") then {
+                                        _profilesToAttackWith pushback _vehicleUnderCommand;
+                                    };
+                                } foreach _attackerVehiclesInCommandOf;
+
+                                // entity shouldn't attack separately if it's inside vehicle(s)
+                                if (_profilesToAttackWith isEqualTo []) then {
+                                    _profilesToAttackWith pushback _attacker;
+                                };
+
+                                // get targets to attack
+
+                                private _targetsToAttack = [];
+                                private _targetVehiclesInCommandOf = _target select 2 select 8;
+
+                                {
+                                    private _targetToAttack = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
+
+                                    if (!isnil "_targetToAttack") then {
+                                        _targetsToAttack pushback _targetToAttack;
+                                    };
+                                } foreach _targetVehiclesInCommandOf;
+
+                                // entity shouldn't be attacked separately if it's in a vehicle
+                                if (_targetsToAttack isEqualTo []) then {
+                                    _targetsToAttack pushback _target;
+                                } else {
+                                    reverse _targetsToAttack; // destroy vehicles in reverse order to avoid corrupting unit assignment indexes
+                                };
+
+                                if !(_targetsToAttack isEqualTo []) then {
+                                    // attack each target profile individually
+                                    // if vehicle is destroyed, unassigned it from it's entity
+
+                                    private _targetToAttack = _targetsToAttack select 0;
+                                    private _targetToAttackID = _targetToAttack select 2 select 4;
+                                    private _targetToAttackType = _targetToAttack select 2 select 5;
+
+                                    private _profileToAttackHealth = [];
 
                                     if (_targetToAttackType == "entity") then {
-                                        // attacking entity
-                                        // spread damage randomly over units
+                                        // must be copied so that calling "removeUnit" doesn't alter the new damage array
+                                        _profileToAttackHealth = +([_targetToAttack,"damages"] call ALiVE_fnc_hashGet);
+                                    } else {
+                                        _profileToAttackHealth = [_targetToAttack,"damage"] call ALiVE_fnc_hashGet;
 
-                                        private _unitCount = count _profileToAttackHealth;
+                                        // if vehicle hasn't been spawned yet
+                                        // init hitpoint values
 
-                                        if (_unitCount > 0) then {
-                                            private _indexesToRemove = [];
-                                            private _dmgPerUnitEven = _damageToInflict / _unitCount;
+                                        if (_profileToAttackHealth isEqualTo []) then {
+                                            private _vehicleClass = _targetToAttack select 2 select 11;
+                                            private _totalHitpoints = _vehicleClass call ALiVE_fnc_configGetVehicleHitPoints;
 
-                                            private _randomDamageMin = _dmgPerUnitEven / 2;
-                                            private _randomDamageMax = _dmgPerUnitEven * 8;
-
-                                            while {_damageToInflictLeft > 0 && {_unitCount > 0}} do {
-                                                private _randomIndex = floor random _unitCount;
-                                                private _randomIndexDamage = _profileToAttackHealth select _randomIndex;
-
-                                                // calc damage - ensure no overdamage
-
-                                                private _randomDamage = random [_randomDamageMin, _dmgPerUnitEven, _randomDamageMax];
-                                                if (_randomDamage > _damageToInflictLeft) then {
-                                                    _randomDamage = _damageToInflictLeft;
-                                                };
-
-                                                _randomIndexDamage = _randomIndexDamage + _randomDamage;
-                                                _damageToInflictLeft = _damageToInflictLeft - _randomDamage;
-
-                                                if (_randomIndexDamage >= 1) then {
-                                                    _indexesToRemove pushback _randomIndex;
-                                                    _profileToAttackHealth deleteAt _randomIndex;
-                                                    _unitCount = _unitCount - 1;
-                                                } else {
-                                                    _profileToAttackHealth set [_randomIndex,_randomIndexDamage];
-                                                };
+                                            if (_totalHitpoints isEqualTo []) then {
+                                                private _hp = [(configfile >> "CfgVehicles" >> _vehicleClass >> "HitPoints"),0] call BIS_fnc_returnChildren;
+                                                {_totalHitpoints pushBack (configName _x)} forEach _hp;
                                             };
 
-                                            {
-                                                [_targetToAttack,"removeUnit", _x] call ALiVE_fnc_profileEntity;
-                                                _unitCount = _unitCount - 1;
-                                            } foreach _indexesToRemove;
+                                            {_profileToAttackHealth pushback [_x,0]} foreach _totalHitpoints;
+                                        };
+                                    };
 
-                                            [_targetToAttack,"damages", _profileToAttackHealth] call ALiVE_fnc_hashSet;
+                                    // get total damage that can be dealt this turn
+                                    // damage is calculated from each vehicle the entity controls
+                                    // if entity controls no vehicles, the entity itself attacks
 
-                                            if (_unitCount == 0) then {
+                                    private _damageToInflict = 0;
+                                    {
+                                        _damageToInflict = _damageToInflict + (([_x,_targetToAttack] call ALiVE_fnc_profileGetDamageOutput) * _combatRate * _simModifier);
+                                    } foreach _profilesToAttackWith;
+
+                                    if (_damageToInflict > 0) then {
+                                        private _damageToInflictLeft = _damageToInflict;
+
+                                        if (_targetToAttackType == "entity") then {
+                                            // attacking entity
+                                            // spread damage randomly over units
+
+                                            private _unitCount = count _profileToAttackHealth;
+
+                                            if (_unitCount > 0) then {
+                                                private _dmgPerUnitEven = _damageToInflict / _unitCount;
+
+                                                private _randomDamageMin = _dmgPerUnitEven / 2;
+                                                private _randomDamageMax = _dmgPerUnitEven * 8;
+
+                                                private _indexesToRemove = [];
+
+                                                while {_damageToInflictLeft > 0 && {_unitCount > 0}} do {
+                                                    private _randomIndex = floor random _unitCount;
+                                                    private _randomIndexDamage = _profileToAttackHealth select _randomIndex;
+
+                                                    // calc damage - ensure no overdamage
+                                                    private _randomDamage = random [_randomDamageMin, _dmgPerUnitEven, _randomDamageMax];
+                                                    if (_randomDamage > _damageToInflictLeft) then {
+                                                        _randomDamage = _damageToInflictLeft;
+                                                    };
+
+                                                    _randomIndexDamage = _randomIndexDamage + _randomDamage;
+                                                    _damageToInflictLeft = _damageToInflictLeft - _randomDamage;
+
+                                                    if (_randomIndexDamage >= 1) then {
+                                                        _indexesToRemove pushback _randomIndex;
+                                                        _profileToAttackHealth deleteAt _randomIndex;
+                                                        _unitCount = _unitCount - 1;
+                                                    } else {
+                                                        _profileToAttackHealth set [_randomIndex,_randomIndexDamage];
+                                                    };
+                                                };
+
+                                                {
+                                                    [_targetToAttack,"removeUnit", _x] call ALiVE_fnc_profileEntity;
+                                                    _unitCount = _unitCount - 1;
+                                                } foreach _indexesToRemove;
+
+                                                [_targetToAttack,"damages", _profileToAttackHealth] call ALiVE_fnc_hashSet;
+
+                                                if (_unitCount == 0) then {
+                                                    _toBeKilled pushbackunique [_attacker,_targetToAttack];
+                                                    _targetsToAttack deleteAt 0;
+                                                };
+                                            } else {
                                                 _toBeKilled pushbackunique [_attacker,_targetToAttack];
                                                 _targetsToAttack deleteAt 0;
                                             };
                                         } else {
-                                            _toBeKilled pushbackunique [_attacker,_targetToAttack];
-                                            _targetsToAttack deleteAt 0;
-                                        };
-                                    } else {
-                                        // attacking vehicle
-                                        // spread damage randomly over hit points
+                                            // attacking vehicle
+                                            // spread damage randomly over hit points
 
-                                        private _hitPointCount = count _profileToAttackHealth;
-                                        private _dmgPerHitPointEven = _damageToInflict / _hitPointCount;
+                                            private _hitPointCount = count _profileToAttackHealth;
+                                            private _dmgPerHitPointEven = _damageToInflict / _hitPointCount;
 
-                                        private _randomDamageMin = _dmgPerHitPointEven / 2;
-                                        private _randomDamageMax = _dmgPerHitPointEven * 8;
+                                            private _randomDamageMin = _dmgPerHitPointEven / 2;
+                                            private _randomDamageMax = _dmgPerHitPointEven * 8;
 
-                                        while {_damageToInflictLeft > 0} do {
-                                            private _randomIndex = floor random _hitPointCount;
-                                            private _randomHitPoint = _profileToAttackHealth select _randomIndex;
+                                            while {_damageToInflictLeft > 0} do {
+                                                private _randomIndex = floor random _hitPointCount;
+                                                private _randomHitPoint = _profileToAttackHealth select _randomIndex;
 
-                                            _randomHitPoint params ["_randomHitPointNme","_randomHitPointDmg"];
+                                                _randomHitPoint params ["_randomHitPointNme","_randomHitPointDmg"];
 
-                                            if (_randomHitPointNme != "HitFuel") then {
-                                                private _randomDamage = random [_randomDamageMin, _dmgPerHitPointEven, _randomDamageMax];
+                                                // HitFuel can lead to rapid explosions on spawn
+                                                // if damaged at all
+                                                if (_randomHitPointNme != "HitFuel") then {
+                                                    private _randomDamage = random [_randomDamageMin, _dmgPerHitPointEven, _randomDamageMax];
 
-                                                _randomHitPointDmg = _randomHitPointDmg + _randomDamage;
-                                                _damageToInflictLeft = _damageToInflictLeft - _randomDamage;
+                                                    _randomHitPointDmg = _randomHitPointDmg + _randomDamage;
+                                                    _damageToInflictLeft = _damageToInflictLeft - _randomDamage;
 
-                                                if (_randomHitPointDmg >= 1) then {
-                                                    _randomHitPoint set [1,1];
-                                                } else {
-                                                    _randomHitPoint set [1,_randomHitPointDmg];
+                                                    if (_randomHitPointDmg >= 1) then {
+                                                        _randomHitPoint set [1,1];
+                                                    } else {
+                                                        _randomHitPoint set [1,_randomHitPointDmg];
+                                                    };
+
+                                                    _profileToAttackHealth set [_randomIndex,_randomHitPoint];
                                                 };
-
-                                                _profileToAttackHealth set [_randomIndex,_randomHitPoint];
                                             };
-                                        };
 
-                                        // if all of the vehicles hitpoints are 0, vehicle is dead
+                                            // if all of the vehicles hitpoints are 0, vehicle is dead
 
-                                        private _vehCritical = false;
-                                        private _deadHitPointCount = 0;
-
-                                        {
-                                            if ((_x select 0) != "HitHull" && {(_x select 0) != "HitFuel"}) then {
-                                                if ((_x select 1) == 1) then {_deadHitPointCount = _deadHitPointCount + 1};
-                                            } else {
-                                                if ((_x select 1) > 0.85) then {_vehCritical = true}; // HitHull, HitFuel damage of > 0.90 causes most vehicles to explode upon spawn
-                                            };
-                                        } foreach _profileToAttackHealth;
-
-                                        if (
-                                            _deadHitPointCount < floor (_hitPointCount * 0.85)
-                                            &&
-                                            {_deadHitPointCount < floor (_hitPointCount * 0.75) && {!_vehCritical}}
-                                        ) then {
-                                            [_targetToAttack,"damage", _profileToAttackHealth] call ALiVE_fnc_hashSet;
-                                        } else {
-                                            _toBeUnassigned pushbackunique [_target,_targetToAttack];
-                                            _toBeKilled pushbackunique [_attacker,_targetToAttack];
-                                            _targetsToAttack deleteAt 0;
-
-                                            // if this vehicle is the last vehicles it's commanding entity controls
-                                            // kill the commanding entity as well
-
+                                            private _vehCritical = false;
+                                            private _deadHitPointCount = 0;
                                             {
-                                                private _entityInCommandOf = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
-                                                private _assignedVehicles = [_entityInCommandOf,"vehiclesInCommandOf"] call ALiVE_fnc_hashGet;
-
-                                                if (_assignedVehicles isEqualTo [_targetToAttackID]) then {
-                                                    _toBeKilled pushbackunique [_attacker, [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler];
+                                                if ((_x select 0) != "HitHull" && {(_x select 0) != "HitFuel"}) then {
+                                                    if ((_x select 1) == 1) then {_deadHitPointCount = _deadHitPointCount + 1};
+                                                } else {
+                                                    // HitHull, HitFuel damage of > 0.90 causes most vehicles to explode upon spawn
+                                                    if ((_x select 1) > 0.85) then {_vehCritical = true};
                                                 };
-                                            } foreach ([_targetToAttack,"entitiesInCommandOf"] call ALiVE_fnc_hashGet);
+                                            } foreach _profileToAttackHealth;
+
+                                            if (_deadHitPointCount < floor (_hitPointCount * 0.75) && !_vehCritical) then {
+                                                [_targetToAttack,"damage", _profileToAttackHealth] call ALiVE_fnc_hashSet;
+                                            } else {
+                                                _toBeUnassigned pushbackunique [_target,_targetToAttack];
+                                                _toBeKilled pushbackunique [_attacker,_targetToAttack];
+                                                _targetsToAttack deleteAt 0;
+
+                                                // if this vehicle is the last vehicle it's commanding entity controls
+                                                // kill the commanding entity as well
+
+                                                {
+                                                    private _entityInCommandOf = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
+                                                    private _assignedVehicles = _entityInCommandOf select 2 select 8;
+
+                                                    if (_assignedVehicles isEqualTo [_targetToAttackID]) then {
+                                                        _toBeKilled pushbackunique [_attacker, [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler];
+                                                    };
+                                                } foreach ([_targetToAttack,"entitiesInCommandOf"] call ALiVE_fnc_hashGet);
+                                            };
                                         };
                                     };
-                                };
 
-                                // combat simulation over
+                                    // combat simulation over
+                                    // end attack if no targets remain
 
-                                if !(_targetsToAttack isEqualTo []) then {
-                                    _active = true;
+                                    if !(_targetsToAttack isEqualTo []) then {
+                                        _active = true;
+                                    };
                                 };
                             };
                         };
-                    } else {
-                        // all targets are spawned
-                        // don't end attack
-                        // but don't simulate it either
-                        //_active = true;
                     };
                 };
 
-            } else {
-                // attacker is spawned
-                // don't end attack
-                // but don't simulate it either
-                //_active = true;
+                if (!_active) then {
+                    _attacksToRemove pushback _attack;
+
+                    if (!isnil "_attacker") then {
+                        [_attacker,"combat", false] call ALiVE_fnc_hashSet;
+                        [_attacker,"attackID"] call ALiVE_fnc_hashRem;
+                    };
+                };
+
+                [_attack,"timeLastSim", diag_tickTime] call ALiVE_fnc_hashSet;
+
             };
         };
-    };
 
-    if (!_active) then {
-        _attacksToRemove pushback _attack;
 
-        if !(isnil "_attacker") then {
-            [_attacker,"combat", false] call ALiVE_fnc_hashSet;
-            [_attacker,"attackID", nil] call ALiVE_fnc_hashSet;
-        };
-    };
-},_profileAttacks select 2,10] call ALiVE_fnc_ArrayFrameSplitter;
-
-//[false, "ALiVE Profile Attack Simulation ending", format["profileClash_%1",_id]] call ALIVE_fnc_timer;
-
-{
-     _x params ["_commandingEntity","_subordinateVehicle"];
-
-    // remove crew from commanding entity
-
-    private _vehAssignments = [_commandingEntity,"vehicleAssignments"] call ALiVE_fnc_hashGet;
-    private _vehicleID = _subordinateVehicle select 2 select 4;
-
-    private _vehAssignment = [_vehAssignments,_vehicleID] call ALiVE_fnc_hashGet;
-    private _unitAssignments = + (_vehAssignment select 2);
-
-    reverse _unitAssignments; // must remove in reverse order
-
-    {
         {
-            [_commandingEntity,"removeUnit", _x] call ALiVE_fnc_profileEntity
-        } foreach _x;
-    } foreach _unitAssignments;
+             _x params ["_commandingEntity","_subordinateVehicle"];
 
-    // unassign vehicle from entity
+            // remove crew from commanding entity
 
-    _x call ALIVE_fnc_removeProfileVehicleAssignment;
-} foreach _toBeUnassigned;
+            private _vehAssignments = _commandingEntity select 2 select 7;
+            private _vehicleID = _subordinateVehicle select 2 select 4;
 
-//[true, "ALiVE Profile Battle Cleanup starting", format["profileClean_%1",_id]] call ALIVE_fnc_timer;
-{
-    _x params ["_killer","_victim"];
+            private _vehAssignment = [_vehAssignments,_vehicleID] call ALiVE_fnc_hashGet;
+            private _unitAssignments = + (_vehAssignment select 2);
 
-    private _victimType = _victim select 2 select 5;
+            reverse _unitAssignments; // must remove in reverse order
 
-    if (_victimType == "entity") then {
-        private _victimPos = _victim select 2 select 2;
-        private _victimFaction = _victim select 2 select 29;
-        private _victimSide = _victim select 2 select 3;
+            {
+                {
+                    [_commandingEntity,"removeUnit", _x] call ALiVE_fnc_profileEntity
+                } foreach _x;
+            } foreach _unitAssignments;
 
-        private _killerSide = _killer select 2 select 3;
+            // unassign vehicle from entity
 
-        // log event
+            _x call ALiVE_fnc_removeProfileVehicleAssignment;
+        } foreach _toBeUnassigned;
 
-        private _event = ['PROFILE_KILLED', [_victimPos,_victimFaction,_victimSide,_killerSide],"Profile"] call ALIVE_fnc_event;
-       [ALIVE_eventLog, "addEvent",_event] call ALIVE_fnc_eventLog;
+        {
+            _x params ["_killer","_victim"];
+
+            private _victimType = _victim select 2 select 5;
+
+            if (_victimType == "entity") then {
+                private _victimPos = _victim select 2 select 2;
+                private _victimFaction = _victim select 2 select 29;
+                private _victimSide = _victim select 2 select 3;
+
+                private _killerSide = _killer select 2 select 3;
+
+                // log event
+
+                private _event = ['PROFILE_KILLED', [_victimPos,_victimFaction,_victimSide,_killerSide],"Profile"] call ALiVE_fnc_event;
+               [MOD(eventLog),"addEvent",_event] call ALiVE_fnc_eventLog;
+            };
+
+            [MOD(profileHandler),"unregisterProfile", _victim] call ALiVE_fnc_profileHandler;
+        } foreach _toBekilled;
+
+        if !(_attacksToRemove isEqualTo []) then {
+            [MOD(profileCombatHandler),"removeAttacks", _attacksToRemove] call ALiVE_fnc_profileCombatHandler;
+        };
+
     };
 
-    [MOD(profileHandler), "unregisterProfile", _victim] call ALiVE_fnc_profileHandler;
-
-} foreach _toBekilled;
-//[false, "ALiVE Profile Combat Cleanup ending", format["profileClean_%1",_id]] call ALIVE_fnc_timer;
-
-// attacks must be removed killed profiles have been unregistered
-
-if !(_attacksToRemove isEqualTo []) then {
-    [MOD(profileCombatHandler),"removeAttacks", _attacksToRemove] call ALiVE_fnc_profileCombatHandler;
 };
-
-//["ALiVE Profile Simulation - Time taken per profile %1 (%2)",(time - _time) / _totalEntities, _totalEntities] call ALiVE_fnc_DumpR;
-//[false, "ALiVE Profile Simulation end!", format["profileSimTotal_%1",_id]] call ALIVE_fnc_timer;

--- a/addons/sys_profile/fnc_profileSimulator.sqf
+++ b/addons/sys_profile/fnc_profileSimulator.sqf
@@ -139,7 +139,7 @@ private _totalEntities = 0;
                     };
 
                 },_profiles select 2,2] call ALiVE_fnc_ArrayFrameSplitter;
-                
+
 
                 if !(_nearEnemies isEqualTo []) then {
 
@@ -151,15 +151,15 @@ private _totalEntities = 0;
                     [_profileAttack,"attackerSide", _side] call ALiVE_fnc_hashSet;
 
                     private _attackID = [MOD(profileCombatHandler),"addAttack", _profileAttack] call ALiVE_fnc_profileCombatHandler;
-                    
+
                     if !(isNil "_attackID") then {
-	
+
 	                    _combat = true;
 	                    [_entityProfile,"combat", _combat] call ALIVE_fnc_HashSet;
 	                    [_entityProfile,"attackID", _attackID] call ALIVE_fnc_HashSet;
-	
+
 	                    _collected = true;
-	
+
 	                    //["ALiVE Profile Simulation - Profile %1 begins attacking profiles %2!",_profileID,_nearEnemies] call ALIVE_fnc_dump;
 	                };
                 };
@@ -252,7 +252,7 @@ private _totalEntities = 0;
                                 [_entityProfile,"waypointsCompleted",_waypointsCompleted] call ALIVE_fnc_hashSet;
                             };
                         };
-                        
+
                         private ["_boatProfileID","_boatProfile"];
 
                         if(_vehicleCommander) then {
@@ -274,58 +274,58 @@ private _totalEntities = 0;
                                     [_vehicleProfile,"position",_newPosition] call ALIVE_fnc_profileVehicle;
                                     [_vehicleProfile,"direction",_direction] call ALIVE_fnc_profileVehicle;
                                     [_vehicleProfile,"mergePositions"] call ALIVE_fnc_profileVehicle;
-                                    
+
                                     // Remove any boat if not on water anymore
 	                                if (_boatsEnabled && {!isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}} && {!surfaceIsWater _currentPosition}) then {
 
 										_boatProfileID = ([_entityProfile,"boat"] call ALIVE_fnc_hashGet) select 0;
                                         _boatProfile = [ALiVE_ProfileHandler,"getProfile",_boatProfileID] call ALiVE_fnc_ProfileHandler;
-                                        
+
                                         if (isNil "_boatProfile") then {
                                             ["ALiVE Profile Simulator _boatProfile is nil _entityProfile is %1",_entityProfile] call ALiVE_fnc_DumpR;
-                                            
+
                                             [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
                                         } else {
 	                                    	_profileID = [_entityProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
 	                                        _boatID = [_boatProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
-	                                                                        	                                
+
 											if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatID,_profileID] call ALiVE_fnc_Dump};
-	                                                                                                                        
+
 	                                        if (count _waypoints > 1) then {_waypoints deleteAt 0};
-		
+
 		                                    [_entityProfile,_boatProfile] call ALIVE_fnc_removeProfileVehicleAssignment;
 		                                    [ALIVE_profileHandler, "unregisterProfile", _boatProfile] call ALIVE_fnc_profileHandler;
-		                                    
+
 		                                    [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
-                                        
+
                                         };
-	                                };                                    
+	                                };
                                 };
                             } forEach _vehiclesInCommandOf;
                         }else{
 
                             //["PROFILE SIM SIMMED ENTITY %1 NOT IN COMMAND SET ENTITY POS: %2",_entityProfile select 2 select 4,_newPosition] call ALIVE_fnc_dump;
-							
+
                             // Assign a boat to entities if on water
 							if (_boatsEnabled && {surfaceIsWater _currentPosition} && {surfaceIsWater _newPosition}) then {
                                 if (isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}) then {
 
 									if (_debug) then {["ALiVE Profile Simulator is adding a boat to entity profile %1",_profileID] call ALiVE_fnc_Dump};
-									
+
 									private _boatTypes = [(count _positions)-1, [_faction],"SHIP"] call ALiVE_fnc_findVehicleType;
                                     private _boatType = if (count _boatTypes > 0) then {selectRandom _boatTypes} else {"C_Boat_Transport_02_F"};
 
-									_boatProfile = [_boatType,_side,_faction,_newPosition,0,false,_faction,[]] call ALIVE_fnc_createProfileVehicle;                                                                      
+									_boatProfile = [_boatType,_side,_faction,_newPosition,0,false,_faction,[]] call ALIVE_fnc_createProfileVehicle;
                                     [_entityProfile,_boatProfile] call ALIVE_fnc_createProfileVehicleAssignment;
-                                    
+
 									private _shore = [_newPosition,_destination] call ALiVE_fnc_findNearestShore;
 
                                     if !(_shore isEqualTo [0,0,0]) then {
 	                                    _shoreWaypoint = [_shore, 10] call ALIVE_fnc_createProfileWaypoint;
-	                                    [_entityProfile,"insertWaypoint",_shoreWaypoint] call ALIVE_fnc_profileEntity;                                    
+	                                    [_entityProfile,"insertWaypoint",_shoreWaypoint] call ALIVE_fnc_profileEntity;
 									};
 
-									[_entityProfile,"boat",[[_boatProfile,"profileID"] call ALiVE_fnc_HashGet,_newPosition]] call ALIVE_fnc_hashSet;                                                                                                                                                                                                                                                                                                                                                                                                                                                
+									[_entityProfile,"boat",[[_boatProfile,"profileID"] call ALiVE_fnc_HashGet,_newPosition]] call ALIVE_fnc_hashSet;
                                 };
 
                             } else {
@@ -334,22 +334,22 @@ private _totalEntities = 0;
 
 									_boatProfileID = ([_entityProfile,"boat"] call ALIVE_fnc_hashGet) select 0;
                                     _boatProfile = [ALiVE_ProfileHandler,"getProfile",_boatProfileID] call ALiVE_fnc_ProfileHandler;
-                                    
+
                                     if (isNil "_boatProfile") then {
                                         ["ALiVE Profile Simulator _boatProfile is nil _entityProfile is %1",_entityProfile] call ALiVE_fnc_DumpR;
-                                        
+
                                         [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
                                     } else {
 	                                	_profileID = [_entityProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
 	                                    _boatID = [_boatProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
-	                                                                    	                                
+
 										if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatID,_profileID] call ALiVE_fnc_Dump};
-	                                                                        
+
 	                                    if (count _waypoints > 1) then {_waypoints deleteAt 0};
-	
+
 	                                    [_entityProfile,_boatProfile] call ALIVE_fnc_removeProfileVehicleAssignment;
 	                                    [ALIVE_profileHandler, "unregisterProfile", _boatProfile] call ALIVE_fnc_profileHandler;
-	                                    
+
 	                                    [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
                                     };
                                 };
@@ -413,34 +413,34 @@ private _totalEntities = 0;
 					            // Remove any boat if not on water anymore
 					            //if (_boatsEnabled && {_shallow} && {!isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}} && {!(([_newPosition,0,50,0,0,0.5,1,[],[[0,0,0]]] call BIS_fnc_findSafePos) isEqualto [0,0,0])}) then {...};
 								if (_boatsEnabled && {((_newPosition) select 2) < 4} && {_nearDestination} && {!isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}}) then {
-									
+
                                     _boatProfileID = ([_entityProfile,"boat"] call ALIVE_fnc_hashGet) select 0;
                                     _creation = ([_entityProfile,"boat"] call ALIVE_fnc_hashGet) select 1;
                                     _boatProfile = [ALiVE_ProfileHandler,"getProfile",_boatProfileID] call ALiVE_fnc_ProfileHandler;
-                                    
+
                                     if (isNil "_boatProfile") then {
                                         ["ALiVE Profile Simulator _boatProfile is nil _entityProfile is %1",_entityProfile] call ALiVE_fnc_DumpR;
-                                        
+
                                         [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
-                                    } else {        
+                                    } else {
 	                                    if (_newPosition distance _creation > 100) then {
-	
+
 		                                	_profileID = [_entityProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
-		                                                                    	                                
+
 											if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2 (LIVE)",_boatProfileID,_profileID] call ALiVE_fnc_Dump};
-	
+
 	                                        // deletevehicle
 	                                        [ALiVE_SYS_GC,"trashIt",vehicle _leader] call ALiVE_fnc_GC;
-	                                        
+
 							                [_entityProfile,_boatProfile] call ALIVE_fnc_removeProfileVehicleAssignment;
 							                [ALIVE_profileHandler, "unregisterProfile", _boatProfile] call ALIVE_fnc_profileHandler;
-		                                    
+
 		                                    if (count _waypoints > 1) then {
 		                                        _waypoints deleteAt 0;
-		                                        
+
 		                                        [_waypoints, _group] call ALIVE_fnc_profileWaypointsToWaypoints;
 		                                    };
-							                
+
 							                [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
 	                                    };
                                     };
@@ -450,32 +450,32 @@ private _totalEntities = 0;
                                 //_leader = _entityProfile select 2 select 10; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
                                 _newPosition = getPosATL _leader;
                                 _newPositionASL = ATLtoASL _newPosition;
-                                
+
                                 private _deepEnough = (_newPositionASL select 2) < 1 && {_newPosition select 2 > 4};
 
 	                            // Assign a boat to entities if on water
 								if (_boatsEnabled && {surfaceIsWater _position} && {surfaceIsWater _newPosition} && {_deepEnough} && {[_position,_destination] call ALiVE_fnc_crossesSea}) then {
 	                                if (isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}) then {
-        	
+
 										if (_debug) then {["ALiVE Profile Simulator is adding a boat to entity profile (LIVE) %1",_profileID] call ALiVE_fnc_Dump};
-										
+
 										private _boatTypes = [(count _positions)-1, [_faction],"SHIP"] call ALiVE_fnc_findVehicleType;
 	                                    private _boatType = if (count _boatTypes > 0) then {selectRandom _boatTypes} else {"C_Boat_Transport_02_F"};
-	
-										_boatProfile = [_boatType,_side,_faction,_newPosition,0,false,_faction,[]] call ALIVE_fnc_createProfileVehicle;                                                                      
+
+										_boatProfile = [_boatType,_side,_faction,_newPosition,0,false,_faction,[]] call ALIVE_fnc_createProfileVehicle;
                                         [_entityProfile,_boatProfile] call ALIVE_fnc_createProfileVehicleAssignment;
-                                        
+
                                         _vehicleAssignments = [_entityProfile,"vehicleAssignments"] call ALiVE_fnc_hashGet;
                                         [_vehicleAssignments, _entityProfile, true] call ALIVE_fnc_profileVehicleAssignmentsToVehicleAssignments;
-	                                    
+
 										private _shore = [_newPosition,_destination] call ALiVE_fnc_findNearestShore;
 
 	                                    if !(_shore isEqualTo [0,0,0]) then {
 		                                    _shoreWaypoint = [_shore, 10] call ALIVE_fnc_createProfileWaypoint;
 		                                    [_entityProfile,"insertWaypoint",_shoreWaypoint] call ALIVE_fnc_profileEntity;
 										};
-	
-										[_entityProfile,"boat",[[_boatProfile,"profileID"] call ALiVE_fnc_HashGet,_newPosition]] call ALIVE_fnc_hashSet;                                                                                                                                                                                                                                                                                                                                                                                                                                                
+
+										[_entityProfile,"boat",[[_boatProfile,"profileID"] call ALiVE_fnc_HashGet,_newPosition]] call ALIVE_fnc_hashSet;
 	                                };
 	                            };
 
@@ -501,11 +501,11 @@ private _totalEntities = 0;
 
                     // but the profile has waypoints set, but not by ALiVE
                     // eg Zeus
-                    
+
                     //_group = group _leader;
                     private _group = _entityProfile select 2 select 13; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
                     private _leader = _entityProfile select 2 select 10; //_leader = [_profile,"leader"] call ALIVE_fnc_hashGet;
-                    
+
                     if((!isNull _group) && {currentWaypoint _group < count waypoints _group && currentWaypoint _group > 0}) then {
                         //["S1: %1 %2", currentWaypoint _group, count waypoints _group] call ALIVE_fnc_dump;
 
@@ -558,27 +558,27 @@ private _totalEntities = 0;
                             ["Profile-Simulator corrupted profile detected %1: _newPosition %2 _position %3",_profileID,_newPosition,_position] call ALIVE_fnc_dump;
                         };
                     };
-                    
+
                     ///*
                     // Remove any ambient sea transport if no waypoint is assigned (should not happen - failsafe)
 	                if (_boatsEnabled && {_vehicleCommander} && {!isnil {[_entityProfile,"boat"] call ALIVE_fnc_hashGet}}) then {
-	
+
 						_boatProfileID = ([_entityProfile,"boat"] call ALIVE_fnc_hashGet) select 0;
                         _boatProfile = [ALiVE_ProfileHandler,"getProfile",_boatProfileID] call ALiVE_fnc_ProfileHandler;
-                        
+
                         if (isNil "_boatProfile") then {
                         	["ALiVE Profile Simulator _boatProfile is nil _entityProfile is %1",_entityProfile] call ALiVE_fnc_DumpR;
-                            
+
                             [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
                         } else {
 		                	_profileID = [_entityProfile,"profileID","no-ID"] call ALIVE_fnc_hashGet;
-		                                                    	                                
+
 							if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatProfileID,_profileID] call ALiVE_fnc_Dump};
-	
+
 		                    [_entityProfile,_boatProfile] call ALIVE_fnc_removeProfileVehicleAssignment;
-	                        
+
 		                    [ALIVE_profileHandler, "unregisterProfile", _boatProfile] call ALIVE_fnc_profileHandler;
-		                    
+
 		                    [_entityProfile,"boat"] call ALIVE_fnc_hashRem;
                         };
 	                };
@@ -647,7 +647,7 @@ private _totalEntities = 0;
 //[true, "ALiVE Profile Battle Simulation starting", format["profileClash_%1",_id]] call ALIVE_fnc_timer;
 
 // Simulate attacks
-	
+
 private _combatRate = [MOD(profileCombatHandler),"combatRate"] call ALiVE_fnc_hashGet;
 private _profileAttacks = [MOD(profileCombatHandler),"attacksByID"] call ALiVE_fnc_hashGet;
 private _attacksToRemove = [];
@@ -767,7 +767,7 @@ private _damageModifier = _cycleTime * _combatRate;
                                         private _totalHitpoints = _vehicleClass call ALiVE_fnc_configGetVehicleHitPoints;
                                         if (_totalHitpoints isEqualTo []) then {
                                             private _hp = [(configfile >> "CfgVehicles" >> _vehicleClass >> "HitPoints"),0] call BIS_fnc_returnChildren;
-                                            {_totalHitpoints pushBack (configName _x)} forEach _hp; 
+                                            {_totalHitpoints pushBack (configName _x)} forEach _hp;
                                         };
                                         {_profileToAttackHealth pushback [_x,0]} foreach _totalHitpoints;
                                     };

--- a/addons/sys_profile/fnc_profileSimulator.sqf
+++ b/addons/sys_profile/fnc_profileSimulator.sqf
@@ -37,11 +37,18 @@ Highhead
 SpyderBlack723
 ---------------------------------------------------------------------------- */
 
+if (ALiVE_gamePaused) exitwith {
+    private _profiles = [MOD(profileHandler),"profiles"] call ALiVE_fnc_hashGet;
+    {[_x,"timeLastSim", diag_tickTime] call ALiVE_fnc_hashSet} foreach (_profiles select 2);
+};
+
 // parse CBA perFrameHandler arguments
 //_this = _this select 0;
 
 
 private _debug = [MOD(profileSystem),"debug"] call ALiVE_fnc_hashGet;
+private _profileSystemPaused = [MOD(profileSystem),"paused"] call ALiVE_fnc_hashGet;
+
 private _combatRange = [MOD(profileCombatHandler),"combatRange"] call ALiVE_fnc_hashGet;
 private _profilesToSim = [MOD(profileSystem),"profilesToSim"] call ALiVE_fnc_hashGet;
 private _simAttacks = [MOD(profileSystem),"simulatingAttacks"] call ALiVE_fnc_hashGet;
@@ -76,350 +83,210 @@ if (!_simAttacks) then {
         };
 
         if (!isnil "_profile") then {
-            // begin sim
 
-            private _locked = [_profile,"locked", false] call ALiVE_fnc_HashGet;
-            private _combat = [_profile,"combat", false] call ALiVE_fnc_HashGet;
+            if (!_profileSystemPaused && !ALiVE_gamePaused) then {
+                // begin sim
 
-            // only sim if profile is not locked or in combat
-            // locked entities could be spawning/despawning or other
+                private _locked = [_profile,"locked", false] call ALiVE_fnc_HashGet;
+                private _combat = [_profile,"combat", false] call ALiVE_fnc_HashGet;
 
-            if (!_locked && !_combat) then {
+                // only sim if profile is not locked or in combat
+                // locked entities could be spawning/despawning or other
 
-                private _timeLastSim = [_profile,"timeLastSim", diag_tickTime - 0.001] call ALiVE_fnc_hashGet;
-                private _simModifier = diag_tickTime - _timeLastSim;
+                if (!_locked && !_combat) then {
 
-                // gather info on this profile
+                    private _timeLastSim = [_profile,"timeLastSim", diag_tickTime - 0.001] call ALiVE_fnc_hashGet;
+                    private _simModifier = diag_tickTime - _timeLastSim;
 
-                private _profilePosition = _profile select 2 select 2;
-                private _isPlayer = _profile select 2 select 30;
+                    // gather info on this profile
 
-                // determine if entity occupies a vehicle
-                private _vehiclesInCommandOf = _profile select 2 select 8;
-                private _vehiclesInCargoOf = _profile select 2 select 9;
+                    private _profilePosition = _profile select 2 select 2;
+                    private _isPlayer = _profile select 2 select 30;
 
-                private _vehicleCommander = false;
-                private _isAir = false;
+                    // determine if entity occupies a vehicle
+                    private _vehiclesInCommandOf = _profile select 2 select 8;
+                    private _vehiclesInCargoOf = _profile select 2 select 9;
 
-                if !(_vehiclesInCommandOf isEqualTo []) then {
-                    _vehicleCommander = true;
+                    private _vehicleCommander = false;
+                    private _isAir = false;
 
-                    // determine if vehicles is a moving air unit
-                    {
-                        private _vehicle = [MOD(ProfileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
+                    if !(_vehiclesInCommandOf isEqualTo []) then {
+                        _vehicleCommander = true;
 
-                        // if engineOn and vehicleClass is air vehicle
-                        if (!isnil "_vehicle" && {(_vehicle select 2 select 15)} && {(_vehicle select 2 select 11) isKindOf "Air"}) then {
-                            _isAir = true;
-                        };
-                    } foreach _vehiclesInCommandOf;
-                };
+                        // determine if vehicles is a moving air unit
+                        {
+                            private _vehicle = [MOD(ProfileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
 
-                // determine if entity is cargo of vehicle
+                            // if engineOn and vehicleClass is air vehicle
+                            if (!isnil "_vehicle" && {(_vehicle select 2 select 15)} && {(_vehicle select 2 select 11) isKindOf "Air"}) then {
+                                _isAir = true;
+                            };
+                        } foreach _vehiclesInCommandOf;
+                    };
 
-                private _vehicleCargo = false;
-                if !(_vehiclesInCargoOf isEqualTo []) then {
-                    _vehicleCargo = true;
-                };
+                    // determine if entity is cargo of vehicle
+
+                    private _vehicleCargo = false;
+                    if !(_vehiclesInCargoOf isEqualTo []) then {
+                        _vehicleCargo = true;
+                    };
 
 
-                // check for combat opportunities
-                if (!_vehicleCargo && !_isPlayer && !_isAir && !_combat) then {
-                    // get enemy sides
-                    private _side = _profile select 2 select 3;
-                    private _sideObj = [_side] call ALiVE_fnc_sideTextToObject;
-                    private _sidesEnemy = [];
-                    if (_sideObj getfriend east < 0.6) then {_sidesEnemy pushback "EAST"};
-                    if (_sideObj getfriend west < 0.6) then {_sidesEnemy pushback "WEST"};
-                    if (_sideObj getfriend resistance < 0.6) then {_sidesEnemy pushback "GUER"};
+                    // check for combat opportunities
+                    if (!_vehicleCargo && !_isPlayer && !_isAir && !_combat) then {
+                        // get enemy sides
+                        private _side = _profile select 2 select 3;
+                        private _sideObj = [_side] call ALiVE_fnc_sideTextToObject;
+                        private _sidesEnemy = [];
+                        if (_sideObj getfriend east < 0.6) then {_sidesEnemy pushback "EAST"};
+                        if (_sideObj getfriend west < 0.6) then {_sidesEnemy pushback "WEST"};
+                        if (_sideObj getfriend resistance < 0.6) then {_sidesEnemy pushback "GUER"};
 
-                    // find and attack enemy profiles in-range
-                    // only attack non-player, inactive entities
+                        // find and attack enemy profiles in-range
+                        // only attack non-player, inactive entities
 
-                    private _nearEnemies = [_profilePosition, _combatRange, [_sidesEnemy,"entity", "none", {!(_x select 2 select 1) && !(_x select 2 select 30)}], true] call ALiVE_fnc_getNearProfiles;
-                    _nearEnemies = _nearEnemies apply {_x select 2 select 4};
+                        private _nearEnemies = [_profilePosition, _combatRange, [_sidesEnemy,"entity", "none", {!(_x select 2 select 1) && !(_x select 2 select 30)}], true] call ALiVE_fnc_getNearProfiles;
+                        _nearEnemies = _nearEnemies apply {_x select 2 select 4};
 
-                    if !(_nearEnemies isEqualTo []) then {
+                        if !(_nearEnemies isEqualTo []) then {
 
-                        private _profileID = _profile select 2 select 4;
+                            private _profileID = _profile select 2 select 4;
 
-                        private _profileAttack = [nil,"create", [_profilePosition,_profileID,_nearEnemies,_side]] call ALiVE_fnc_profileAttack;
-                        private _attackID = [MOD(profileCombatHandler),"addAttack", _profileAttack] call ALiVE_fnc_profileCombatHandler;
+                            private _profileAttack = [nil,"create", [_profilePosition,_profileID,_nearEnemies,_side]] call ALiVE_fnc_profileAttack;
+                            private _attackID = [MOD(profileCombatHandler),"addAttack", _profileAttack] call ALiVE_fnc_profileCombatHandler;
 
-                        if (!isnil "_attackID") then {
-                            //["%1 begins attacking %2", _profileID, _nearEnemies] call ALiVE_fnc_Dump;
-                            _combat = true;
-                            [_profile,"combat", true] call ALiVE_fnc_HashSet;
-                            [_profile,"attackID", _attackID] call ALiVE_fnc_HashSet;
+                            if (!isnil "_attackID") then {
+                                //["%1 begins attacking %2", _profileID, _nearEnemies] call ALiVE_fnc_Dump;
+                                _combat = true;
+                                [_profile,"combat", true] call ALiVE_fnc_HashSet;
+                                [_profile,"attackID", _attackID] call ALiVE_fnc_HashSet;
+                            };
                         };
                     };
-                };
 
 
-                private _waypoints = _profile select 2 select 16;
+                    private _waypoints = _profile select 2 select 16;
 
-                if (!_isPlayer && !_vehicleCargo && !_combat) then {
-                    if (!(_waypoints isEqualTo [])) then {
-                        // profile has waypoints
+                    if (!_isPlayer && !_vehicleCargo && !_combat) then {
+                        if (!(_waypoints isEqualTo [])) then {
+                            // profile has waypoints
 
-                        private _active = _profile select 2 select 1;
-                        if (!_active) then {
+                            private _active = _profile select 2 select 1;
+                            if (!_active) then {
 
-                            // profile is not spawned, simulate movement
+                                // profile is not spawned, simulate movement
 
-                            private _activeWaypoint = _waypoints select 0;
-                            private _destination = [_activeWaypoint,"position"] call ALiVE_fnc_hashGet;
-                            private _distanceToWaypoint = _profilePosition distance _destination;
-
-                            private _speedPerSecondArray = _profile select 2 select 22;
-                            private _speedPerSecond = _speedPerSecondArray select 1;
-
-                            switch ([_activeWaypoint,"speed"] call ALiVE_fnc_hashGet) do {
-                                case "LIMITED": {_speedPerSecond = _speedPerSecondArray select 0};
-                                case "NORMAL":  {_speedPerSecond = _speedPerSecondArray select 1};
-                                case "FULL":    {_speedPerSecond = _speedPerSecondArray select 2};
-                            };
-
-                            private _moveDistance = _speedPerSecond * _simModifier * _speedModifier * accTime;
-                            private _direction = 0;
-
-                            if (!isnil "_profilePosition" && {!(_profilePosition isEqualTo [])} && {!isnil "_destination"}) then {
-
-                                // add z-index since some profiles dont one defined
-                                _profilePosition set [2,0];
-                                _destination set [2,0];
-
-                                private _executeStatements = false;
-
-                                private _newPosition = _profilePosition;
-                                private _handleWPcomplete = {};
-
-                                switch ([_activeWaypoint,"type"] call ALiVE_fnc_hashGet) do {
-                                    case "MOVE" : {
-                                        _direction = _profilePosition getDir _destination;
-                                        _newPosition = _profilePosition getPos [_moveDistance, _direction];
-                                        _handleWPcomplete = {};
-                                    };
-                                    case "CYCLE" : {
-                                        _direction = _profilePosition getDir _destination;
-                                        _newPosition = _profilePosition getPos [_moveDistance, _direction];
-                                        _handleWPcomplete = {
-                                            _waypoints append _waypointsCompleted;
-                                            _waypointsCompleted = [];
-                                        };
-                                    };
-                                };
-
-                                // if distance to wp destination is within completion radius
-                                // mark waypoint as complete
-                                if (_distanceToWaypoint <= (_moveDistance * 2)) then {
-                                    private _isCycling = _profile select 2 select 25;
-                                    private _waypointsCompleted = _profile select 2 select 17;
-
-                                    if (_isCycling) then {
-                                        _waypointsCompleted pushback _activeWaypoint;
-                                    };
-
-                                    _waypoints deleteat 0;
-
-                                    call _handleWPcomplete;
-                                    _executeStatements = true;
-                                };
-
-                                if (_vehicleCommander) then {
-                                    // move vehicles that profile is in
-                                    [_profile,"hasSimulated", true] call ALiVE_fnc_hashSet;
-
-                                    {
-                                        private _vehicleProfile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
-
-                                        if (!isnil "_vehicleProfile") then {
-                                            // turn engineOn virtually
-                                            // move all entities within the vehicle
-                                            // set the vehicle position and merge all assigned entities positions
-
-                                            //["PROFILE SIM SIMMED ENTITY %1 IN COMMAND OF %2 SET VEHICLE POS: %3",_profile select 2 select 4,_vehicleProfile select 2 select 4,_newPosition] call ALiVE_fnc_dump;
-
-                                            [_vehicleProfile,"hasSimulated", true] call ALiVE_fnc_hashSet;
-                                            [_vehicleProfile,"engineOn", true] call ALiVE_fnc_profileVehicle;
-                                            [_vehicleProfile,"position", _newPosition] call ALiVE_fnc_profileVehicle;
-                                            [_vehicleProfile,"direction", _direction] call ALiVE_fnc_profileVehicle;
-                                            [_vehicleProfile,"mergePositions"] call ALiVE_fnc_profileVehicle;
-
-                                            // if profile is in boat, and is no longer on water
-                                            // remove boat
-
-                                            private _boat = [_profile,"boat"] call ALiVE_fnc_hashGet;
-                                            if (_boatsEnabled && {!isnil "_boat"} && {!surfaceIsWater _profilePosition}) then {
-                                                private _boatProfileID = _boat select 0;
-                                                private _boatProfile = [MOD(profileHandler),"getProfile", _boatProfileID] call ALiVE_fnc_ProfileHandler;
-
-                                                if (isnil "_boatProfile") then {
-                                                    if (_debug) then {["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR};
-                                                } else {
-                                                    private _profileID = [_profile,"profileID", "no-ID"] call ALiVE_fnc_hashGet;
-                                                    private _boatID = [_boatProfile,"profileID", "no-ID"] call ALiVE_fnc_hashGet;
-
-                                                    if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2", _boatID, _profileID] call ALiVE_fnc_Dump};
-
-                                                    if (count _waypoints > 1) then {_waypoints deleteAt 0};
-
-                                                    [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
-                                                    [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
-                                                };
-
-                                                [_profile,"boat"] call ALiVE_fnc_hashRem;
-                                            };
-                                        };
-                                    } forEach _vehiclesInCommandOf;
-                                } else {
-                                    // assign a boat to entities if on water
-
-                                    if (_boatsEnabled && {surfaceIsWater _profilePosition} && {surfaceIsWater _newPosition}) then {
-                                        if (isnil {[_profile,"boat"] call ALiVE_fnc_hashGet}) then {
-                                            if (_debug) then {["ALiVE Profile Simulator is adding a boat to entity profile %1",_profileID] call ALiVE_fnc_Dump};
-
-                                            private _unitPositions = _profile select 2 select 18;
-                                            private _faction = [_profile, "faction"] call ALiVE_fnc_hashGet;
-                                            private _side = _profile select 2 select 3;
-
-                                            private _boatTypes = [(count _unitPositions) - 1, [_faction],"SHIP"] call ALiVE_fnc_findVehicleType;
-                                            private _boatType = if (count _boatTypes > 0) then {selectRandom _boatTypes} else {"C_Boat_Transport_02_F"};
-
-                                            private _boatProfile = [_boatType,_side,_faction,_newPosition,0,false,_faction,[]] call ALiVE_fnc_createProfileVehicle;
-                                            [_profile,_boatProfile] call ALiVE_fnc_createProfileVehicleAssignment;
-
-                                            // create waypoint to nearest shore point
-                                            private _shore = [_newPosition,_destination] call ALiVE_fnc_findNearestShore;
-                                            if !(_shore isEqualTo [0,0,0]) then {
-                                                private _shoreWaypoint = [_shore, 10] call ALiVE_fnc_createProfileWaypoint;
-                                                [_profile,"insertWaypoint", _shoreWaypoint] call ALiVE_fnc_profileEntity;
-                                            };
-
-                                            [_profile, "boat", [[_boatProfile,"profileID"] call ALiVE_fnc_HashGet, _newPosition]] call ALiVE_fnc_hashSet;
-                                        };
-                                    } else {
-                                        // Remove boat if not on water anymore
-                                        // failsafe, will be handled by _vehicleCommander case above
-
-                                        private _boat = [_profile,"boat"] call ALiVE_fnc_hashGet;
-                                        if (_boatsEnabled && {!isnil "_boat"}) then {
-                                            private _boatProfileID = _boat select 0;
-                                            private _boatProfile = [MOD(profileHandler),"getProfile", _boatProfileID] call ALiVE_fnc_ProfileHandler;
-
-                                            if (isnil "_boatProfile") then {
-                                                if (_debug) then {["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR};
-                                            } else {
-                                                private _profileID = [_profile,"profileID","no-ID"] call ALiVE_fnc_hashGet;
-                                                private _boatID = [_boatProfile,"profileID","no-ID"] call ALiVE_fnc_hashGet;
-
-                                                if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatID,_profileID] call ALiVE_fnc_Dump};
-
-                                                if (count _waypoints > 1) then {_waypoints deleteAt 0};
-
-                                                [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
-                                                [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
-                                            };
-
-                                            [_profile,"boat"] call ALiVE_fnc_hashRem;
-                                        };
-                                    };
-
-                                    // set the profile position and merge all unit positions to group position
-                                    [_profile,"hasSimulated", true] call ALiVE_fnc_hashSet;
-                                    [_profile,"position", _newPosition] call ALiVE_fnc_profileEntity;
-                                    [_profile,"mergePositions"] call ALiVE_fnc_profileEntity;
-                                };
-
-                                // Execute statements at the end, needs review of any variables in hashes
-                                if (_executeStatements) then {
-                                    private _statements = [_activeWaypoint,"statements"] call ALiVE_fnc_hashGet;
-
-                                    if ((_statements isEqualType []) && {call compile (_statements select 0)}) then {
-                                        call compile (_statements select 1);
-                                    };
-                                };
-                            } else {
-                                if (_debug) then {["ALiVE Profile-Simulator profile movement stopped for profile %1: currentPosition: %2 destination: %3", [_profile,"profileID","no-ID"] call ALiVE_fnc_hashGet, _profilePosition, _destination] call ALiVE_fnc_dump};
-                            };
-
-                        } else {
-
-                            // profile is spawned, update positions
-
-                            private _group = _profile select 2 select 13;
-                            private _leader = leader _group;
-                            private _newPosition = getPosATL _leader;
-
-                            if (!isnil "_newPosition" && {!(_newPosition isEqualTo [])} && {!isnil "_profilePosition"} && {!(_profilePosition isEqualTo [])}) then {
                                 private _activeWaypoint = _waypoints select 0;
-                                private _type = [_activeWaypoint,"type"] call ALiVE_fnc_hashGet;
-                                private _speed = [_activeWaypoint,"speed"] call ALiVE_fnc_hashGet;
                                 private _destination = [_activeWaypoint,"position"] call ALiVE_fnc_hashGet;
+                                private _distanceToWaypoint = _profilePosition distance _destination;
 
-                                private _moveDistance = _newPosition distance _profilePosition;
-                                private _nearDestination = _newPosition distance _destination < 100;
+                                private _speedPerSecondArray = _profile select 2 select 22;
+                                private _speedPerSecond = _speedPerSecondArray select 1;
 
-                                // handle waypoint completion
+                                switch ([_activeWaypoint,"speed"] call ALiVE_fnc_hashGet) do {
+                                    case "LIMITED": {_speedPerSecond = _speedPerSecondArray select 0};
+                                    case "NORMAL":  {_speedPerSecond = _speedPerSecondArray select 1};
+                                    case "FULL":    {_speedPerSecond = _speedPerSecondArray select 2};
+                                };
 
-                                if (_moveDistance > 10 || {_nearDestination}) then {
+                                private _moveDistance = _speedPerSecond * _simModifier * _speedModifier * accTime;
+                                private _direction = 0;
+
+                                if (!isnil "_profilePosition" && {!(_profilePosition isEqualTo [])} && {!isnil "_destination"}) then {
+
+                                    // add z-index since some profiles dont one defined
+                                    _profilePosition set [2,0];
+                                    _destination set [2,0];
+
+                                    private _executeStatements = false;
+
+                                    private _newPosition = _profilePosition;
+                                    private _handleWPcomplete = {};
+
+                                    switch ([_activeWaypoint,"type"] call ALiVE_fnc_hashGet) do {
+                                        case "MOVE" : {
+                                            _direction = _profilePosition getDir _destination;
+                                            _newPosition = _profilePosition getPos [_moveDistance, _direction];
+                                            _handleWPcomplete = {};
+                                        };
+                                        case "CYCLE" : {
+                                            _direction = _profilePosition getDir _destination;
+                                            _newPosition = _profilePosition getPos [_moveDistance, _direction];
+                                            _handleWPcomplete = {
+                                                _waypoints append _waypointsCompleted;
+                                                _waypointsCompleted = [];
+                                            };
+                                        };
+                                    };
+
+                                    // if distance to wp destination is within completion radius
+                                    // mark waypoint as complete
+                                    if (_distanceToWaypoint <= (_moveDistance * 2)) then {
+                                        private _isCycling = _profile select 2 select 25;
+                                        private _waypointsCompleted = _profile select 2 select 17;
+
+                                        if (_isCycling) then {
+                                            _waypointsCompleted pushback _activeWaypoint;
+                                        };
+
+                                        _waypoints deleteat 0;
+
+                                        call _handleWPcomplete;
+                                        _executeStatements = true;
+                                    };
+
                                     if (_vehicleCommander) then {
-
-                                        // move all entities within the vehicle
-                                        // set the vehicle position and merge all assigned entities positions
-
-                                        _newPosition = getPosATL vehicle _leader;
+                                        // move vehicles that profile is in
+                                        [_profile,"hasSimulated", true] call ALiVE_fnc_hashSet;
 
                                         {
                                             private _vehicleProfile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
 
                                             if (!isnil "_vehicleProfile") then {
+                                                // turn engineOn virtually
+                                                // move all entities within the vehicle
+                                                // set the vehicle position and merge all assigned entities positions
+
+                                                //["PROFILE SIM SIMMED ENTITY %1 IN COMMAND OF %2 SET VEHICLE POS: %3",_profile select 2 select 4,_vehicleProfile select 2 select 4,_newPosition] call ALiVE_fnc_dump;
+
+                                                [_vehicleProfile,"hasSimulated", true] call ALiVE_fnc_hashSet;
+                                                [_vehicleProfile,"engineOn", true] call ALiVE_fnc_profileVehicle;
                                                 [_vehicleProfile,"position", _newPosition] call ALiVE_fnc_profileVehicle;
+                                                [_vehicleProfile,"direction", _direction] call ALiVE_fnc_profileVehicle;
                                                 [_vehicleProfile,"mergePositions"] call ALiVE_fnc_profileVehicle;
-                                            };
-                                        } forEach _vehiclesInCommandOf;
 
-                                        // remove any boat if not on water anymore
-                                        // if (_boatsEnabled && {_shallow} && {!isnil {[_profile,"boat"] call ALiVE_fnc_hashGet}} && {!(([_newPosition,0,50,0,0,0.5,1,[],[[0,0,0]]] call BIS_fnc_findSafePos) isEqualto [0,0,0])}) then {...};
+                                                // if profile is in boat, and is no longer on water
+                                                // remove boat
 
-                                        private _boat = [_profile,"boat"] call ALiVE_fnc_hashGet;
-                                        if (_boatsEnabled && {((_newPosition) select 2) < 4} && {_nearDestination} && {!isnil "_boat"}) then {
-                                            private _boatProfileID = _boat select 0;
-                                            private _creation = ([_profile,"boat"] call ALiVE_fnc_hashGet) select 1;
-                                            private _boatProfile = [MOD(profileHandler),"getProfile", _boatProfileID] call ALiVE_fnc_ProfileHandler;
+                                                private _boat = [_profile,"boat"] call ALiVE_fnc_hashGet;
+                                                if (_boatsEnabled && {!isnil "_boat"} && {!surfaceIsWater _profilePosition}) then {
+                                                    private _boatProfileID = _boat select 0;
+                                                    private _boatProfile = [MOD(profileHandler),"getProfile", _boatProfileID] call ALiVE_fnc_ProfileHandler;
 
-                                            if (isnil "_boatProfile") then {
-                                                if (_debug) then {["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR};
-                                            } else {
-                                                if (_newPosition distance _creation > 100) then {
-                                                    private _profileID = [_profile,"profileID", "no-ID"] call ALiVE_fnc_hashGet;
+                                                    if (isnil "_boatProfile") then {
+                                                        if (_debug) then {["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR};
+                                                    } else {
+                                                        private _profileID = [_profile,"profileID", "no-ID"] call ALiVE_fnc_hashGet;
+                                                        private _boatID = [_boatProfile,"profileID", "no-ID"] call ALiVE_fnc_hashGet;
 
-                                                    if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2 (LIVE)",_boatProfileID,_profileID] call ALiVE_fnc_Dump};
+                                                        if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2", _boatID, _profileID] call ALiVE_fnc_Dump};
 
-                                                    [MOD(SYS_GC),"trashIt", vehicle _leader] call ALiVE_fnc_GC;
+                                                        if (count _waypoints > 1) then {_waypoints deleteAt 0};
 
-                                                    [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
-                                                    [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
-
-                                                    if (count _waypoints > 1) then {
-                                                        _waypoints deleteAt 0;
-                                                        [_waypoints, _group] call ALiVE_fnc_profileWaypointsToWaypoints;
+                                                        [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
+                                                        [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
                                                     };
+
+                                                    [_profile,"boat"] call ALiVE_fnc_hashRem;
                                                 };
                                             };
-
-                                            [_profile,"boat"] call ALiVE_fnc_hashRem;
-                                        };
-
+                                        } forEach _vehiclesInCommandOf;
                                     } else {
+                                        // assign a boat to entities if on water
 
-                                        private _deepEnough = ((ATLtoASL _newPosition) select 2) < 1 && {(_newPosition select 2) > 4};
-
-                                        // Assign a boat to entities if on water
-                                        if (_boatsEnabled && {surfaceIsWater _profilePosition} && {surfaceIsWater _newPosition} && {_deepEnough} && {[_position,_destination] call ALiVE_fnc_crossesSea}) then {
+                                        if (_boatsEnabled && {surfaceIsWater _profilePosition} && {surfaceIsWater _newPosition}) then {
                                             if (isnil {[_profile,"boat"] call ALiVE_fnc_hashGet}) then {
-
-                                                if (_debug) then {["ALiVE Profile Simulator is adding a boat to entity profile (LIVE) %1",_profileID] call ALiVE_fnc_Dump};
+                                                if (_debug) then {["ALiVE Profile Simulator is adding a boat to entity profile %1",_profileID] call ALiVE_fnc_Dump};
 
                                                 private _unitPositions = _profile select 2 select 18;
                                                 private _faction = [_profile, "faction"] call ALiVE_fnc_hashGet;
@@ -431,9 +298,6 @@ if (!_simAttacks) then {
                                                 private _boatProfile = [_boatType,_side,_faction,_newPosition,0,false,_faction,[]] call ALiVE_fnc_createProfileVehicle;
                                                 [_profile,_boatProfile] call ALiVE_fnc_createProfileVehicleAssignment;
 
-                                                private _vehicleAssignments = [_profile,"vehicleAssignments"] call ALiVE_fnc_hashGet;
-                                                [_vehicleAssignments,_profile, true] call ALiVE_fnc_profileVehicleAssignmentsToVehicleAssignments;
-
                                                 // create waypoint to nearest shore point
                                                 private _shore = [_newPosition,_destination] call ALiVE_fnc_findNearestShore;
                                                 if !(_shore isEqualTo [0,0,0]) then {
@@ -441,128 +305,274 @@ if (!_simAttacks) then {
                                                     [_profile,"insertWaypoint", _shoreWaypoint] call ALiVE_fnc_profileEntity;
                                                 };
 
-                                                [_profile,"boat", [[_boatProfile,"profileID"] call ALiVE_fnc_HashGet, _newPosition]] call ALiVE_fnc_hashSet;
+                                                [_profile, "boat", [[_boatProfile,"profileID"] call ALiVE_fnc_HashGet, _newPosition]] call ALiVE_fnc_hashSet;
+                                            };
+                                        } else {
+                                            // Remove boat if not on water anymore
+                                            // failsafe, will be handled by _vehicleCommander case above
+
+                                            private _boat = [_profile,"boat"] call ALiVE_fnc_hashGet;
+                                            if (_boatsEnabled && {!isnil "_boat"}) then {
+                                                private _boatProfileID = _boat select 0;
+                                                private _boatProfile = [MOD(profileHandler),"getProfile", _boatProfileID] call ALiVE_fnc_ProfileHandler;
+
+                                                if (isnil "_boatProfile") then {
+                                                    if (_debug) then {["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR};
+                                                } else {
+                                                    private _profileID = [_profile,"profileID","no-ID"] call ALiVE_fnc_hashGet;
+                                                    private _boatID = [_boatProfile,"profileID","no-ID"] call ALiVE_fnc_hashGet;
+
+                                                    if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatID,_profileID] call ALiVE_fnc_Dump};
+
+                                                    if (count _waypoints > 1) then {_waypoints deleteAt 0};
+
+                                                    [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
+                                                    [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
+                                                };
+
+                                                [_profile,"boat"] call ALiVE_fnc_hashRem;
                                             };
                                         };
 
-                                        // set the entity position and merge all unit positions to group position
+                                        // set the profile position and merge all unit positions to group position
+                                        [_profile,"hasSimulated", true] call ALiVE_fnc_hashSet;
                                         [_profile,"position", _newPosition] call ALiVE_fnc_profileEntity;
                                         [_profile,"mergePositions"] call ALiVE_fnc_profileEntity;
-
                                     };
+
+                                    // Execute statements at the end, needs review of any variables in hashes
+                                    if (_executeStatements) then {
+                                        private _statements = [_activeWaypoint,"statements"] call ALiVE_fnc_hashGet;
+
+                                        if ((_statements isEqualType []) && {call compile (_statements select 0)}) then {
+                                            call compile (_statements select 1);
+                                        };
+                                    };
+                                } else {
+                                    if (_debug) then {["ALiVE Profile-Simulator profile movement stopped for profile %1: currentPosition: %2 destination: %3", [_profile,"profileID","no-ID"] call ALiVE_fnc_hashGet, _profilePosition, _destination] call ALiVE_fnc_dump};
                                 };
+
                             } else {
-                                if (_debug) then {["Profile-Simulator corrupted spawned profile detected %1: _newPosition %2 _position %3",_profileID,_newPosition,_position] call ALiVE_fnc_dump};
-                            };
 
-                        };
-                    } else {
-                        // profile has no waypoints
+                                // profile is spawned, update positions
 
-                        private _active = _profile select 2 select 1;
-                        if (_active) then {
-                            private _group = _profile select 2 select 13;
-                            private _leader = _profile select 2 select 10;
-                            private _currentWaypoint = currentWaypoint _group;
-
-                            if ((_currentWaypoint < count waypoints _group) && (_currentWaypoint > 0)) then {
-                                _leader = leader _group;
+                                private _group = _profile select 2 select 13;
+                                private _leader = leader _group;
                                 private _newPosition = getPosATL _leader;
 
                                 if (!isnil "_newPosition" && {!(_newPosition isEqualTo [])} && {!isnil "_profilePosition"} && {!(_profilePosition isEqualTo [])}) then {
-                                    private _moveDistance = _newPosition distance _profilePosition;
+                                    private _activeWaypoint = _waypoints select 0;
+                                    private _type = [_activeWaypoint,"type"] call ALiVE_fnc_hashGet;
+                                    private _speed = [_activeWaypoint,"speed"] call ALiVE_fnc_hashGet;
+                                    private _destination = [_activeWaypoint,"position"] call ALiVE_fnc_hashGet;
 
-                                    if (_moveDistance > 10) then {
+                                    private _moveDistance = _newPosition distance _profilePosition;
+                                    private _nearDestination = _newPosition distance _destination < 100;
+
+                                    // handle waypoint completion
+
+                                    if (_moveDistance > 10 || {_nearDestination}) then {
                                         if (_vehicleCommander) then {
-                                            // if in command of vehicle move all entities within the vehicle
+
+                                            // move all entities within the vehicle
                                             // set the vehicle position and merge all assigned entities positions
 
                                             _newPosition = getPosATL vehicle _leader;
 
                                             {
                                                 private _vehicleProfile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
+
                                                 if (!isnil "_vehicleProfile") then {
                                                     [_vehicleProfile,"position", _newPosition] call ALiVE_fnc_profileVehicle;
                                                     [_vehicleProfile,"mergePositions"] call ALiVE_fnc_profileVehicle;
                                                 };
                                             } forEach _vehiclesInCommandOf;
+
+                                            // remove any boat if not on water anymore
+                                            // if (_boatsEnabled && {_shallow} && {!isnil {[_profile,"boat"] call ALiVE_fnc_hashGet}} && {!(([_newPosition,0,50,0,0,0.5,1,[],[[0,0,0]]] call BIS_fnc_findSafePos) isEqualto [0,0,0])}) then {...};
+
+                                            private _boat = [_profile,"boat"] call ALiVE_fnc_hashGet;
+                                            if (_boatsEnabled && {((_newPosition) select 2) < 4} && {_nearDestination} && {!isnil "_boat"}) then {
+                                                private _boatProfileID = _boat select 0;
+                                                private _creation = ([_profile,"boat"] call ALiVE_fnc_hashGet) select 1;
+                                                private _boatProfile = [MOD(profileHandler),"getProfile", _boatProfileID] call ALiVE_fnc_ProfileHandler;
+
+                                                if (isnil "_boatProfile") then {
+                                                    if (_debug) then {["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR};
+                                                } else {
+                                                    if (_newPosition distance _creation > 100) then {
+                                                        private _profileID = [_profile,"profileID", "no-ID"] call ALiVE_fnc_hashGet;
+
+                                                        if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2 (LIVE)",_boatProfileID,_profileID] call ALiVE_fnc_Dump};
+
+                                                        [MOD(SYS_GC),"trashIt", vehicle _leader] call ALiVE_fnc_GC;
+
+                                                        [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
+                                                        [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
+
+                                                        if (count _waypoints > 1) then {
+                                                            _waypoints deleteAt 0;
+                                                            [_waypoints, _group] call ALiVE_fnc_profileWaypointsToWaypoints;
+                                                        };
+                                                    };
+                                                };
+
+                                                [_profile,"boat"] call ALiVE_fnc_hashRem;
+                                            };
+
                                         } else {
+
+                                            private _deepEnough = ((ATLtoASL _newPosition) select 2) < 1 && {(_newPosition select 2) > 4};
+
+                                            // Assign a boat to entities if on water
+                                            if (_boatsEnabled && {surfaceIsWater _profilePosition} && {surfaceIsWater _newPosition} && {_deepEnough} && {[_position,_destination] call ALiVE_fnc_crossesSea}) then {
+                                                if (isnil {[_profile,"boat"] call ALiVE_fnc_hashGet}) then {
+
+                                                    if (_debug) then {["ALiVE Profile Simulator is adding a boat to entity profile (LIVE) %1",_profileID] call ALiVE_fnc_Dump};
+
+                                                    private _unitPositions = _profile select 2 select 18;
+                                                    private _faction = [_profile, "faction"] call ALiVE_fnc_hashGet;
+                                                    private _side = _profile select 2 select 3;
+
+                                                    private _boatTypes = [(count _unitPositions) - 1, [_faction],"SHIP"] call ALiVE_fnc_findVehicleType;
+                                                    private _boatType = if (count _boatTypes > 0) then {selectRandom _boatTypes} else {"C_Boat_Transport_02_F"};
+
+                                                    private _boatProfile = [_boatType,_side,_faction,_newPosition,0,false,_faction,[]] call ALiVE_fnc_createProfileVehicle;
+                                                    [_profile,_boatProfile] call ALiVE_fnc_createProfileVehicleAssignment;
+
+                                                    private _vehicleAssignments = [_profile,"vehicleAssignments"] call ALiVE_fnc_hashGet;
+                                                    [_vehicleAssignments,_profile, true] call ALiVE_fnc_profileVehicleAssignmentsToVehicleAssignments;
+
+                                                    // create waypoint to nearest shore point
+                                                    private _shore = [_newPosition,_destination] call ALiVE_fnc_findNearestShore;
+                                                    if !(_shore isEqualTo [0,0,0]) then {
+                                                        private _shoreWaypoint = [_shore, 10] call ALiVE_fnc_createProfileWaypoint;
+                                                        [_profile,"insertWaypoint", _shoreWaypoint] call ALiVE_fnc_profileEntity;
+                                                    };
+
+                                                    [_profile,"boat", [[_boatProfile,"profileID"] call ALiVE_fnc_HashGet, _newPosition]] call ALiVE_fnc_hashSet;
+                                                };
+                                            };
+
                                             // set the entity position and merge all unit positions to group position
                                             [_profile,"position", _newPosition] call ALiVE_fnc_profileEntity;
                                             [_profile,"mergePositions"] call ALiVE_fnc_profileEntity;
+
                                         };
                                     };
                                 } else {
-                                    if (_debug) then {["Profile-Simulator corrupted profile detected %1: _newPosition %2 _profilePosition %3",_profileID,_newPosition,_profilePosition] call ALiVE_fnc_dump};
+                                    if (_debug) then {["Profile-Simulator corrupted spawned profile detected %1: _newPosition %2 _position %3",_profileID,_newPosition,_position] call ALiVE_fnc_dump};
+                                };
+
+                            };
+                        } else {
+                            // profile has no waypoints
+
+                            private _active = _profile select 2 select 1;
+                            if (_active) then {
+                                private _group = _profile select 2 select 13;
+                                private _leader = _profile select 2 select 10;
+                                private _currentWaypoint = currentWaypoint _group;
+
+                                if ((_currentWaypoint < count waypoints _group) && (_currentWaypoint > 0)) then {
+                                    _leader = leader _group;
+                                    private _newPosition = getPosATL _leader;
+
+                                    if (!isnil "_newPosition" && {!(_newPosition isEqualTo [])} && {!isnil "_profilePosition"} && {!(_profilePosition isEqualTo [])}) then {
+                                        private _moveDistance = _newPosition distance _profilePosition;
+
+                                        if (_moveDistance > 10) then {
+                                            if (_vehicleCommander) then {
+                                                // if in command of vehicle move all entities within the vehicle
+                                                // set the vehicle position and merge all assigned entities positions
+
+                                                _newPosition = getPosATL vehicle _leader;
+
+                                                {
+                                                    private _vehicleProfile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
+                                                    if (!isnil "_vehicleProfile") then {
+                                                        [_vehicleProfile,"position", _newPosition] call ALiVE_fnc_profileVehicle;
+                                                        [_vehicleProfile,"mergePositions"] call ALiVE_fnc_profileVehicle;
+                                                    };
+                                                } forEach _vehiclesInCommandOf;
+                                            } else {
+                                                // set the entity position and merge all unit positions to group position
+                                                [_profile,"position", _newPosition] call ALiVE_fnc_profileEntity;
+                                                [_profile,"mergePositions"] call ALiVE_fnc_profileEntity;
+                                            };
+                                        };
+                                    } else {
+                                        if (_debug) then {["Profile-Simulator corrupted profile detected %1: _newPosition %2 _profilePosition %3",_profileID,_newPosition,_profilePosition] call ALiVE_fnc_dump};
+                                    };
                                 };
                             };
-                        };
 
-                        // remove any ambient sea transport if no waypoint is assigned (should not happen - failsafe)
-                        if (_boatsEnabled && {_vehicleCommander} && {!isnil {[_profile,"boat"] call ALiVE_fnc_hashGet}}) then {
-                            private _boatProfileID = ([_profile,"boat"] call ALiVE_fnc_hashGet) select 0;
-                            private _boatProfile = [ALiVE_ProfileHandler,"getProfile",_boatProfileID] call ALiVE_fnc_ProfileHandler;
+                            // remove any ambient sea transport if no waypoint is assigned (should not happen - failsafe)
+                            if (_boatsEnabled && {_vehicleCommander} && {!isnil {[_profile,"boat"] call ALiVE_fnc_hashGet}}) then {
+                                private _boatProfileID = ([_profile,"boat"] call ALiVE_fnc_hashGet) select 0;
+                                private _boatProfile = [ALiVE_ProfileHandler,"getProfile",_boatProfileID] call ALiVE_fnc_ProfileHandler;
 
-                            if (isnil "_boatProfile") then {
-                                ["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR;
-                            } else {
-                                private _profileID = [_profile,"profileID","no-ID"] call ALiVE_fnc_hashGet;
+                                if (isnil "_boatProfile") then {
+                                    ["ALiVE Profile Simulator _boatProfile is nil _profile is %1",_profile] call ALiVE_fnc_DumpR;
+                                } else {
+                                    private _profileID = [_profile,"profileID","no-ID"] call ALiVE_fnc_hashGet;
 
-                                if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatProfileID,_profileID] call ALiVE_fnc_Dump};
+                                    if (_debug) then {["ALiVE Profile Simulator is removing boat %1 from entity profile %2",_boatProfileID,_profileID] call ALiVE_fnc_Dump};
 
-                                [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
+                                    [_profile,_boatProfile] call ALiVE_fnc_removeProfileVehicleAssignment;
 
-                                [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
+                                    [MOD(profileHandler),"unregisterProfile", _boatProfile] call ALiVE_fnc_profileHandler;
+                                };
+
+                                [_profile,"boat"] call ALiVE_fnc_hashRem;
                             };
+                        };
+                    };
 
-                            [_profile,"boat"] call ALiVE_fnc_hashRem;
+                    if (_isPlayer) then {
+                        private _leader = _profile select 2 select 10;
+                        private _newPosition = getPosATL _leader;
+
+                        // verify that position is valid
+
+                        if (!isnil "_newPosition" && {str _newPosition != "[0,0,0]"} && {!isnil "_profilePosition"} && {str _profilePosition != "[0,0,0]"}) then {
+                            private _moveDistance = _newPosition distance _profilePosition;
+
+                            if (_moveDistance > 10) then {
+                                if (_vehicleCommander) then {
+                                    // if in command of vehicle move all entities within the vehicle
+                                    // set the vehicle position and merge all assigned entities positions
+
+                                    //_leader = _profile select 2 select 10; //_leader = [_profile,"leader"] call ALiVE_fnc_hashGet;
+                                    _newPosition = getPosATL vehicle _leader;
+
+                                    {
+                                        private _vehicleProfile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
+                                        if (!isnil "_vehicleProfile") then {
+                                            [_vehicleProfile,"position", _newPosition] call ALiVE_fnc_profileVehicle;
+                                            [_vehicleProfile,"mergePositions"] call ALiVE_fnc_profileVehicle;
+                                        };
+                                    } forEach _vehiclesInCommandOf;
+                                } else {
+                                    _newPosition = getPosATL _leader;
+
+                                    // set the entity position and merge all unit positions to group position
+                                    [_profile,"position", _newPosition] call ALiVE_fnc_profileEntity;
+                                    [_profile,"mergePositions"] call ALiVE_fnc_profileEntity;
+                                };
+                            };
+                        } else {
+                            // position is invalid
+                            // (due to missing player object or corrupted profile)
+
+                            ["DISCONNECT"] call ALiVE_fnc_createProfilesFromPlayers;
                         };
                     };
                 };
 
-                if (_isPlayer) then {
-                    private _leader = _profile select 2 select 10;
-                    private _newPosition = getPosATL _leader;
-
-                    // verify that position is valid
-
-                    if (!isnil "_newPosition" && {str _newPosition != "[0,0,0]"} && {!isnil "_profilePosition"} && {str _profilePosition != "[0,0,0]"}) then {
-                        private _moveDistance = _newPosition distance _profilePosition;
-
-                        if (_moveDistance > 10) then {
-                            if (_vehicleCommander) then {
-                                // if in command of vehicle move all entities within the vehicle
-                                // set the vehicle position and merge all assigned entities positions
-
-                                //_leader = _profile select 2 select 10; //_leader = [_profile,"leader"] call ALiVE_fnc_hashGet;
-                                _newPosition = getPosATL vehicle _leader;
-
-                                {
-                                    private _vehicleProfile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_ProfileHandler;
-                                    if (!isnil "_vehicleProfile") then {
-                                        [_vehicleProfile,"position", _newPosition] call ALiVE_fnc_profileVehicle;
-                                        [_vehicleProfile,"mergePositions"] call ALiVE_fnc_profileVehicle;
-                                    };
-                                } forEach _vehiclesInCommandOf;
-                            } else {
-                                _newPosition = getPosATL _leader;
-
-                                // set the entity position and merge all unit positions to group position
-                                [_profile,"position", _newPosition] call ALiVE_fnc_profileEntity;
-                                [_profile,"mergePositions"] call ALiVE_fnc_profileEntity;
-                            };
-                        };
-                    } else {
-                        // position is invalid
-                        // (due to missing player object or corrupted profile)
-
-                        ["DISCONNECT"] call ALiVE_fnc_createProfilesFromPlayers;
-                    };
-                };
             };
 
             [_profile,"timeLastSim", diag_tickTime] call ALiVE_fnc_hashSet;
-
         };
     };
 
@@ -597,266 +607,269 @@ if (!_simAttacks) then {
 
             if (!isnil "_attack") then {
 
-                private _cyclesLeft = [_attack,"cyclesLeft"] call ALiVE_fnc_hashGet;
-                private _timeLastSim = [_attack,"timeLastSim", diag_tickTime - 0.001] call ALiVE_fnc_hashGet;
-                private _simModifier = diag_tickTime - _timeLastSim * accTime;
+                if (!_profileSystemPaused && !ALiVE_gamePaused) then {
 
-                private _active = false;
+                    private _cyclesLeft = [_attack,"cyclesLeft"] call ALiVE_fnc_hashGet;
+                    private _timeLastSim = [_attack,"timeLastSim", diag_tickTime - 0.001] call ALiVE_fnc_hashGet;
+                    private _simModifier = diag_tickTime - _timeLastSim * accTime;
 
-                if (_cyclesLeft > 0) then {
-                    [_attack,"cyclesLeft", _cyclesLeft - 1] call ALiVE_fnc_hashSet;
+                    private _active = false;
 
-                    private _attackerID = [_attack,"attacker"] call ALiVE_fnc_hashGet;
-                    private _targetIDs = [_attack,"targets"] call ALiVE_fnc_hashGet;
+                    if (_cyclesLeft > 0) then {
+                        [_attack,"cyclesLeft", _cyclesLeft - 1] call ALiVE_fnc_hashSet;
 
-                    _attacker = [MOD(profileHandler),"getProfile", _attackerID] call ALiVE_fnc_profileHandler;
+                        private _attackerID = [_attack,"attacker"] call ALiVE_fnc_hashGet;
+                        private _targetIDs = [_attack,"targets"] call ALiVE_fnc_hashGet;
 
-                    if (!isnil "_attacker") then {
-                        private "_target";
-                        while {isnil "_target" && !(_targetIDs isEqualTo [])} do {
-                            _target = [MOD(profileHandler),"getProfile", _targetIDs select 0] call ALiVE_fnc_profileHandler;
+                        _attacker = [MOD(profileHandler),"getProfile", _attackerID] call ALiVE_fnc_profileHandler;
 
-                            // if target is active, remove it
-                            if (isnil "_target" || {_target select 2 select 1}) then {
-                                _targetIDs deleteat 0;
-                                _target = nil;
+                        if (!isnil "_attacker") then {
+                            private "_target";
+                            while {isnil "_target" && !(_targetIDs isEqualTo [])} do {
+                                _target = [MOD(profileHandler),"getProfile", _targetIDs select 0] call ALiVE_fnc_profileHandler;
+
+                                // if target is active, remove it
+                                if (isnil "_target" || {_target select 2 select 1}) then {
+                                    _targetIDs deleteat 0;
+                                    _target = nil;
+                                };
                             };
-                        };
 
-                        if (!isnil "_target") then {
-                            private _attackerPos = _attacker select 2 select 2;                     // [_attacker,"position"] call ALiVE_fnc_hashGet;
-                            private _targetPos = _target select 2 select 2;                         // [_target,"position"] call ALiVE_fnc_hashGet;
+                            if (!isnil "_target") then {
+                                private _attackerPos = _attacker select 2 select 2;                     // [_attacker,"position"] call ALiVE_fnc_hashGet;
+                                private _targetPos = _target select 2 select 2;                         // [_target,"position"] call ALiVE_fnc_hashGet;
 
-                            private _maxEngagementRange = [_attack,"maxRange"] call ALiVE_fnc_hashGet;
+                                private _maxEngagementRange = [_attack,"maxRange"] call ALiVE_fnc_hashGet;
 
-                            if (_attackerPos distance2D _targetPos <= _maxEngagementRange) then {
-                                // get profiles to attack with
-                                // vehicles entity commands, or just the entity
+                                if (_attackerPos distance2D _targetPos <= _maxEngagementRange) then {
+                                    // get profiles to attack with
+                                    // vehicles entity commands, or just the entity
 
-                                private _profilesToAttackWith = [];
-                                private _attackerVehiclesInCommandOf = _attacker select 2 select 8;
+                                    private _profilesToAttackWith = [];
+                                    private _attackerVehiclesInCommandOf = _attacker select 2 select 8;
 
-                                {
-                                    private _vehicleUnderCommand = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
-
-                                    if (!isnil "_vehicleUnderCommand") then {
-                                        _profilesToAttackWith pushback _vehicleUnderCommand;
-                                    };
-                                } foreach _attackerVehiclesInCommandOf;
-
-                                // entity shouldn't attack separately if it's inside vehicle(s)
-                                if (_profilesToAttackWith isEqualTo []) then {
-                                    _profilesToAttackWith pushback _attacker;
-                                };
-
-                                // get targets to attack
-
-                                private _targetsToAttack = [];
-                                private _targetVehiclesInCommandOf = _target select 2 select 8;
-
-                                {
-                                    private _targetToAttack = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
-
-                                    if (!isnil "_targetToAttack") then {
-                                        _targetsToAttack pushback _targetToAttack;
-                                    };
-                                } foreach _targetVehiclesInCommandOf;
-
-                                // entity shouldn't be attacked separately if it's in a vehicle
-                                if (_targetsToAttack isEqualTo []) then {
-                                    _targetsToAttack pushback _target;
-                                } else {
-                                    reverse _targetsToAttack; // destroy vehicles in reverse order to avoid corrupting unit assignment indexes
-                                };
-
-                                if !(_targetsToAttack isEqualTo []) then {
-                                    // attack each target profile individually
-                                    // if vehicle is destroyed, unassigned it from it's entity
-
-                                    private _targetToAttack = _targetsToAttack select 0;
-                                    private _targetToAttackID = _targetToAttack select 2 select 4;
-                                    private _targetToAttackType = _targetToAttack select 2 select 5;
-
-                                    private _profileToAttackHealth = [];
-
-                                    if (_targetToAttackType == "entity") then {
-                                        // must be copied so that calling "removeUnit" doesn't alter the new damage array
-                                        _profileToAttackHealth = +([_targetToAttack,"damages"] call ALiVE_fnc_hashGet);
-                                    } else {
-                                        _profileToAttackHealth = [_targetToAttack,"damage"] call ALiVE_fnc_hashGet;
-
-                                        // if vehicle hasn't been spawned yet
-                                        // init hitpoint values
-
-                                        if (_profileToAttackHealth isEqualTo []) then {
-                                            private _vehicleClass = _targetToAttack select 2 select 11;
-                                            private _totalHitpoints = _vehicleClass call ALiVE_fnc_configGetVehicleHitPoints;
-
-                                            if (_totalHitpoints isEqualTo []) then {
-                                                private _hp = [(configfile >> "CfgVehicles" >> _vehicleClass >> "HitPoints"),0] call BIS_fnc_returnChildren;
-                                                {_totalHitpoints pushBack (configName _x)} forEach _hp;
-                                            };
-
-                                            {_profileToAttackHealth pushback [_x,0]} foreach _totalHitpoints;
-                                        };
-                                    };
-
-                                    // get total damage that can be dealt this turn
-                                    // damage is calculated from each vehicle the entity controls
-                                    // if entity controls no vehicles, the entity itself attacks
-
-                                    private _damageToInflict = 0;
                                     {
-                                        _damageToInflict = _damageToInflict + (([_x,_targetToAttack] call ALiVE_fnc_profileGetDamageOutput) * _combatRate * _simModifier);
-                                    } foreach _profilesToAttackWith;
+                                        private _vehicleUnderCommand = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
 
-                                    if (_damageToInflict > 0) then {
-                                        private _damageToInflictLeft = _damageToInflict;
+                                        if (!isnil "_vehicleUnderCommand") then {
+                                            _profilesToAttackWith pushback _vehicleUnderCommand;
+                                        };
+                                    } foreach _attackerVehiclesInCommandOf;
+
+                                    // entity shouldn't attack separately if it's inside vehicle(s)
+                                    if (_profilesToAttackWith isEqualTo []) then {
+                                        _profilesToAttackWith pushback _attacker;
+                                    };
+
+                                    // get targets to attack
+
+                                    private _targetsToAttack = [];
+                                    private _targetVehiclesInCommandOf = _target select 2 select 8;
+
+                                    {
+                                        private _targetToAttack = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
+
+                                        if (!isnil "_targetToAttack") then {
+                                            _targetsToAttack pushback _targetToAttack;
+                                        };
+                                    } foreach _targetVehiclesInCommandOf;
+
+                                    // entity shouldn't be attacked separately if it's in a vehicle
+                                    if (_targetsToAttack isEqualTo []) then {
+                                        _targetsToAttack pushback _target;
+                                    } else {
+                                        reverse _targetsToAttack; // destroy vehicles in reverse order to avoid corrupting unit assignment indexes
+                                    };
+
+                                    if !(_targetsToAttack isEqualTo []) then {
+                                        // attack each target profile individually
+                                        // if vehicle is destroyed, unassigned it from it's entity
+
+                                        private _targetToAttack = _targetsToAttack select 0;
+                                        private _targetToAttackID = _targetToAttack select 2 select 4;
+                                        private _targetToAttackType = _targetToAttack select 2 select 5;
+
+                                        private _profileToAttackHealth = [];
 
                                         if (_targetToAttackType == "entity") then {
-                                            // attacking entity
-                                            // spread damage randomly over units
+                                            // must be copied so that calling "removeUnit" doesn't alter the new damage array
+                                            _profileToAttackHealth = +([_targetToAttack,"damages"] call ALiVE_fnc_hashGet);
+                                        } else {
+                                            _profileToAttackHealth = [_targetToAttack,"damage"] call ALiVE_fnc_hashGet;
 
-                                            private _unitCount = count _profileToAttackHealth;
+                                            // if vehicle hasn't been spawned yet
+                                            // init hitpoint values
 
-                                            if (_unitCount > 0) then {
-                                                private _dmgPerUnitEven = _damageToInflict / _unitCount;
+                                            if (_profileToAttackHealth isEqualTo []) then {
+                                                private _vehicleClass = _targetToAttack select 2 select 11;
+                                                private _totalHitpoints = _vehicleClass call ALiVE_fnc_configGetVehicleHitPoints;
 
-                                                private _randomDamageMin = _dmgPerUnitEven / 2;
-                                                private _randomDamageMax = _dmgPerUnitEven * 8;
-
-                                                private _indexesToRemove = [];
-
-                                                while {_damageToInflictLeft > 0 && {_unitCount > 0}} do {
-                                                    private _randomIndex = floor random _unitCount;
-                                                    private _randomIndexDamage = _profileToAttackHealth select _randomIndex;
-
-                                                    // calc damage - ensure no overdamage
-                                                    private _randomDamage = random [_randomDamageMin, _dmgPerUnitEven, _randomDamageMax];
-                                                    if (_randomDamage > _damageToInflictLeft) then {
-                                                        _randomDamage = _damageToInflictLeft;
-                                                    };
-
-                                                    _randomIndexDamage = _randomIndexDamage + _randomDamage;
-                                                    _damageToInflictLeft = _damageToInflictLeft - _randomDamage;
-
-                                                    if (_randomIndexDamage >= 1) then {
-                                                        _indexesToRemove pushback _randomIndex;
-                                                        _profileToAttackHealth deleteAt _randomIndex;
-                                                        _unitCount = _unitCount - 1;
-                                                    } else {
-                                                        _profileToAttackHealth set [_randomIndex,_randomIndexDamage];
-                                                    };
+                                                if (_totalHitpoints isEqualTo []) then {
+                                                    private _hp = [(configfile >> "CfgVehicles" >> _vehicleClass >> "HitPoints"),0] call BIS_fnc_returnChildren;
+                                                    {_totalHitpoints pushBack (configName _x)} forEach _hp;
                                                 };
 
-                                                {
-                                                    [_targetToAttack,"removeUnit", _x] call ALiVE_fnc_profileEntity;
-                                                    _unitCount = _unitCount - 1;
-                                                } foreach _indexesToRemove;
+                                                {_profileToAttackHealth pushback [_x,0]} foreach _totalHitpoints;
+                                            };
+                                        };
 
-                                                [_targetToAttack,"damages", _profileToAttackHealth] call ALiVE_fnc_hashSet;
+                                        // get total damage that can be dealt this turn
+                                        // damage is calculated from each vehicle the entity controls
+                                        // if entity controls no vehicles, the entity itself attacks
 
-                                                if (_unitCount == 0) then {
+                                        private _damageToInflict = 0;
+                                        {
+                                            _damageToInflict = _damageToInflict + (([_x,_targetToAttack] call ALiVE_fnc_profileGetDamageOutput) * _combatRate * _simModifier);
+                                        } foreach _profilesToAttackWith;
+
+                                        if (_damageToInflict > 0) then {
+                                            private _damageToInflictLeft = _damageToInflict;
+
+                                            if (_targetToAttackType == "entity") then {
+                                                // attacking entity
+                                                // spread damage randomly over units
+
+                                                private _unitCount = count _profileToAttackHealth;
+
+                                                if (_unitCount > 0) then {
+                                                    private _dmgPerUnitEven = _damageToInflict / _unitCount;
+
+                                                    private _randomDamageMin = _dmgPerUnitEven / 2;
+                                                    private _randomDamageMax = _dmgPerUnitEven * 8;
+
+                                                    private _indexesToRemove = [];
+
+                                                    while {_damageToInflictLeft > 0 && {_unitCount > 0}} do {
+                                                        private _randomIndex = floor random _unitCount;
+                                                        private _randomIndexDamage = _profileToAttackHealth select _randomIndex;
+
+                                                        // calc damage - ensure no overdamage
+                                                        private _randomDamage = random [_randomDamageMin, _dmgPerUnitEven, _randomDamageMax];
+                                                        if (_randomDamage > _damageToInflictLeft) then {
+                                                            _randomDamage = _damageToInflictLeft;
+                                                        };
+
+                                                        _randomIndexDamage = _randomIndexDamage + _randomDamage;
+                                                        _damageToInflictLeft = _damageToInflictLeft - _randomDamage;
+
+                                                        if (_randomIndexDamage >= 1) then {
+                                                            _indexesToRemove pushback _randomIndex;
+                                                            _profileToAttackHealth deleteAt _randomIndex;
+                                                            _unitCount = _unitCount - 1;
+                                                        } else {
+                                                            _profileToAttackHealth set [_randomIndex,_randomIndexDamage];
+                                                        };
+                                                    };
+
+                                                    {
+                                                        [_targetToAttack,"removeUnit", _x] call ALiVE_fnc_profileEntity;
+                                                        _unitCount = _unitCount - 1;
+                                                    } foreach _indexesToRemove;
+
+                                                    [_targetToAttack,"damages", _profileToAttackHealth] call ALiVE_fnc_hashSet;
+
+                                                    if (_unitCount == 0) then {
+                                                        _toBeKilled pushbackunique [_attacker,_targetToAttack];
+                                                        _targetsToAttack deleteAt 0;
+                                                    };
+                                                } else {
                                                     _toBeKilled pushbackunique [_attacker,_targetToAttack];
                                                     _targetsToAttack deleteAt 0;
                                                 };
                                             } else {
-                                                _toBeKilled pushbackunique [_attacker,_targetToAttack];
-                                                _targetsToAttack deleteAt 0;
-                                            };
-                                        } else {
-                                            // attacking vehicle
-                                            // spread damage randomly over hit points
+                                                // attacking vehicle
+                                                // spread damage randomly over hit points
 
-                                            private _hitPointCount = count _profileToAttackHealth;
-                                            private _dmgPerHitPointEven = _damageToInflict / _hitPointCount;
+                                                private _hitPointCount = count _profileToAttackHealth;
+                                                private _dmgPerHitPointEven = _damageToInflict / _hitPointCount;
 
-                                            private _randomDamageMin = _dmgPerHitPointEven / 2;
-                                            private _randomDamageMax = _dmgPerHitPointEven * 8;
+                                                private _randomDamageMin = _dmgPerHitPointEven / 2;
+                                                private _randomDamageMax = _dmgPerHitPointEven * 8;
 
-                                            while {_damageToInflictLeft > 0} do {
-                                                private _randomIndex = floor random _hitPointCount;
-                                                private _randomHitPoint = _profileToAttackHealth select _randomIndex;
+                                                while {_damageToInflictLeft > 0} do {
+                                                    private _randomIndex = floor random _hitPointCount;
+                                                    private _randomHitPoint = _profileToAttackHealth select _randomIndex;
 
-                                                private _randomHitPointNme = _randomHitPoint select 0;
-                                                private _randomHitPointDmg = _randomHitPoint select 1;
+                                                    private _randomHitPointNme = _randomHitPoint select 0;
+                                                    private _randomHitPointDmg = _randomHitPoint select 1;
 
-                                                // HitFuel can lead to rapid explosions on spawn
-                                                // if damaged at all
-                                                if (_randomHitPointNme != "HitFuel") then {
-                                                    private _randomDamage = random [_randomDamageMin, _dmgPerHitPointEven, _randomDamageMax];
+                                                    // HitFuel can lead to rapid explosions on spawn
+                                                    // if damaged at all
+                                                    if (_randomHitPointNme != "HitFuel") then {
+                                                        private _randomDamage = random [_randomDamageMin, _dmgPerHitPointEven, _randomDamageMax];
 
-                                                    _randomHitPointDmg = _randomHitPointDmg + _randomDamage;
-                                                    _damageToInflictLeft = _damageToInflictLeft - _randomDamage;
+                                                        _randomHitPointDmg = _randomHitPointDmg + _randomDamage;
+                                                        _damageToInflictLeft = _damageToInflictLeft - _randomDamage;
 
-                                                    if (_randomHitPointDmg >= 1) then {
-                                                        _randomHitPoint set [1,1];
-                                                    } else {
-                                                        _randomHitPoint set [1,_randomHitPointDmg];
+                                                        if (_randomHitPointDmg >= 1) then {
+                                                            _randomHitPoint set [1,1];
+                                                        } else {
+                                                            _randomHitPoint set [1,_randomHitPointDmg];
+                                                        };
+
+                                                        _profileToAttackHealth set [_randomIndex,_randomHitPoint];
                                                     };
-
-                                                    _profileToAttackHealth set [_randomIndex,_randomHitPoint];
                                                 };
-                                            };
 
-                                            // if all of the vehicles hitpoints are 0, vehicle is dead
+                                                // if all of the vehicles hitpoints are 0, vehicle is dead
 
-                                            private _vehCritical = false;
-                                            private _deadHitPointCount = 0;
-                                            {
-                                                if ((_x select 0) != "HitHull" && {(_x select 0) != "HitFuel"}) then {
-                                                    if ((_x select 1) == 1) then {_deadHitPointCount = _deadHitPointCount + 1};
-                                                } else {
-                                                    // HitHull, HitFuel damage of > 0.90 causes most vehicles to explode upon spawn
-                                                    if ((_x select 1) > 0.85) then {_vehCritical = true};
-                                                };
-                                            } foreach _profileToAttackHealth;
-
-                                            if (_deadHitPointCount < floor (_hitPointCount * 0.75) && !_vehCritical) then {
-                                                [_targetToAttack,"damage", _profileToAttackHealth] call ALiVE_fnc_hashSet;
-                                            } else {
-                                                _toBeUnassigned pushbackunique [_target,_targetToAttack];
-                                                _toBeKilled pushbackunique [_attacker,_targetToAttack];
-                                                _targetsToAttack deleteAt 0;
-
-                                                // if this vehicle is the last vehicle it's commanding entity controls
-                                                // kill the commanding entity as well
-
+                                                private _vehCritical = false;
+                                                private _deadHitPointCount = 0;
                                                 {
-                                                    private _entityInCommandOf = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
-                                                    private _assignedVehicles = _entityInCommandOf select 2 select 8;
-
-                                                    if (_assignedVehicles isEqualTo [_targetToAttackID]) then {
-                                                        _toBeKilled pushbackunique [_attacker, [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler];
+                                                    if ((_x select 0) != "HitHull" && {(_x select 0) != "HitFuel"}) then {
+                                                        if ((_x select 1) == 1) then {_deadHitPointCount = _deadHitPointCount + 1};
+                                                    } else {
+                                                        // HitHull, HitFuel damage of > 0.90 causes most vehicles to explode upon spawn
+                                                        if ((_x select 1) > 0.85) then {_vehCritical = true};
                                                     };
-                                                } foreach ([_targetToAttack,"entitiesInCommandOf"] call ALiVE_fnc_hashGet);
+                                                } foreach _profileToAttackHealth;
+
+                                                if (_deadHitPointCount < floor (_hitPointCount * 0.75) && !_vehCritical) then {
+                                                    [_targetToAttack,"damage", _profileToAttackHealth] call ALiVE_fnc_hashSet;
+                                                } else {
+                                                    _toBeUnassigned pushbackunique [_target,_targetToAttack];
+                                                    _toBeKilled pushbackunique [_attacker,_targetToAttack];
+                                                    _targetsToAttack deleteAt 0;
+
+                                                    // if this vehicle is the last vehicle it's commanding entity controls
+                                                    // kill the commanding entity as well
+
+                                                    {
+                                                        private _entityInCommandOf = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
+                                                        private _assignedVehicles = _entityInCommandOf select 2 select 8;
+
+                                                        if (_assignedVehicles isEqualTo [_targetToAttackID]) then {
+                                                            _toBeKilled pushbackunique [_attacker, [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler];
+                                                        };
+                                                    } foreach ([_targetToAttack,"entitiesInCommandOf"] call ALiVE_fnc_hashGet);
+                                                };
                                             };
                                         };
-                                    };
 
-                                    // combat simulation over
-                                    // end attack if no targets remain
+                                        // combat simulation over
+                                        // end attack if no targets remain
 
-                                    if !(_targetsToAttack isEqualTo []) then {
-                                        _active = true;
+                                        if !(_targetsToAttack isEqualTo []) then {
+                                            _active = true;
+                                        };
                                     };
                                 };
                             };
                         };
                     };
-                };
 
-                if (!_active) then {
-                    _attacksToRemove pushback _attack;
+                    if (!_active) then {
+                        _attacksToRemove pushback _attack;
 
-                    if (!isnil "_attacker") then {
-                        [_attacker,"combat", false] call ALiVE_fnc_hashSet;
-                        [_attacker,"attackID"] call ALiVE_fnc_hashRem;
+                        if (!isnil "_attacker") then {
+                            [_attacker,"combat", false] call ALiVE_fnc_hashSet;
+                            [_attacker,"attackID"] call ALiVE_fnc_hashRem;
+                        };
                     };
+
                 };
 
                 [_attack,"timeLastSim", diag_tickTime] call ALiVE_fnc_hashSet;
-
             };
         };
 

--- a/addons/sys_profile/fnc_profileSimulator.sqf
+++ b/addons/sys_profile/fnc_profileSimulator.sqf
@@ -778,7 +778,8 @@ if (!_simAttacks) then {
                                                 private _randomIndex = floor random _hitPointCount;
                                                 private _randomHitPoint = _profileToAttackHealth select _randomIndex;
 
-                                                _randomHitPoint params ["_randomHitPointNme","_randomHitPointDmg"];
+                                                private _randomHitPointNme = _randomHitPoint select 0;
+                                                private _randomHitPointDmg = _randomHitPoint select 1;
 
                                                 // HitFuel can lead to rapid explosions on spawn
                                                 // if damaged at all
@@ -861,7 +862,8 @@ if (!_simAttacks) then {
 
 
         {
-             _x params ["_commandingEntity","_subordinateVehicle"];
+            private _commandingEntity = _x select 0;
+            private _subordinateVehicle = _x select 1;
 
             // remove crew from commanding entity
 
@@ -869,7 +871,7 @@ if (!_simAttacks) then {
             private _vehicleID = _subordinateVehicle select 2 select 4;
 
             private _vehAssignment = [_vehAssignments,_vehicleID] call ALiVE_fnc_hashGet;
-            private _unitAssignments = + (_vehAssignment select 2);
+            private _unitAssignments = +(_vehAssignment param [2, [], [[]]]);
 
             reverse _unitAssignments; // must remove in reverse order
 
@@ -885,7 +887,8 @@ if (!_simAttacks) then {
         } foreach _toBeUnassigned;
 
         {
-            _x params ["_killer","_victim"];
+            private _killer = _x select 0;
+            private _victim = _x select 1;
 
             private _victimType = _victim select 2 select 5;
 

--- a/addons/sys_profile/fnc_profileSpawner.sqf
+++ b/addons/sys_profile/fnc_profileSpawner.sqf
@@ -123,6 +123,25 @@ private _spawnSources = [MOD(profileSystem),"profileSpawnSources"] call ALiVE_fn
 if (_spawnSources isEqualTo []) then {
     _spawnSources append allPlayers;
     _spawnSources append (allUnitsUAV select {isUavConnected _x});
+
+    // avoid unnecessary work
+    // delete spawn sources that are in close proximity
+    // ie. treat squads/nearby units as a single spawn source
+
+    /*
+    if (count _spawnSources > 10) {
+        private _code = {_x distance _source < 30};
+        {
+            private _source = _x;
+
+            {
+                if (_x != _source && _code) then {
+                    _spawnSources deleteat (_spawnSources find _x);
+                };
+            } foreach _spawnSources;
+        } foreach _spawnSources;
+    };
+    */
 };
 
 private _inNonDespawnRange = [];

--- a/addons/sys_profile/fnc_profileSpawner.sqf
+++ b/addons/sys_profile/fnc_profileSpawner.sqf
@@ -23,6 +23,14 @@ SpyderBlack723
 
 _this = _this select 0;
 
+if ([ALiVE_profileSystem,"paused"] call ALiVE_fnc_hashGet) exitwith {
+	private _profilesToSpawnQueue = [ALiVE_profileSystem,"profilesToSpawn"] call ALiVE_fnc_hashGet;
+	private _profilesToDespawnQueue = [ALiVE_profileSystem,"profilesToDespawn"] call ALiVE_fnc_hashGet;
+
+	_profilesToSpawnQueue resize 0;
+	_profilesToDespawnQueue resize 0;
+};
+
 private _spawnRadius = _this select 0;
 private _spawnRadiusHeli = _this select 1;
 private _spawnRadiusPlane = _this select 2;

--- a/addons/sys_profile/fnc_profileSpawner.sqf
+++ b/addons/sys_profile/fnc_profileSpawner.sqf
@@ -128,20 +128,17 @@ if (_spawnSources isEqualTo []) then {
     // delete spawn sources that are in close proximity
     // ie. treat squads/nearby units as a single spawn source
 
-    /*
     if (count _spawnSources > 10) {
-        private _code = {_x distance _source < 30};
         {
             private _source = _x;
 
             {
-                if (_x != _source && _code) then {
+                if (_x != _source && {_x distance _source < 30}) then {
                     _spawnSources deleteat (_spawnSources find _x);
                 };
             } foreach _spawnSources;
         } foreach _spawnSources;
     };
-    */
 };
 
 private _inNonDespawnRange = [];
@@ -166,8 +163,7 @@ if !(_spawnSources isEqualTo []) then {
         };
     };
 
-    private _profilesInDeactivationRange = [_center,_radius * 1.2, ["all","all"]] call ALiVE_fnc_getNearProfiles;
-
+    private _profilesInDeactivationRange = [_center,_radius * 1.2] call ALiVE_fnc_getNearProfiles;
     {
         // don't spawn or despawn player profiles
         if (!([_x,"isPlayer", false] call ALiVE_fnc_hashGet)) then {

--- a/addons/sys_profile/fnc_profileSpawner.sqf
+++ b/addons/sys_profile/fnc_profileSpawner.sqf
@@ -1,8 +1,8 @@
-#include <\x\alive\addons\sys_profile\script_component.hpp>
+#include <\x\ALiVE\addons\sys_profile\script_component.hpp>
 SCRIPT(profileSpawner);
 
 /* ----------------------------------------------------------------------------
-Function: ALIVE_fnc_profileSpawner
+Function: ALiVE_fnc_profileSpawner
 
 Description:
 Spawns and despawns from profiles based on player distance
@@ -13,95 +13,167 @@ Returns:
 
 Examples:
 (begin example)
-// start the profile spawner
-[] call ALIVE_fnc_profileSpawner;
 (end)
 
 See Also:
 
 Author:
-Highhead
+SpyderBlack723
 ---------------------------------------------------------------------------- */
 
-private ["_side","_spawnDistance","_activeLimiter","_debug","_activeEntities","_activeEntityCount","_profiles","_entityProfiles","_vehicleProfiles"];
+_this = _this select 0;
 
-_side = _this select 0;
-_spawnDistance = if(count _this > 1) then {_this select 1} else {1000};
-_activeLimiter = if(count _this > 2) then {_this select 2} else {100};
-_debug = if(count _this > 3) then {_this select 3} else {false};
+private _spawnRadius = _this select 0;
+private _spawnRadiusHeli = _this select 1;
+private _spawnRadiusPlane = _this select 2;
+private _activeLimiter = _this select 3;
 
-_activeEntities = [ALIVE_profileHandler, "getActiveEntities"] call ALIVE_fnc_profileHandler;
-_activeEntityCount = count _activeEntities;
+private _uavSpawnRadius = _spawnRadius + 800;
 
-_profiles = [ALIVE_profileHandler, "getProfilesBySideFull", _side] call ALIVE_fnc_profileHandler;
+private _activeProfiles = [ALiVE_profileHandler,"profilesActive"] call ALiVE_fnc_hashGet;
+private _inactiveProfiles = [ALiVE_profileHandler,"profilesInActive"] call ALiVE_fnc_hashGet;
+
+private _profilesToSpawnQueue = [ALiVE_profileSystem,"profilesToSpawn"] call ALiVE_fnc_hashGet;
+private _profilesToDespawnQueue = [ALiVE_profileSystem,"profilesToDespawn"] call ALiVE_fnc_hashGet;
+private _lastProfileSpawnedTime = [ALiVE_profileSystem,"profileLastSpawnTime"] call ALiVE_fnc_hashGet;
+
+///////////////////////////////////////
+//     Spawn/Despawn Profiles
+///////////////////////////////////////
+
+private _activeEntityCount = count ([ALiVE_profileHandler,"getActiveEntities"] call ALiVE_fnc_profileHandler);
+
+if !(_profilesToSpawnQueue isEqualTo [] && {time - _lastProfileSpawnedTime > ALiVE_smoothSpawn}) then {
+    private _profileID = _profilesToSpawnQueue select 0;
+
+    private _profile = [ALiVE_profileHandler,"getProfile", _profileID] call ALiVE_fnc_profileHandler;
+
+    if (isnil "_profile" || {_profile select 2 select 1} || {[_profile,"locked", false] call ALiVE_fnc_HashGet}) then {
+        // profile no longer exists, is active, or is locked
+        // remove from queue
+
+        _profilesToSpawnQueue deleteat 0;
+    } else {
+        if (_activeEntityCount < _activeLimiter) then {
+            if ((_profile select 2 select 5) == "entity") then {
+                [_profile,"spawn"] spawn ALiVE_fnc_profileEntity;
+            } else {
+                [_profile,"spawn"] spawn ALiVE_fnc_profileVehicle;
+            };
+
+            [ALiVE_profileSystem,"profileLastSpawnTime", time] call ALiVE_fnc_hashSet;
+
+            _activeProfiles pushback _profileID;
+            _inactiveProfiles deleteat (_inactiveProfiles find _profileID);
+        } else {
+            // we've breached the active limiter
+            // unregister profile if entity and inactive
+
+            if (!(_profile select 2 select 1) && {(_profile select 2 select 5) == "entity"}) then {
+                {
+                    private _vehicleProfile = [ALiVE_profileHandler,"getProfile", _x] call ALiVE_fnc_profileHandler;
+
+                    if (!isnil "_vehicleProfile") then {
+                        [ALiVE_profileHandler,"unregisterProfile", _vehicleProfile] call ALiVE_fnc_profileHandler;
+                    };
+                } foreach (_profile select 2 select 8); // "vehiclesInCommandOf"
+
+                [ALiVE_profileHandler,"unregisterProfile", _profile] call ALiVE_fnc_profileHandler;
+            };
+        };
+    };
+};
+
+if !(_profilesToDespawnQueue isEqualTo []) then {
+    private _profileID = _profilesToDespawnQueue select 0;
+    _profilesToDespawnQueue deleteat 0;
+
+    private _profile = [ALiVE_profileHandler,"getProfile", _profileID] call ALiVE_fnc_profileHandler;
+
+    if (!isnil "_profile") then {
+        private _leader = _profile select 2 select 10;
+
+        // if unit is in the air, prevent despawn
+        if ((getpos _leader) select 2 < 3) then {
+            if ((_profile select 2 select 5) == "entity") then {
+                [_profile,"despawn"] call ALiVE_fnc_profileEntity;
+            } else {
+                [_profile,"despawn"] call ALiVE_fnc_profileVehicle;
+            };
+
+            _inactiveProfiles pushback _profileID;
+            _activeProfiles deleteat (_activeProfiles find _profileID);
+        };
+    };
+};
+
+///////////////////////////////////////
+// Sort Profiles Set To Spawn/Despawn
+///////////////////////////////////////
+
+private _spawnSources = [ALiVE_profileSystem,"profileSpawnSources"] call ALiVE_fnc_hashGet;
+if (_spawnSources isEqualTo []) then {
+    _spawnSources append allPlayers;
+    _spawnSources append (allUnitsUAV select {isUavConnected _x});
+};
+
+private _inNonDespawnRange = [];
+
+// find entities to spawn
+
+if !(_spawnSources isEqualTo []) then {
+    _spawnSource = _spawnSources select 0;
+    _spawnSources deleteat 0;
+
+    private _center = getpos _spawnSource;
+    private _radius = _spawnRadius;
+
+    // figure out what radius to use
+    // based on source unit type
+
+    switch ((typeof _spawnSource) call ALiVE_fnc_vehicleGetKindOf) do {
+        case "Helicopter": {_radius = _spawnRadiusHeli};
+        case "Plane": {_radius = _spawnRadiusPlane};
+        default {
+            if (unitIsUAV _spawnSource) then {_radius = _uavSpawnRadius};
+        };
+    };
+
+    private _profilesInDeactivationRange = [_center,_radius * 1.2, ["all","all"]] call ALiVE_fnc_getNearProfiles;
+
+    {
+        // don't spawn or despawn player profiles
+        if (!([_x,"isPlayer", false] call ALiVE_fnc_hashGet)) then {
+            if (!(_x select 2 select 1)) then {
+                if ((_x select 2 select 2) distance _center <= _radius) then {
+                    _profilesToSpawnQueue pushbackunique (_x select 2 select 4);
+                };
+            } else {
+                // if leader is null
+                // find new leader
+                if (isnull (_x select 2 select 10) && {(_x select 2 select 5) == "entity"}) then {
+                    private _leader = leader (_x select 2 select 13); // group
+
+                    if (!isnull _leader) then {
+                        [_x,"leader", _leader] call ALiVE_fnc_hashSet;
+                    };
+                };
+
+                // mark profile as safe from despawn
+                _inNonDespawnRange pushbackunique (_x select 2 select 4);
+            };
+        };
+    } foreach _profilesInDeactivationRange;
+};
+
+// find entities to despawn
+// select ID's from activeProfiles
+// that are outside despawn range
 
 {
-    private ["_profile","_profileID","_profileType","_position","_spawn","_active","_vehiclesInCommandOf","_vehicleProfile"];
+    if !(_x in _inNonDespawnRange) then {
+        _profilesToDespawnQueue pushbackunique _x;
+    };
+} foreach _activeProfiles;
 
-    _profile = _x;
-    _active = _profile select 2 select 1; //[_profile, "active"] call ALIVE_fnc_hashGet;
-
-    if!(_active) then {
-
-        _profileID = _profile select 2 select 4; //[_profile,"profileID"] call ALIVE_fnc_hashGet;
-        _profileType = _profile select 2 select 5; //[_profile,"type"] call ALIVE_fnc_hashGet;
-        _position = _profile select 2 select 2; //_position = [_profile,"position"] call ALIVE_fnc_hashGet;
-
-        _spawn = false;
-        if ([_position, _spawnDistance] call ALiVE_fnc_anyPlayersInRange > 0) then {
-            _spawn = true;
-        }else{
-            if ([_position, _spawnDistance] call ALiVE_fnc_anyAutonomousInRange > 0) then {
-                _spawn = true;
-            };
-        };
-
-        if (_spawn) then {
-
-            // spawn limiter
-            if(_activeEntityCount > _activeLimiter) then {
-
-                // DEBUG -------------------------------------------------------------------------------------
-                if(_debug) then {
-                    //["----------------------------------------------------------------------------------------"] call ALIVE_fnc_dump;
-                    ["ALIVE Profile spawner - spawn limited reached destroying..  [%1]",_profileID] call ALIVE_fnc_dump;
-                };
-                // DEBUG -------------------------------------------------------------------------------------
-
-                if (!(isnil "_profile") && {!(_profile select 2 select 1)}) then {
-                        _vehiclesInCommandOf = _profile select 2 select 8;
-
-                        if (count _vehiclesInCommandOf > 0) then {
-                            {
-                                _vehicleProfile = [ALIVE_profileHandler, "getProfile", _x] call ALIVE_fnc_profileHandler;
-                                [ALIVE_profileHandler, "unregisterProfile", _vehicleProfile] call ALIVE_fnc_profileHandler;
-                            } foreach _vehiclesInCommandOf;
-                        };
-
-                        [ALIVE_profileHandler, "unregisterProfile", _profile] call ALIVE_fnc_profileHandler;
-                };
-            }else{
-                _activeEntityCount = _activeEntityCount + 1;
-
-                switch(_profileType) do {
-                        case "entity": {
-                            [_profile, "spawn"] call ALIVE_fnc_profileEntity;
-                        };
-                        case "vehicle": {
-                            [_profile, "spawn"] call ALIVE_fnc_profileVehicle;
-                        };
-                };
-            };
-
-            sleep 0.05;
-
-            // DEBUG -------------------------------------------------------------------------------------
-            if(_debug) then {
-                //["----------------------------------------------------------------------------------------"] call ALIVE_fnc_dump;
-                //["ALIVE Profile spawner - spawn [%1]",_profileID] call ALIVE_fnc_dump;
-            };
-            // DEBUG -------------------------------------------------------------------------------------
-
-        };
-    }
-} forEach (_profiles select 2);
+//hint format ["Spawning: %1 \n\nDespawning: %2\n\ninNonDespawnRange: %3", _profilesToSpawnQueue, _profilesToDespawnQueue, _inNonDespawnRange];

--- a/addons/sys_profile/fnc_profileSpawner.sqf
+++ b/addons/sys_profile/fnc_profileSpawner.sqf
@@ -21,6 +21,8 @@ Author:
 SpyderBlack723
 ---------------------------------------------------------------------------- */
 
+if (ALiVE_gamePaused) exitwith {};
+
 _this = _this select 0;
 
 if ([MOD(profileSystem),"paused"] call ALiVE_fnc_hashGet) exitwith {
@@ -127,8 +129,7 @@ if (_spawnSources isEqualTo []) then {
     // avoid unnecessary work
     // delete spawn sources that are in close proximity
     // ie. treat squads/nearby units as a single spawn source
-
-    if (count _spawnSources > 10) {
+    if (count _spawnSources > 10) then {
         {
             private _source = _x;
 
@@ -163,7 +164,7 @@ if !(_spawnSources isEqualTo []) then {
         };
     };
 
-    private _profilesInDeactivationRange = [_center,_radius * 1.2] call ALiVE_fnc_getNearProfiles;
+    private _profilesInDeactivationRange = [_center,_radius * 1.2, ["all","all"], true] call ALiVE_fnc_getNearProfiles;
     {
         // don't spawn or despawn player profiles
         if (!([_x,"isPlayer", false] call ALiVE_fnc_hashGet)) then {

--- a/addons/sys_profile/fnc_profileSpawner.sqf
+++ b/addons/sys_profile/fnc_profileSpawner.sqf
@@ -23,12 +23,12 @@ SpyderBlack723
 
 _this = _this select 0;
 
-if ([ALiVE_profileSystem,"paused"] call ALiVE_fnc_hashGet) exitwith {
-	private _profilesToSpawnQueue = [ALiVE_profileSystem,"profilesToSpawn"] call ALiVE_fnc_hashGet;
-	private _profilesToDespawnQueue = [ALiVE_profileSystem,"profilesToDespawn"] call ALiVE_fnc_hashGet;
+if ([MOD(profileSystem),"paused"] call ALiVE_fnc_hashGet) exitwith {
+    private _profilesToSpawnQueue = [MOD(profileSystem),"profilesToSpawn"] call ALiVE_fnc_hashGet;
+    private _profilesToDespawnQueue = [MOD(profileSystem),"profilesToDespawn"] call ALiVE_fnc_hashGet;
 
-	_profilesToSpawnQueue resize 0;
-	_profilesToDespawnQueue resize 0;
+    _profilesToSpawnQueue resize 0;
+    _profilesToDespawnQueue resize 0;
 };
 
 private _spawnRadius = _this select 0;
@@ -38,23 +38,23 @@ private _activeLimiter = _this select 3;
 
 private _uavSpawnRadius = _spawnRadius + 800;
 
-private _activeProfiles = [ALiVE_profileHandler,"profilesActive"] call ALiVE_fnc_hashGet;
-private _inactiveProfiles = [ALiVE_profileHandler,"profilesInActive"] call ALiVE_fnc_hashGet;
+private _activeProfiles = [MOD(profileHandler),"profilesActive"] call ALiVE_fnc_hashGet;
+private _inactiveProfiles = [MOD(profileHandler),"profilesInActive"] call ALiVE_fnc_hashGet;
 
-private _profilesToSpawnQueue = [ALiVE_profileSystem,"profilesToSpawn"] call ALiVE_fnc_hashGet;
-private _profilesToDespawnQueue = [ALiVE_profileSystem,"profilesToDespawn"] call ALiVE_fnc_hashGet;
-private _lastProfileSpawnedTime = [ALiVE_profileSystem,"profileLastSpawnTime"] call ALiVE_fnc_hashGet;
+private _profilesToSpawnQueue = [MOD(profileSystem),"profilesToSpawn"] call ALiVE_fnc_hashGet;
+private _profilesToDespawnQueue = [MOD(profileSystem),"profilesToDespawn"] call ALiVE_fnc_hashGet;
+private _lastProfileSpawnedTime = [MOD(profileSystem),"profileLastSpawnTime"] call ALiVE_fnc_hashGet;
 
 ///////////////////////////////////////
 //     Spawn/Despawn Profiles
 ///////////////////////////////////////
 
-private _activeEntityCount = count ([ALiVE_profileHandler,"getActiveEntities"] call ALiVE_fnc_profileHandler);
+private _activeEntityCount = count ([MOD(profileHandler),"getActiveEntities"] call ALiVE_fnc_profileHandler);
 
 if !(_profilesToSpawnQueue isEqualTo [] && {time - _lastProfileSpawnedTime > ALiVE_smoothSpawn}) then {
     private _profileID = _profilesToSpawnQueue select 0;
 
-    private _profile = [ALiVE_profileHandler,"getProfile", _profileID] call ALiVE_fnc_profileHandler;
+    private _profile = [MOD(profileHandler),"getProfile", _profileID] call ALiVE_fnc_profileHandler;
 
     if (isnil "_profile" || {_profile select 2 select 1} || {[_profile,"locked", false] call ALiVE_fnc_HashGet}) then {
         // profile no longer exists, is active, or is locked
@@ -69,7 +69,7 @@ if !(_profilesToSpawnQueue isEqualTo [] && {time - _lastProfileSpawnedTime > ALi
                 [_profile,"spawn"] spawn ALiVE_fnc_profileVehicle;
             };
 
-            [ALiVE_profileSystem,"profileLastSpawnTime", time] call ALiVE_fnc_hashSet;
+            [MOD(profileSystem),"profileLastSpawnTime", time] call ALiVE_fnc_hashSet;
 
             _activeProfiles pushback _profileID;
             _inactiveProfiles deleteat (_inactiveProfiles find _profileID);
@@ -79,14 +79,14 @@ if !(_profilesToSpawnQueue isEqualTo [] && {time - _lastProfileSpawnedTime > ALi
 
             if (!(_profile select 2 select 1) && {(_profile select 2 select 5) == "entity"}) then {
                 {
-                    private _vehicleProfile = [ALiVE_profileHandler,"getProfile", _x] call ALiVE_fnc_profileHandler;
+                    private _vehicleProfile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
 
                     if (!isnil "_vehicleProfile") then {
-                        [ALiVE_profileHandler,"unregisterProfile", _vehicleProfile] call ALiVE_fnc_profileHandler;
+                        [MOD(profileHandler),"unregisterProfile", _vehicleProfile] call ALiVE_fnc_profileHandler;
                     };
                 } foreach (_profile select 2 select 8); // "vehiclesInCommandOf"
 
-                [ALiVE_profileHandler,"unregisterProfile", _profile] call ALiVE_fnc_profileHandler;
+                [MOD(profileHandler),"unregisterProfile", _profile] call ALiVE_fnc_profileHandler;
             };
         };
     };
@@ -96,7 +96,7 @@ if !(_profilesToDespawnQueue isEqualTo []) then {
     private _profileID = _profilesToDespawnQueue select 0;
     _profilesToDespawnQueue deleteat 0;
 
-    private _profile = [ALiVE_profileHandler,"getProfile", _profileID] call ALiVE_fnc_profileHandler;
+    private _profile = [MOD(profileHandler),"getProfile", _profileID] call ALiVE_fnc_profileHandler;
 
     if (!isnil "_profile") then {
         private _leader = _profile select 2 select 10;
@@ -119,7 +119,7 @@ if !(_profilesToDespawnQueue isEqualTo []) then {
 // Sort Profiles Set To Spawn/Despawn
 ///////////////////////////////////////
 
-private _spawnSources = [ALiVE_profileSystem,"profileSpawnSources"] call ALiVE_fnc_hashGet;
+private _spawnSources = [MOD(profileSystem),"profileSpawnSources"] call ALiVE_fnc_hashGet;
 if (_spawnSources isEqualTo []) then {
     _spawnSources append allPlayers;
     _spawnSources append (allUnitsUAV select {isUavConnected _x});

--- a/addons/sys_profile/fnc_profileSpawner.sqf
+++ b/addons/sys_profile/fnc_profileSpawner.sqf
@@ -80,22 +80,17 @@ if (_spawnSources isEqualTo []) then {
 
         [MOD(profileSystem),"profilesInSpawnRange", []] call ALiVE_fnc_hashSet;
 
-        _spawnSources append allPlayers;
-        _spawnSources append (allUnitsUAV select {isUavConnected _x});
+        private _spawnSourcesUnfiltered = allPlayers + (allUnitsUAV select {isUavConnected _x});
 
         // avoid unnecessary work
         // delete spawn sources that are in close proximity
         // ie. treat squads/nearby units as a single spawn source
-        if (count _spawnSources > 10) then {
-            {
-                private _source = _x;
 
-                {
-                    if (_x != _source && {_x distance _source < 30}) then {
-                        _spawnSources deleteat (_spawnSources find _x);
-                    };
-                } foreach _spawnSources;
-            } foreach _spawnSources;
+        while {!(_spawnSourcesUnfiltered isEqualTo [])} do {
+            private _spawnSource = _spawnSourcesUnfiltered deleteat 0;
+            _spawnSources pushback _spawnSource;
+
+            _spawnSourcesUnfiltered = _spawnSourcesUnfiltered select {_x distance _spawnSource > 30};
         };
     };
 } else {

--- a/addons/sys_profile/fnc_profileSystem.sqf
+++ b/addons/sys_profile/fnc_profileSystem.sqf
@@ -202,10 +202,13 @@ switch(_operation) do {
             // DEBUG -------------------------------------------------------------------------------------
 
             // start the profile simulator
-            [ALiVE_fnc_profileSimulator, 0, []] call CBA_fnc_addPerFrameHandler;
+            private _profileSimPerFrameID = [ALiVE_fnc_profileSimulator, 0, []] call CBA_fnc_addPerFrameHandler;
 
             // start the profile spawners
-            [ALiVE_fnc_profileSpawner, 0, [_spawnRadius,_spawnTypeHeliRadius,_spawnTypeJetRadius,_activeLimiter]] call CBA_fnc_addPerFrameHandler;
+            private _profileSpawnerPerFrameID = [ALiVE_fnc_profileSpawner, 0, [_spawnRadius,_spawnTypeHeliRadius,_spawnTypeJetRadius,_activeLimiter]] call CBA_fnc_addPerFrameHandler;
+
+            [_logic,"profileSimulatorPerFrameID", _profileSimPerFrameID] call ALiVE_fnc_hashSet;
+            [_logic,"profileSpawnerPerFrameID", _profileSpawnerPerFrameID] call ALiVE_fnc_hashSet;
 
             // if persistent load data
             if(ALIVE_loadProfilesPersistent) then {
@@ -236,6 +239,12 @@ switch(_operation) do {
 
         [_logic, "debug", false] call MAINCLASS;
         if (isServer) then {
+
+            private _profileSimulatorPerFrameID = [_logic,"profileSimulatorPerFrameID"] call ALiVE_fnc_hashGet;
+            private _profileSpawnerPerFrameID = [_logic,"profileSpawnerPerFrameID"] call ALiVE_fnc_hashGet;
+
+            _profileSimulatorPerFrameID call CBA_fnc_removePerFrameHandler;
+            _profileSpawnerPerFrameID call CBA_fnc_removePerFrameHandler;
 
             _profileSimulatorFSM = [_logic, "simulator_FSM"] call ALiVE_fnc_HashGet;
             _profileSimulatorFSM setFSMVariable ["_destroy",true];

--- a/addons/sys_profile/fnc_profileSystem.sqf
+++ b/addons/sys_profile/fnc_profileSystem.sqf
@@ -80,6 +80,7 @@ switch(_operation) do {
 
             [_logic,"profilesToSpawn", []] call ALiVE_fnc_hashSet;
             [_logic,"profilesToDespawn", []] call ALiVE_fnc_hashSet;
+            [_logic,"profilesInSpawnRange", []] call ALiVE_fnc_hashSet;
             [_logic,"profileSpawnSources", []] call ALiVE_fnc_hashSet;
             [_logic,"profileLastSpawnTime", 0] call ALiVE_fnc_hashSet;
 

--- a/addons/sys_profile/fnc_profileSystem.sqf
+++ b/addons/sys_profile/fnc_profileSystem.sqf
@@ -71,6 +71,8 @@ switch(_operation) do {
             [_logic,"despawnCycleTime",1] call ALIVE_fnc_hashSet;
             [_logic,"speedModifier",1] call ALIVE_fnc_hashSet;
 
+			[_logic,"paused", false] call ALiVE_fnc_hashSet;
+
             [_logic,"profilesToSpawn", []] call ALiVE_fnc_hashSet;
             [_logic,"profilesToDespawn", []] call ALiVE_fnc_hashSet;
             [_logic,"profileSpawnSources", []] call ALiVE_fnc_hashSet;
@@ -86,8 +88,8 @@ switch(_operation) do {
     case "start": {
 
         private["_debug","_persistent","_plotSectors","_syncMode","_syncedUnits","_spawnRadius","_spawnTypeJetRadius","_spawnTypeHeliRadius",
-        "_activeLimiter","_spawnCycleTime","_despawnCycleTime","_combatRate","_profileSimulatorFSM","_profileSpawnerFSMEast","_profileSpawnerFSMWest",
-        "_profileSpawnerFSMGuer","_profileSpawnerFSMCiv","_sectors","_persistent","_file"];
+        "_activeLimiter","_spawnCycleTime","_despawnCycleTime","_combatRate","_profileSimulatorFSM",
+        "_sectors","_persistent","_file"];
 
         if (isServer) then {
 
@@ -205,19 +207,6 @@ switch(_operation) do {
             [ALiVE_fnc_profileSpawner, 0, [_spawnRadius,_spawnTypeHeliRadius,_spawnTypeJetRadius,_activeLimiter]] call CBA_fnc_addPerFrameHandler;
             ///////
 
-            /*
-            // version 2.1 spawner system
-            _profileSpawnerFSMEast = [_logic,"EAST",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
-            _profileSpawnerFSMWest = [_logic,"WEST",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
-            _profileSpawnerFSMGuer = [_logic,"GUER",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
-            _profileSpawnerFSMCiv = [_logic,"CIV",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
-
-            [_logic,"spawner_FSMEast",_profileSpawnerFSMEast] call ALIVE_fnc_hashSet;
-            [_logic,"spawner_FSMWest",_profileSpawnerFSMWest] call ALIVE_fnc_hashSet;
-            [_logic,"spawner_FSMGuer",_profileSpawnerFSMGuer] call ALIVE_fnc_hashSet;
-            [_logic,"spawner_FSMCiv",_profileSpawnerFSMCiv] call ALIVE_fnc_hashSet;
-            */
-
             // if persistent load data
             if(ALIVE_loadProfilesPersistent) then {
                 call ALIVE_fnc_profilesLoadData;
@@ -244,25 +233,13 @@ switch(_operation) do {
 
         case "destroy": {
 
-                private ["_profileSimulatorFSM","_profileSpawnerFSMEast","_profileSpawnerFSMWest","_profileSpawnerFSMGuer","_profileSpawnerFSMCiv"];
+                private ["_profileSimulatorFSM"];
 
                 [_logic, "debug", false] call MAINCLASS;
                 if (isServer) then {
 
                     _profileSimulatorFSM = [_logic, "simulator_FSM"] call ALiVE_fnc_HashGet;
                     _profileSimulatorFSM setFSMVariable ["_destroy",true];
-
-                    _profileSpawnerFSMEast = [_logic, "spawner_FSMEast"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMEast setFSMVariable ["_destroy",true];
-
-                    _profileSpawnerFSMWest = [_logic, "spawner_FSMWest"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMWest setFSMVariable ["_destroy",true];
-
-                    _profileSpawnerFSMGuer = [_logic, "spawner_FSMGuer"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMGuer setFSMVariable ["_destroy",true];
-
-                    _profileSpawnerFSMCiv = [_logic, "spawner_FSMCiv"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMCiv setFSMVariable ["_destroy",true];
 
                     [ALIVE_commandRouter, "pause", true] call ALIVE_fnc_commandRouter;
                     [ALIVE_liveAnalysis, "pause", true] call ALIVE_fnc_liveAnalysis;
@@ -301,17 +278,7 @@ switch(_operation) do {
                     _profileSimulatorFSM = [_logic, "simulator_FSM"] call ALiVE_fnc_HashGet;
                     _profileSimulatorFSM setFSMVariable ["_pause",true];
 
-                    _profileSpawnerFSMEast = [_logic, "spawner_FSMEast"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMEast setFSMVariable ["_pause",true];
-
-                    _profileSpawnerFSMWest = [_logic, "spawner_FSMWest"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMWest setFSMVariable ["_pause",true];
-
-                    _profileSpawnerFSMGuer = [_logic, "spawner_FSMGuer"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMGuer setFSMVariable ["_pause",true];
-
-                    _profileSpawnerFSMCiv = [_logic, "spawner_FSMCiv"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMCiv setFSMVariable ["_pause",true];
+					[_logic,"paused", true] call ALiVE_fnc_hashSet;
 
                     [ALIVE_commandRouter, "pause", true] call ALIVE_fnc_commandRouter;
                     [ALIVE_liveAnalysis, "pause", true] call ALIVE_fnc_liveAnalysis;
@@ -321,17 +288,7 @@ switch(_operation) do {
                     _profileSimulatorFSM = [_logic, "simulator_FSM"] call ALiVE_fnc_HashGet;
                     _profileSimulatorFSM setFSMVariable ["_pause",false];
 
-                    _profileSpawnerFSMEast = [_logic, "spawner_FSMEast"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMEast setFSMVariable ["_pause",false];
-
-                    _profileSpawnerFSMWest = [_logic, "spawner_FSMWest"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMWest setFSMVariable ["_pause",false];
-
-                    _profileSpawnerFSMGuer = [_logic, "spawner_FSMGuer"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMGuer setFSMVariable ["_pause",false];
-
-                    _profileSpawnerFSMCiv = [_logic, "spawner_FSMCiv"] call ALiVE_fnc_HashGet;
-                    _profileSpawnerFSMCiv setFSMVariable ["_pause",false];
+					[_logic,"paused", false] call ALiVE_fnc_hashSet;
 
                     [ALIVE_commandRouter, "pause", false] call ALIVE_fnc_commandRouter;
                     [ALIVE_liveAnalysis, "pause", false] call ALIVE_fnc_liveAnalysis;

--- a/addons/sys_profile/fnc_profileSystem.sqf
+++ b/addons/sys_profile/fnc_profileSystem.sqf
@@ -49,183 +49,187 @@ _result = true;
 #define MTEMPLATE "ALiVE_PROFILESYSTEM_%1"
 
 switch(_operation) do {
-        case "init": {
-                if (isServer) then {
-                        // if server, initialise module game logic
-                        [_logic,"super",SUPERCLASS] call ALIVE_fnc_hashSet;
-                        [_logic,"class",MAINCLASS] call ALIVE_fnc_hashSet;
-                        [_logic,"moduleType","ALIVE_profileHandler"] call ALIVE_fnc_hashSet;
-                        [_logic,"startupComplete",false] call ALIVE_fnc_hashSet;
-                        //TRACE_1("After module init",_logic);
+    case "init": {
+        if (isServer) then {
+            // if server, initialise module game logic
+            [_logic,"super",SUPERCLASS] call ALIVE_fnc_hashSet;
+            [_logic,"class",MAINCLASS] call ALIVE_fnc_hashSet;
+            [_logic,"moduleType","ALIVE_profileHandler"] call ALIVE_fnc_hashSet;
+            [_logic,"startupComplete",false] call ALIVE_fnc_hashSet;
+            //TRACE_1("After module init",_logic);
 
-                        [_logic,"debug",false] call ALIVE_fnc_hashSet;
-                        [_logic,"persistent",false] call ALIVE_fnc_hashSet;
-                        [_logic,"plotSectors",false] call ALIVE_fnc_hashSet;
-                        [_logic,"syncMode","ADD"] call ALIVE_fnc_hashSet;
-                        [_logic,"syncedUnits",[]] call ALIVE_fnc_hashSet;
-                        [_logic,"spawnRadius",1000] call ALIVE_fnc_hashSet;
-                        [_logic,"spawnTypeJetRadius",1000] call ALIVE_fnc_hashSet;
-                        [_logic,"spawnTypeHeliRadius",1000] call ALIVE_fnc_hashSet;
-                        [_logic,"activeLimiter",30] call ALIVE_fnc_hashSet;
-                        [_logic,"spawnCycleTime",1] call ALIVE_fnc_hashSet;
-                        [_logic,"despawnCycleTime",1] call ALIVE_fnc_hashSet;
-                        [_logic,"speedModifier",1] call ALIVE_fnc_hashSet;
+            [_logic,"debug",false] call ALIVE_fnc_hashSet;
+            [_logic,"persistent",false] call ALIVE_fnc_hashSet;
+            [_logic,"plotSectors",false] call ALIVE_fnc_hashSet;
+            [_logic,"syncMode","ADD"] call ALIVE_fnc_hashSet;
+            [_logic,"syncedUnits",[]] call ALIVE_fnc_hashSet;
+            [_logic,"spawnRadius",1000] call ALIVE_fnc_hashSet;
+            [_logic,"spawnTypeJetRadius",1000] call ALIVE_fnc_hashSet;
+            [_logic,"spawnTypeHeliRadius",1000] call ALIVE_fnc_hashSet;
+            [_logic,"activeLimiter",30] call ALIVE_fnc_hashSet;
+            [_logic,"spawnCycleTime",1] call ALIVE_fnc_hashSet;
+            [_logic,"despawnCycleTime",1] call ALIVE_fnc_hashSet;
+            [_logic,"speedModifier",1] call ALIVE_fnc_hashSet;
 
-                };
+            // create spacial grid
+            private _spacialGridProfiles = [nil,"create", [[-2000,-2000], worldsize + 4000, 1000]] call alive_fnc_spacialGrid;
+            [_logic,"spacialGridProfiles", _spacialGridProfiles] call ALiVE_fnc_hashSet;
         };
-        case "start": {
+    };
 
-                private["_debug","_persistent","_plotSectors","_syncMode","_syncedUnits","_spawnRadius","_spawnTypeJetRadius","_spawnTypeHeliRadius",
-                "_activeLimiter","_spawnCycleTime","_despawnCycleTime","_combatRate","_profileSimulatorFSM","_profileSpawnerFSMEast","_profileSpawnerFSMWest",
-                "_profileSpawnerFSMGuer","_profileSpawnerFSMCiv","_sectors","_persistent","_file"];
+    case "start": {
 
-                if (isServer) then {
+        private["_debug","_persistent","_plotSectors","_syncMode","_syncedUnits","_spawnRadius","_spawnTypeJetRadius","_spawnTypeHeliRadius",
+        "_activeLimiter","_spawnCycleTime","_despawnCycleTime","_combatRate","_profileSimulatorFSM","_profileSpawnerFSMEast","_profileSpawnerFSMWest",
+        "_profileSpawnerFSMGuer","_profileSpawnerFSMCiv","_sectors","_persistent","_file"];
 
-                        _debug = [_logic,"debug",false] call ALIVE_fnc_hashGet;
-                        _persistent = [_logic,"persistent",false] call ALIVE_fnc_hashGet;
-                        _plotSectors = [_logic,"plotSectors",false] call ALIVE_fnc_hashGet;
-                        _syncMode = [_logic,"syncMode","ADD"] call ALIVE_fnc_hashGet;
-                        _syncedUnits = [_logic,"syncedUnits",[]] call ALIVE_fnc_hashGet;
-                        _spawnRadius = [_logic,"spawnRadius"] call ALIVE_fnc_hashGet;
-                        _spawnTypeJetRadius = [_logic,"spawnTypeJetRadius"] call ALIVE_fnc_hashGet;
-                        _spawnTypeHeliRadius = [_logic,"spawnTypeHeliRadius"] call ALIVE_fnc_hashGet;
-                        _activeLimiter = [_logic,"activeLimiter"] call ALIVE_fnc_hashGet;
-                        _spawnCycleTime = [_logic,"spawnCycleTime"] call ALIVE_fnc_hashGet;
-                        _despawnCycleTime = [_logic,"despawnCycleTime"] call ALIVE_fnc_hashGet;
-                        _combatRate = [_logic,"combatRate"] call ALIVE_fnc_hashGet;
-                        _smoothSpawn = [_logic,"smoothSpawn"] call ALIVE_fnc_hashGet;
-                        
-                        // set smoothSpawn value
-                        ALiVE_smoothSpawn = _smoothSpawn;
+        if (isServer) then {
 
-                        // set global profiles persistent var
-                        ALIVE_loadProfilesPersistent = _persistent;
-                        ALIVE_saveProfilesPersistent = _persistent;
+            _debug = [_logic,"debug",false] call ALIVE_fnc_hashGet;
+            _persistent = [_logic,"persistent",false] call ALIVE_fnc_hashGet;
+            _plotSectors = [_logic,"plotSectors",false] call ALIVE_fnc_hashGet;
+            _syncMode = [_logic,"syncMode","ADD"] call ALIVE_fnc_hashGet;
+            _syncedUnits = [_logic,"syncedUnits",[]] call ALIVE_fnc_hashGet;
+            _spawnRadius = [_logic,"spawnRadius"] call ALIVE_fnc_hashGet;
+            _spawnTypeJetRadius = [_logic,"spawnTypeJetRadius"] call ALIVE_fnc_hashGet;
+            _spawnTypeHeliRadius = [_logic,"spawnTypeHeliRadius"] call ALIVE_fnc_hashGet;
+            _activeLimiter = [_logic,"activeLimiter"] call ALIVE_fnc_hashGet;
+            _spawnCycleTime = [_logic,"spawnCycleTime"] call ALIVE_fnc_hashGet;
+            _despawnCycleTime = [_logic,"despawnCycleTime"] call ALIVE_fnc_hashGet;
+            _combatRate = [_logic,"combatRate"] call ALIVE_fnc_hashGet;
+            _smoothSpawn = [_logic,"smoothSpawn"] call ALIVE_fnc_hashGet;
 
-                        // DEBUG -------------------------------------------------------------------------------------
-                        if(_debug) then {
-                            ["----------------------------------------------------------------------------------------"] call ALIVE_fnc_dump;
-                            ["ALIVE ProfileSystem - Startup"] call ALIVE_fnc_dump;
-                        };
-                        // DEBUG -------------------------------------------------------------------------------------
+            // set smoothSpawn value
+            ALiVE_smoothSpawn = _smoothSpawn;
 
-                        // load static data
-                        call ALiVE_fnc_staticDataHandler;
+            // set global profiles persistent var
+            ALIVE_loadProfilesPersistent = _persistent;
+            ALIVE_saveProfilesPersistent = _persistent;
 
-                        // global server flag
-                        ALIVE_profileSystemDataLoaded = true;
+            // DEBUG -------------------------------------------------------------------------------------
+            if(_debug) then {
+                ["----------------------------------------------------------------------------------------"] call ALIVE_fnc_dump;
+                ["ALIVE ProfileSystem - Startup"] call ALIVE_fnc_dump;
+            };
+            // DEBUG -------------------------------------------------------------------------------------
 
-                        // create the profile handler
-                        ALIVE_profileHandler = [nil, "create"] call ALIVE_fnc_profileHandler;
-                        [ALIVE_profileHandler, "init"] call ALIVE_fnc_profileHandler;
+            // load static data
+            call ALiVE_fnc_staticDataHandler;
 
-                        // create profile combat handler
-                        ALIVE_profileCombatHandler = [nil,"create"] call ALIVE_fnc_profileCombatHandler;
-                        [ALIVE_profileCombatHandler,"init"] call ALIVE_fnc_profileCombatHandler;
-                        [ALIVE_profileCombatHandler,"debug", _debug] call ALIVE_fnc_profileCombatHandler;
-                        [ALIVE_profileCombatHandler,"combatRate", _combatRate] call ALIVE_fnc_profileCombatHandler;
+            // global server flag
+            ALIVE_profileSystemDataLoaded = true;
 
-                        // create sector grid
-                        ALIVE_sectorGrid = [nil, "create"] call ALIVE_fnc_sectorGrid;
-                        [ALIVE_sectorGrid, "init"] call ALIVE_fnc_sectorGrid;
-                        [ALIVE_sectorGrid, "createGrid"] call ALIVE_fnc_sectorGrid;
+            // create the profile handler
+            ALIVE_profileHandler = [nil, "create"] call ALIVE_fnc_profileHandler;
+            [ALIVE_profileHandler, "init"] call ALIVE_fnc_profileHandler;
 
-                        // create sector plotter
-                        ALIVE_sectorPlotter = [nil, "create"] call ALIVE_fnc_plotSectors;
-                        [ALIVE_sectorPlotter, "init"] call ALIVE_fnc_plotSectors;
+            // create profile combat handler
+            ALIVE_profileCombatHandler = [nil,"create"] call ALIVE_fnc_profileCombatHandler;
+            [ALIVE_profileCombatHandler,"init"] call ALIVE_fnc_profileCombatHandler;
+            [ALIVE_profileCombatHandler,"debug", _debug] call ALIVE_fnc_profileCombatHandler;
+            [ALIVE_profileCombatHandler,"combatRate", _combatRate] call ALIVE_fnc_profileCombatHandler;
 
-                        // import static map analysis to the grid
-                        [ALIVE_sectorGrid] call ALIVE_fnc_gridImportStaticMapAnalysis;
+            // create sector grid
+            ALIVE_sectorGrid = [nil, "create"] call ALIVE_fnc_sectorGrid;
+            [ALIVE_sectorGrid, "init"] call ALIVE_fnc_sectorGrid;
+            [ALIVE_sectorGrid, "createGrid"] call ALIVE_fnc_sectorGrid;
 
-                        // create live analysis
-                        ALIVE_liveAnalysis = [nil, "create"] call ALIVE_fnc_liveAnalysis;
-                        [ALIVE_liveAnalysis, "init"] call ALIVE_fnc_liveAnalysis;
-                        [ALIVE_liveAnalysis, "debug", false] call ALIVE_fnc_liveAnalysis;
+            // create sector plotter
+            ALIVE_sectorPlotter = [nil, "create"] call ALIVE_fnc_plotSectors;
+            [ALIVE_sectorPlotter, "init"] call ALIVE_fnc_plotSectors;
 
-                        // create battlefield analysis
-                        ALIVE_battlefieldAnalysis = [nil, "create"] call ALIVE_fnc_battlefieldAnalysis;
-                        [ALIVE_battlefieldAnalysis, "init"] call ALIVE_fnc_battlefieldAnalysis;
-                        [ALIVE_battlefieldAnalysis, "debug", false] call ALIVE_fnc_battlefieldAnalysis;
+            // import static map analysis to the grid
+            [ALIVE_sectorGrid] call ALIVE_fnc_gridImportStaticMapAnalysis;
 
-                        // create profiles for all players that dont have profiles
-                        ["INIT"] call ALIVE_fnc_createProfilesFromPlayers;
+            // create live analysis
+            ALIVE_liveAnalysis = [nil, "create"] call ALIVE_fnc_liveAnalysis;
+            [ALIVE_liveAnalysis, "init"] call ALIVE_fnc_liveAnalysis;
+            [ALIVE_liveAnalysis, "debug", false] call ALIVE_fnc_liveAnalysis;
 
-                        // create profiles for all map units that dont have profiles
-                        [_syncMode, _syncedUnits, false] call ALIVE_fnc_createProfilesFromUnits;
+            // create battlefield analysis
+            ALIVE_battlefieldAnalysis = [nil, "create"] call ALIVE_fnc_battlefieldAnalysis;
+            [ALIVE_battlefieldAnalysis, "init"] call ALIVE_fnc_battlefieldAnalysis;
+            [ALIVE_battlefieldAnalysis, "debug", false] call ALIVE_fnc_battlefieldAnalysis;
 
-                        // turn on debug again to see the state of the profile handler, and set debug on all a profiles
-                        [ALIVE_profileHandler, "debug", _debug] call ALIVE_fnc_profileHandler;
+            // create profiles for all players that dont have profiles
+            ["INIT"] call ALIVE_fnc_createProfilesFromPlayers;
 
-                        // create array block stepper
-                        ALIVE_arrayBlockHandler = [nil, "create"] call ALIVE_fnc_arrayBlockHandler;
-                        [ALIVE_arrayBlockHandler, "init"] call ALIVE_fnc_arrayBlockHandler;
+            // create profiles for all map units that dont have profiles
+            [_syncMode, _syncedUnits, false] call ALIVE_fnc_createProfilesFromUnits;
 
-                        // create command router
-                        ALIVE_commandRouter = [nil, "create"] call ALIVE_fnc_commandRouter;
-                        [ALIVE_commandRouter, "init"] call ALIVE_fnc_commandRouter;
-                        [ALIVE_commandRouter, "debug", false] call ALIVE_fnc_commandRouter;
+            // turn on debug again to see the state of the profile handler, and set debug on all a profiles
+            [ALIVE_profileHandler, "debug", _debug] call ALIVE_fnc_profileHandler;
+
+            // create array block stepper
+            ALIVE_arrayBlockHandler = [nil, "create"] call ALIVE_fnc_arrayBlockHandler;
+            [ALIVE_arrayBlockHandler, "init"] call ALIVE_fnc_arrayBlockHandler;
+
+            // create command router
+            ALIVE_commandRouter = [nil, "create"] call ALIVE_fnc_commandRouter;
+            [ALIVE_commandRouter, "init"] call ALIVE_fnc_commandRouter;
+            [ALIVE_commandRouter, "debug", false] call ALIVE_fnc_commandRouter;
+
+            // DEBUG -------------------------------------------------------------------------------------
+            if(_debug) then {
+                ["ALIVE ProfileSystem - Startup completed"] call ALIVE_fnc_dump;
+                ["ALIVE Sector grid created"] call ALIVE_fnc_dump;
+                ["ALIVE Profile handler created"] call ALIVE_fnc_dump;
+                ["ALIVE Map units converted to profiles"] call ALIVE_fnc_dump;
+                ["ALIVE Simulation controller created"] call ALIVE_fnc_dump;
+                ["ALIVE Spawn controller created"] call ALIVE_fnc_dump;
+                ["ALIVE Active Limit: %1", _activeLimiter] call ALIVE_fnc_dump;
+                ["ALIVE Spawn Radius: %1", _spawnRadius] call ALIVE_fnc_dump;
+                ["ALIVE Spawn in Jet Radius: %1",_spawnTypeJetRadius] call ALIVE_fnc_dump;
+                ["ALIVE Spawn in Heli Radius: %1",_spawnTypeHeliRadius] call ALIVE_fnc_dump;
+                ["ALIVE Spawn Cycle Time: %1", _spawnCycleTime] call ALIVE_fnc_dump;
+                ["ALIVE Persistent: %1",_persistent] call ALIVE_fnc_dump;
+                ["----------------------------------------------------------------------------------------"] call ALIVE_fnc_dump;
+            };
+            // DEBUG -------------------------------------------------------------------------------------
 
 
-                        // DEBUG -------------------------------------------------------------------------------------
-                        if(_debug) then {
-                            ["ALIVE ProfileSystem - Startup completed"] call ALIVE_fnc_dump;
-                            ["ALIVE Sector grid created"] call ALIVE_fnc_dump;
-                            ["ALIVE Profile handler created"] call ALIVE_fnc_dump;
-                            ["ALIVE Map units converted to profiles"] call ALIVE_fnc_dump;
-                            ["ALIVE Simulation controller created"] call ALIVE_fnc_dump;
-                            ["ALIVE Spawn controller created"] call ALIVE_fnc_dump;
-                            ["ALIVE Active Limit: %1", _activeLimiter] call ALIVE_fnc_dump;
-                            ["ALIVE Spawn Radius: %1", _spawnRadius] call ALIVE_fnc_dump;
-                            ["ALIVE Spawn in Jet Radius: %1",_spawnTypeJetRadius] call ALIVE_fnc_dump;
-                            ["ALIVE Spawn in Heli Radius: %1",_spawnTypeHeliRadius] call ALIVE_fnc_dump;
-                            ["ALIVE Spawn Cycle Time: %1", _spawnCycleTime] call ALIVE_fnc_dump;
-                            ["ALIVE Persistent: %1",_persistent] call ALIVE_fnc_dump;
-                            ["----------------------------------------------------------------------------------------"] call ALIVE_fnc_dump;
-                        };
-                        // DEBUG -------------------------------------------------------------------------------------
+            // start the profile simulator
+            //_profileSimulatorFSM = [_logic] execFSM "\x\alive\addons\sys_profile\profileSimulator_v2.fsm";
+            _profileSimulatorFSM = [_logic] execFSM "\x\alive\addons\sys_profile\profileSimulator.fsm";
+            [_logic,"simulator_FSM",_profileSimulatorFSM] call ALIVE_fnc_hashSet;
 
+            // start the profile spawners
 
-                        // start the profile simulator
-                        //_profileSimulatorFSM = [_logic] execFSM "\x\alive\addons\sys_profile\profileSimulator_v2.fsm";
-                        _profileSimulatorFSM = [_logic] execFSM "\x\alive\addons\sys_profile\profileSimulator.fsm";
-                        [_logic,"simulator_FSM",_profileSimulatorFSM] call ALIVE_fnc_hashSet;
+            // version 2.1 spawner system
+            _profileSpawnerFSMEast = [_logic,"EAST",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
+            _profileSpawnerFSMWest = [_logic,"WEST",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
+            _profileSpawnerFSMGuer = [_logic,"GUER",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
+            _profileSpawnerFSMCiv = [_logic,"CIV",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
 
-                        // start the profile spawners
+            [_logic,"spawner_FSMEast",_profileSpawnerFSMEast] call ALIVE_fnc_hashSet;
+            [_logic,"spawner_FSMWest",_profileSpawnerFSMWest] call ALIVE_fnc_hashSet;
+            [_logic,"spawner_FSMGuer",_profileSpawnerFSMGuer] call ALIVE_fnc_hashSet;
+            [_logic,"spawner_FSMCiv",_profileSpawnerFSMCiv] call ALIVE_fnc_hashSet;
 
-                        // version 2.1 spawner system
-                        _profileSpawnerFSMEast = [_logic,"EAST",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
-                        _profileSpawnerFSMWest = [_logic,"WEST",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
-                        _profileSpawnerFSMGuer = [_logic,"GUER",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
-                        _profileSpawnerFSMCiv = [_logic,"CIV",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
+            // if persistent load data
+            if(ALIVE_loadProfilesPersistent) then {
+                call ALIVE_fnc_profilesLoadData;
+            };
 
-                        [_logic,"spawner_FSMEast",_profileSpawnerFSMEast] call ALIVE_fnc_hashSet;
-                        [_logic,"spawner_FSMWest",_profileSpawnerFSMWest] call ALIVE_fnc_hashSet;
-                        [_logic,"spawner_FSMGuer",_profileSpawnerFSMGuer] call ALIVE_fnc_hashSet;
-                        [_logic,"spawner_FSMCiv",_profileSpawnerFSMCiv] call ALIVE_fnc_hashSet;
+            // global server flag
+            ALIVE_profileSystemInit = true;
 
-                        // if persistent load data
-                        if(ALIVE_loadProfilesPersistent) then {
-                            call ALIVE_fnc_profilesLoadData;
-                        };
+            // set modules as started
+            [_logic,"startupComplete",true] call ALIVE_fnc_hashSet;
 
-                        // global server flag
-                        ALIVE_profileSystemInit = true;
+            // register profile entity analysis job on the live analysis
+            // analysis job will run every 90 seconds and has no run count limit
+            [ALIVE_liveAnalysis, "registerAnalysisJob", [90, 0, "gridProfileEntity", "gridProfileEntity", [_plotSectors]]] call ALIVE_fnc_liveAnalysis;
 
-                        // set modules as started
-                        [_logic,"startupComplete",true] call ALIVE_fnc_hashSet;
+            // register player analysis job on the live analysis
+            // analysis job will run every 10 seconds and has no run count limit
+            [ALIVE_liveAnalysis, "registerAnalysisJob", [15, 0, "activeSectors", "activeSectors", [_plotSectors]]] call ALIVE_fnc_liveAnalysis;
 
-                        // register profile entity analysis job on the live analysis
-                        // analysis job will run every 90 seconds and has no run count limit
-                        [ALIVE_liveAnalysis, "registerAnalysisJob", [90, 0, "gridProfileEntity", "gridProfileEntity", [_plotSectors]]] call ALIVE_fnc_liveAnalysis;
-
-                        // register player analysis job on the live analysis
-                        // analysis job will run every 10 seconds and has no run count limit
-                        [ALIVE_liveAnalysis, "registerAnalysisJob", [15, 0, "activeSectors", "activeSectors", [_plotSectors]]] call ALIVE_fnc_liveAnalysis;
-
-                        // start analysis jobs
-                        [ALIVE_liveAnalysis, "start"] call ALIVE_fnc_liveAnalysis;
-                };
+            // start analysis jobs
+            [ALIVE_liveAnalysis, "start"] call ALIVE_fnc_liveAnalysis;
         };
+    };
+
         case "destroy": {
 
                 private ["_profileSimulatorFSM","_profileSpawnerFSMEast","_profileSpawnerFSMWest","_profileSpawnerFSMGuer","_profileSpawnerFSMCiv"];
@@ -353,7 +357,7 @@ switch(_operation) do {
                 ASSERT_TRUE(typeName _args == "BOOL",str _args);
 
                 _result = _args;
-        };        
+        };
         case "plotSectors": {
                 if(typeName _args != "BOOL") then {
                         _args = [_logic,"plotSectors"] call ALIVE_fnc_hashGet;

--- a/addons/sys_profile/fnc_profileSystem.sqf
+++ b/addons/sys_profile/fnc_profileSystem.sqf
@@ -274,18 +274,12 @@ switch(_operation) do {
 
         if(_args) then {
 
-            _profileSimulatorFSM = [_logic, "simulator_FSM"] call ALiVE_fnc_HashGet;
-            _profileSimulatorFSM setFSMVariable ["_pause",true];
-
             [_logic,"paused", true] call ALiVE_fnc_hashSet;
 
             [ALIVE_commandRouter, "pause", true] call ALIVE_fnc_commandRouter;
             [ALIVE_liveAnalysis, "pause", true] call ALIVE_fnc_liveAnalysis;
 
         }else{
-
-            _profileSimulatorFSM = [_logic, "simulator_FSM"] call ALiVE_fnc_HashGet;
-            _profileSimulatorFSM setFSMVariable ["_pause",false];
 
             [_logic,"paused", false] call ALiVE_fnc_hashSet;
 

--- a/addons/sys_profile/fnc_profileSystem.sqf
+++ b/addons/sys_profile/fnc_profileSystem.sqf
@@ -71,8 +71,14 @@ switch(_operation) do {
             [_logic,"despawnCycleTime",1] call ALIVE_fnc_hashSet;
             [_logic,"speedModifier",1] call ALIVE_fnc_hashSet;
 
+            [_logic,"profilesToSpawn", []] call ALiVE_fnc_hashSet;
+            [_logic,"profilesToDespawn", []] call ALiVE_fnc_hashSet;
+            [_logic,"profileSpawnSources", []] call ALiVE_fnc_hashSet;
+            [_logic,"profileLastSpawnTime", 0] call ALiVE_fnc_hashSet;
+
             // create spacial grid
-            private _spacialGridProfiles = [nil,"create", [[-2000,-2000], worldsize + 4000, 1000]] call alive_fnc_spacialGrid;
+			private _worldSize = [ALiVE_mapBounds,worldname, worldsize] call ALiVE_fnc_hashGet;
+            private _spacialGridProfiles = [nil,"create", [[-3000,-3000], _worldSize + 6000, 1000]] call ALiVE_fnc_spacialGrid;
             [_logic,"spacialGridProfiles", _spacialGridProfiles] call ALiVE_fnc_hashSet;
         };
     };
@@ -195,6 +201,11 @@ switch(_operation) do {
 
             // start the profile spawners
 
+            ///////
+            [ALiVE_fnc_profileSpawner, 0, [_spawnRadius,_spawnTypeHeliRadius,_spawnTypeJetRadius,_activeLimiter]] call CBA_fnc_addPerFrameHandler;
+            ///////
+
+            /*
             // version 2.1 spawner system
             _profileSpawnerFSMEast = [_logic,"EAST",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
             _profileSpawnerFSMWest = [_logic,"WEST",_spawnRadius,_spawnTypeJetRadius,_spawnTypeHeliRadius,_spawnCycleTime,_activeLimiter] execFSM "\x\alive\addons\sys_profile\profileSpawner_v2_1.fsm";
@@ -205,6 +216,7 @@ switch(_operation) do {
             [_logic,"spawner_FSMWest",_profileSpawnerFSMWest] call ALIVE_fnc_hashSet;
             [_logic,"spawner_FSMGuer",_profileSpawnerFSMGuer] call ALIVE_fnc_hashSet;
             [_logic,"spawner_FSMCiv",_profileSpawnerFSMCiv] call ALIVE_fnc_hashSet;
+            */
 
             // if persistent load data
             if(ALIVE_loadProfilesPersistent) then {

--- a/addons/sys_profile/fnc_profileVehicle.sqf
+++ b/addons/sys_profile/fnc_profileVehicle.sqf
@@ -305,6 +305,10 @@ switch(_operation) do {
                         };
 
                         if!(((_args select 0) + (_args select 1)) == 0) then {
+                            private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
+
+                            private _currPos = _logic select 2 select 2;
+                            [_spacialGrid,"move", [_currPos, _args, _logic]] call ALiVE_fnc_spacialGrid;
 
                             [_logic,"position",_args] call ALIVE_fnc_hashSet;
 
@@ -439,7 +443,7 @@ switch(_operation) do {
                         [_entityProfile,_logic] call ALIVE_fnc_removeProfileVehicleAssignment;
                     };
                 } foreach (_entitiesInCommandOf + _entitiesInCargoOf);
-                
+
                 // reset data
                 [_logic,"vehicleAssignments",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
                 [_logic,"entitiesInCommandOf",[]] call ALIVE_fnc_hashSet;
@@ -777,7 +781,8 @@ switch(_operation) do {
                         [_logic] call ALIVE_fnc_vehicleAssignmentsToProfileVehicleAssignments;
 
                         // update profile before despawn
-                        [_logic,"position", getposATL _vehicle] call ALIVE_fnc_hashSet;
+                        //[_logic,"position", getposATL _vehicle] call ALIVE_fnc_hashSet;
+                        [_logic,"position", getposATL _vehicle] call MAINCLASS;
                         [_logic,"despawnPosition", getposATL _vehicle] call ALIVE_fnc_hashSet;
                         [_logic,"direction", getDir _vehicle] call ALIVE_fnc_hashSet;
                         [_logic,"damage", _vehicle call ALIVE_fnc_vehicleGetDamage] call ALIVE_fnc_hashSet;

--- a/addons/sys_profile/fnc_profileVehicle.sqf
+++ b/addons/sys_profile/fnc_profileVehicle.sqf
@@ -100,26 +100,731 @@ _result = true;
 
 #define MTEMPLATE "ALiVE_PROFILEVEHICLE_%1"
 
-_deleteMarkers = {
-        private ["_logic"];
-        _logic = _this;
+switch (_operation) do {
+
+    case "init": {
+        /*
+        MODEL - no visual just reference data
+        - nodes
+        - center
+        - size
+        */
+
+        if (isServer) then {
+            // if server, initialise module game logic
+            // nil these out they add a lot of code to the hash..
+            [_logic,"super"] call ALIVE_fnc_hashRem;
+            [_logic,"class"] call ALIVE_fnc_hashRem;
+            //TRACE_1("After module init",_logic);
+
+            // init the super class
+            [_logic, "init"] call SUPERCLASS;
+
+            // set defaults
+            [_logic,"type","vehicle"] call ALIVE_fnc_hashSet;
+            [_logic,"entitiesInCommandOf",[]] call ALIVE_fnc_hashSet;   // select 2 select 8
+            [_logic,"entitiesInCargoOf",[]] call ALIVE_fnc_hashSet;     // select 2 select 9
+            [_logic,"vehicle",objNull] call ALIVE_fnc_hashSet;          // select 2 select 10
+            [_logic,"vehicleClass",""] call ALIVE_fnc_hashSet;          // select 2 select 11
+            [_logic,"direction",""] call ALIVE_fnc_hashSet;             // select 2 select 12
+            [_logic,"fuel",1] call ALIVE_fnc_hashSet;                   // select 2 select 13
+            [_logic,"ammo",[]] call ALIVE_fnc_hashSet;                  // select 2 select 14
+            [_logic,"engineOn",false] call ALIVE_fnc_hashSet;           // select 2 select 15
+            [_logic,"damage",[]] call ALIVE_fnc_hashSet;                // select 2 select 16
+            [_logic,"canMove",true] call ALIVE_fnc_hashSet;             // select 2 select 17
+            [_logic,"canFire",true] call ALIVE_fnc_hashSet;             // select 2 select 18
+            [_logic,"needReload",0] call ALIVE_fnc_hashSet;             // select 2 select 19
+            [_logic,"despawnPosition",[0,0]] call ALIVE_fnc_hashSet;    // select 2 select 20
+            [_logic,"hasSimulated",false] call ALIVE_fnc_hashSet;       // select 2 select 21
+            [_logic,"spawnType",[]] call ALIVE_fnc_hashSet;             // select 2 select 22
+            [_logic,"faction",""] call ALIVE_fnc_hashSet;               // select 2 select 23
+            [_logic,"_rev",""] call ALIVE_fnc_hashSet;                  // select 2 select 24
+            [_logic,"_id",""] call ALIVE_fnc_hashSet;                   // select 2 select 25
+            [_logic,"busy",false] call ALIVE_fnc_hashSet;               // select 2 select 26
+            [_logic,"cargo",[]] call ALIVE_fnc_hashSet;                 // select 2 select 27
+            [_logic,"slingload",[]] call ALIVE_fnc_hashSet;             // select 2 select 28
+            [_logic,"slung",[]] call ALIVE_fnc_hashSet;                 // select 2 select 28
+        };
+
+        /*
+        VIEW - purely visual
+        */
+
+        /*
+        CONTROLLER  - coordination
+        */
+    };
+
+    case "debug": {
+        if (_args isEqualType true) then {
+            [_logic,"debug", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"debug"] call ALIVE_fnc_hashGet;
+        };
+
+        [_logic,"deleteMarkers"] call MAINCLASS;
+
+        if (_args) then {
+            [_logic,"createMarkers"] call MAINCLASS;
+        };
+
+        _result = _args;
+    };
+
+    case "active": {
+        if (_args isEqualType true) then {
+            [_logic,"active", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"active"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "profileID": {
+        if (_args isEqualType "") then {
+            [_logic,"profileID", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"profileID"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "side": {
+        if (_args isEqualType "") then {
+            [_logic,"side", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"side"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "faction": {
+        if (_args isEqualType "") then {
+            [_logic,"faction", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"faction"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "objectType": {
+        if (_args isEqualType "") then {
+            [_logic,"objectType", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"objectType"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "vehicleClass": {
+        if (_args isEqualType "") then {
+            [_logic,"vehicleClass", _args] call ALIVE_fnc_hashSet;
+            [_logic,"objectType", _args call ALIVE_fnc_vehicleGetKindOf] call ALIVE_fnc_hashSet;
+        } else {
+            _result = _logic select 2 select 11; //[_logic,"vehicleClass"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "position": {
+        if (_args isEqualType []) then {
+
+            if (count _args == 2) then  {
+                _args pushback 0;
+            };
+
+            if !(((_args select 0) + (_args select 1)) == 0) then {
+                private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
+
+                private _currPos = _logic select 2 select 2;
+                [_spacialGrid,"move", [_currPos, _args, _logic]] call ALiVE_fnc_spacialGrid;
+
+                [_logic,"position",_args] call ALIVE_fnc_hashSet;
+
+                if ([_logic,"debug"] call ALIVE_fnc_hashGet) then {
+                    [_logic,"debug", true] call MAINCLASS;
+                };
+
+                //["VEHICLE %1 position: %2",_logic select 2 select 4,_args] call ALIVE_fnc_dump;
+
+                // store position on handler position index
+                _profileID = _logic select 2 select 4; //[_logic,"profileID"] call ALIVE_fnc_hashGet;
+                [ALIVE_profileHandler, "setPosition", [_profileID, _args]] call ALIVE_fnc_profileHandler;
+
+            };
+        } else {
+            _result = [_logic,"position"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "despawnPosition": {
+        if (_args isEqualType []) then {
+            [_logic,"despawnPosition", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"despawnPosition"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "direction": {
+        if (_args isEqualType 0) then {
+            [_logic,"direction", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"direction"] call ALIVE_fnc_hashGet;
+        };
+    };
+    case
+    "damage": {
+        if (_args isEqualType []) then {
+            [_logic,"damage", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"damage"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "fuel": {
+        if (_args isEqualType 0) then {
+            [_logic,"fuel", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"fuel"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "ammo": {
+        if (_args isEqualType []) then {
+            [_logic,"ammo", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"ammo"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "engineOn": {
+        if (_args isEqualType true) then {
+            [_logic,"engineOn", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"engineOn"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "canFire": {
+        if (_args isEqualType true) then {
+            [_logic,"canFire", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"canFire"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "canMove": {
+        if (_args isEqualType true) then {
+            [_logic,"canMove", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"canMove"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "needReload": {
+        if (_args isEqualType 0) then {
+            [_logic,"needReload", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"needReload"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "vehicle": {
+        if (_args isEqualType objnull) then {
+            [_logic,"vehicle", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"vehicle"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "spawnType": {
+        if (_args isEqualType []) then {
+            [_logic,"spawnType", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"spawnType"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "busy": {
+        if (_args isEqualType true) then {
+            [_logic,"busy", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"busy"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "cargo": {
+        if (_args isEqualType []) then {
+            [_logic,"cargo", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"cargo"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "slingload": {
+        if (_args isEqualType []) then {
+            [_logic,"slingload", _args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"slingload"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "slung": {
+        if (_args isEqualType []) then {
+            [_logic,"slung",_args] call ALIVE_fnc_hashSet;
+        } else {
+            _result = [_logic,"slung"] call ALIVE_fnc_hashGet;
+        };
+    };
+
+    case "addVehicleAssignment": {
+        private ["_assignments","_key","_units","_unit","_group"];
+
+        if ((typeName _args == "ARRAY") && {!(isnil {_args select 1})}) then {
+                _assignments = _logic select 2 select 7; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
+                _key = _args select 1;
+                [_assignments, _key, _args] call ALIVE_fnc_hashSet;
+
+                // take assignments and determine if this entity is in command of any of them
+                [_logic,"entitiesInCommandOf",[_assignments,_logic] call ALIVE_fnc_profileVehicleAssignmentsGetInCommand] call ALIVE_fnc_hashSet;
+
+                // take assignments and determine if this entity is in cargo of any of them
+                [_logic,"entitiesInCargoOf",[_assignments,_logic] call ALIVE_fnc_profileVehicleAssignmentsGetInCargo] call ALIVE_fnc_hashSet;
+        };
+    };
+
+    case "clearVehicleAssignments": {
+        // remove this vehicle from referenced entities
+        private _entitiesInCommandOf = [_logic,"entitiesInCommandOf",[]] call ALIVE_fnc_hashGet;
+        private _entitiesInCargoOf = [_logic,"entitiesInCargoOf",[]] call ALIVE_fnc_hashGet;
+
         {
-                deleteMarker _x;
-        } forEach ([_logic,"debugMarkers", []] call ALIVE_fnc_hashGet);
-};
+            private _entityProfile = [ALiVE_ProfileHandler,"getProfile", _x] call ALIVE_fnc_ProfileHandler;
 
-_createMarkers = {
-        private ["_logic","_markers","_m","_position","_profileID","_debugColor","_debugIcon","_debugAlpha","_profileSide","_vehicleType","_profileActive","_typePrefix"];
-        _logic = _this;
-        _markers = [];
+            if (!isnil "_entityProfile") then {
+                [_entityProfile,_logic] call ALIVE_fnc_removeProfileVehicleAssignment;
+            };
+        } foreach (_entitiesInCommandOf + _entitiesInCargoOf);
 
-        _position = [_logic,"position"] call ALIVE_fnc_hashGet;
-        _profileID = [_logic,"profileID"] call ALIVE_fnc_hashGet;
-        _profileSide = [_logic,"side"] call ALIVE_fnc_hashGet;
-        _vehicleType = [_logic,"objectType"] call ALIVE_fnc_hashGet;
-        _profileActive = [_logic,"active"] call ALIVE_fnc_hashGet;
+        // reset data
+        [_logic,"vehicleAssignments", [] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
+        [_logic,"entitiesInCommandOf", []] call ALIVE_fnc_hashSet;
+        [_logic,"entitiesInCargoOf", []] call ALIVE_fnc_hashSet;
+    };
 
-        switch(_profileSide) do {
+    case "mergePositions": {
+        private _profileID = _logic select 2 select 4;      //[_logic,"profileID"] call ALIVE_fnc_hashGet;
+        private _position = _logic select 2 select 2;       //[_logic,"position"] call ALIVE_fnc_hashGet;
+        private _assignments = _logic select 2 select 7;    //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
+
+        //["VEHICLE %1 mergePosition: %2",_logic select 2 select 4,_position] call ALIVE_fnc_dump;
+
+        if (count (_assignments select 1) > 0) then {
+            [_assignments,_position] call ALIVE_fnc_profileVehicleAssignmentsSetAllPositions;
+        };
+    };
+
+    case "spawn": {
+        private ["_debug","_side","_vehicleClass","_vehicleType","_position","_side","_direction","_damage",
+        "_fuel","_ammo","_engineOn","_profileID","_active","_vehicleAssignments","_cargo","_cargoItems","_special","_vehicle","_eventID",
+        "_speed","_velocity","_paraDrop","_parachute","_soundFlyover","_locked","_slingload","_slinging"];
+
+        _debug = _logic select 2 select 0; //[_logic,"debug"] call ALIVE_fnc_hashGet;
+        _vehicleClass = _logic select 2 select 11; //[_logic,"vehicleClass"] call ALIVE_fnc_hashGet;
+        _vehicleType = _logic select 2 select 6; //[_logic,"objectType"] call ALIVE_fnc_hashGet;
+        _position = _logic select 2 select 2; //[_logic,"position"] call ALIVE_fnc_hashGet;
+        _side = _logic select 2 select 3; //[_logic,"side"] call ALIVE_fnc_hashGet;
+        _direction = _logic select 2 select 12; //[_logic,"direction"] call ALIVE_fnc_hashGet;
+        _damage = _logic select 2 select 16; //[_logic,"damage"] call ALIVE_fnc_hashGet;
+        _fuel = _logic select 2 select 13; //[_logic,"fuel"] call ALIVE_fnc_hashGet;
+        _ammo = _logic select 2 select 14; //[_logic,"ammo"] call ALIVE_fnc_hashGet;
+        _engineOn = _logic select 2 select 15; //[_logic,"engineOn"] call ALIVE_fnc_hashGet;
+        _profileID = _logic select 2 select 4; //[_logic,"profileID"] call ALIVE_fnc_hashGet;
+        _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet;
+        _vehicleAssignments = _logic select 2 select 7; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
+        _cargo = _logic select 2 select 27; //[_logic,"cargo"] call ALIVE_fnc_hashGet;
+
+        _slingload = [_logic, "slingload", []] call ALIVE_fnc_HashGet; //unindexed: _slingload = _logic select 2 select 28;
+        _slung = [_logic, "slung", []] call ALIVE_fnc_HashGet; //unindexed: _slung = _logic select 2 select 29;
+        _paraDrop = false;
+
+        _locked = [_logic, "locked",false] call ALIVE_fnc_HashGet;
+
+        // not already active and spawning has not yet been triggered
+        if (!_active && {!_locked}) then {
+
+            //Indicate spawn has been triggered and lock profile during spawn in case it is an asynchronous call
+            [_logic, "locked",true] call ALIVE_fnc_HashSet;
+
+            // determine a suitable spawn position
+            //["Profile [%1] Spawn - Get good spawn position",_profileID] call ALIVE_fnc_dump;
+            //[true] call ALIVE_fnc_timer;
+            [_logic] call ALIVE_fnc_profileGetGoodSpawnPosition;
+            _position = _logic select 2 select 2; //[_entityProfile,"position"] call ALIVE_fnc_hashGet;
+            _special = "NONE";
+            //[] call ALIVE_fnc_timer;
+
+            //["SPAWN VEHICLE [%1] pos: %2",_profileID,_position] call ALIVE_fnc_dump;
+
+            // spawn the unit
+            if (_vehicleType == "Helicopter" || {_vehicleType == "Plane"}) then {
+                if(_engineOn) then {
+                    _special = "FLY";
+
+                    // Place them high enough so they don't crash
+                    if ((_position select 2) < 50) then {_position set [2,300]};
+                    if (_debug) then {
+                        ["SPAWN VEHICLE IN AIR [%1] pos: %2",_profileID,_position] call ALIVE_fnc_dump;
+                    };
+
+                }else{
+                    _special = "CAN_COLLIDE";
+
+                    // Check to see if placed on carrier/ship
+                    if !([_position] call ALiVE_fnc_nearShip) then {
+                        _position set [2,0];
+                    } else {
+                       // _special = "NONE";
+                        if (_debug) then {
+                            ["SPAWN VEHICLE ON SHIP [%1] pos: %2",_profileID,_position] call ALIVE_fnc_dump;
+                        };
+                    };
+                };
+            } else {
+
+                if ((_position select 2) > 300) then {
+                    _paraDrop = true;
+
+                }else{
+                    //_position = [_position, 0, 50, 5, 0, 5 , 0, [], [_position]] call BIS_fnc_findSafePos;
+
+                    _position set [2,0];
+                    //_special = "CAN_COLLIDE";
+                };
+            };
+
+            _vehicle = createVehicle [_vehicleClass, _position, [], 0, _special];
+            //_vehicle setPos _position;
+            _vehicle setDir _direction;
+            _vehicle setFuel _fuel;
+            _vehicle engineOn _engineOn;
+            //_vehicle setVehicleVarName _profileID;
+
+            if(count _cargo > 0) then {
+                _cargoItems = [];
+                _cargoItems = _cargoItems + _cargo;
+                [ALiVE_SYS_LOGISTICS,"fillContainer",[_vehicle,_cargoItems]] call ALiVE_fnc_Logistics;
+            };
+
+            // Profile is being slung by another profile
+            If (_debug) then {
+                ["VEHICLE %3 slingload: %1 slung: %2", _slingload, _slung, _profileID] call ALiVE_fnc_dump;
+            };
+
+            if(count _slingload > 0) then {
+
+                private ["_slingloadClass","_slingloadVehicle"];
+
+                If (_debug) then {
+                    ["SPAWNING SLINGLOAD VEHICLE %1 should be carrying %2", _profileID, _slingload] call ALiVE_fnc_dump;
+                };
+
+                _slinging = false;
+                _slingLoadClass = _slingload select 0;
+
+                if (typeName _slingLoadClass == "STRING") then {
+
+                    _slingloadVehicle = createvehicle [_slingLoadClass, position _vehicle ,[],100,"none"];
+                    _cargoItems = [];
+                    _cargoItems = _cargoItems + (_slingload select 1);
+                    if (count _cargoItems > 0) then {
+                        [ALiVE_SYS_LOGISTICS,"fillContainer",[_slingloadVehicle,_cargoItems]] call ALiVE_fnc_Logistics;
+                    };
+                    _slinging = _vehicle setSlingLoad _slingloadVehicle;
+
+                } else {
+
+                    // Another profile is being slingloaded
+                    if (typeName _slingLoadClass == "ARRAY") then {
+                        // Profile is being slung by another profile
+                        If (_debug) then {
+                            ["HELI WILL TRY TO SLINGLOAD %1", _slingloadClass select 0] call ALiVE_fnc_dump;
+                        };
+
+                        private _slingloadProfile = [ALIVE_profileHandler, "getProfile", _slingloadClass select 0] call ALIVE_fnc_profileHandler;
+
+                        if (!isNil "_slingloadProfile") then {
+                            private _slActive = _slingLoadProfile select 2 select 1;
+
+                            if (typeName _slActive == "BOOL" && _slActive) then {
+                                // Attach the slingload to the vehicle
+                                _slinging = _vehicle setSlingLoad (_slingloadProfile select 2 select 10); // if profile is active, then slingload vehicle
+
+                                if (!_slinging) then {
+                                    If (_debug) then {
+                                        ["%1 FAILED ATTACH %2", _profileID, (_slingloadProfile select 2 select 10)] call ALiVE_fnc_dump;
+                                    };
+                                    [_logic, "slingloading", false] call ALIVE_fnc_hashSet;
+                                    [_logic, "slingload", []] call ALIVE_fnc_profileVehicle;
+                                    [_slingloadProfile,"slung",[]] call ALIVE_fnc_profileVehicle;
+                                };
+                            };
+                            if (typeName _slActive == "BOOL" && !_slActive) then {
+                                [_slingloadProfile,"spawn"] spawn ALIVE_fnc_profileVehicle;
+                            };
+                        } else {
+                            If (_debug) then {
+                                ["%1 FAILED ATTACH AS TARGET DESTROYED?", _profileID] call ALiVE_fnc_dump;
+                            };
+                            [_logic, "slingloading", false] call ALIVE_fnc_hashSet;
+                            [_logic, "slingload", []] call ALIVE_fnc_profileVehicle;
+                        };
+
+                    };
+                };
+
+                If (_debug) then {
+                    ["SLINGLOAD VEHICLE %1 is slinging %2 : ", _profileID, _slinging, getSlingLoad _vehicle] call ALiVE_fnc_dump;
+                };
+
+                if (_slinging) then {
+                    [_logic, "slingloading", true] call ALIVE_fnc_hashSet;
+                } else {
+                    [_logic, "slingloading", false] call ALIVE_fnc_hashSet;
+                };
+            };
+
+            if(count _slung > 0) then {
+                private ["_slingloadClass","_slungActive"];
+
+                If (_debug) then {
+                    ["SPAWNING SLINGLOADED VEHICLE %1 - to be slung by %2", _profileID, _slung] call ALiVE_fnc_dump;
+                };
+
+                _slungActive = false;
+                _slingLoadClass = _slung select 0;
+
+                if (typeName _slingLoadClass == "ARRAY") then {
+
+                    _slingloadClass = [ALIVE_profileHandler, "getProfile", _slingloadClass select 0] call ALIVE_fnc_profileHandler;
+                    private "_slActive";
+                    _slActive = _slingLoadClass select 2 select 1;
+                    _slingloading = [_slingLoadClass,"slinging",false] call ALIVE_fnc_hashGet;
+
+                    if (typeName _slActive == "BOOL" && _slActive && !_slingloading) then {
+                        If (_debug) then {
+                            ["ATTEMPTING TO ATTACH VEHICLE %1 (%3) to %2", _profileID, _slingloadClass select 2 select 4, _vehicle] call ALiVE_fnc_dump;
+                        };
+                        _slungActive = (_slingloadClass select 2 select 10) setSlingLoad _vehicle; // if profile is active, then slingload vehicle
+
+                         if (!_slungActive) then {
+                            If (_debug) then {
+                                ["FAILED ATTACH %1", getSlingLoad (_slingloadClass select 2 select 10)] call ALiVE_fnc_dump;
+                            };
+                             // Something went wrong, remove slingloading info from profiles
+                            [_slingloadClass, "slingloading", false] call ALIVE_fnc_hashSet;
+                            [_slingloadClass, "slingload", []] call ALIVE_fnc_profileVehicle;
+                            [_logic,"slung",[]] call ALIVE_fnc_profileVehicle;
+                        };
+                    };
+                    If (_debug) then {
+                        ["SLINGLOADED VEHICLE %1 is being slung %2 : %3", _profileID, _slungActive, getSlingLoad (_slingloadClass select 2 select 10)] call ALiVE_fnc_dump;
+                    };
+                };
+
+                if (_slungActive) then {
+                    [_slingloadClass, "slingloading", true] call ALIVE_fnc_hashSet;
+                    [_logic,"spawnType",["preventDespawn"]] call ALIVE_fnc_profileVehicle;
+                } else {
+                    [_slingloadClass, "slingloading", false] call ALIVE_fnc_hashSet;
+                };
+            };
+
+            if(_paraDrop) then {
+                _parachute = createvehicle ["B_Parachute_02_F",position _vehicle ,[],0,"none"];
+                _vehicle attachto [_parachute,[0,0,(abs ((boundingbox _vehicle select 0) select 2))]];
+
+                _parachute setpos position _vehicle;
+                _parachute setdir direction _vehicle;
+                _parachute setvelocity [0,0,-1];
+
+                if (time - (missionnamespace getvariable ["bis_fnc_curatorobjectedited_paraSoundTime",0]) > 0) then {
+                    _soundFlyover = selectRandom ["BattlefieldJet1","BattlefieldJet2"];
+                    [_parachute,_soundFlyover,"say3d"] remoteExec ["bis_fnc_sayMessage"];
+                    missionnamespace setvariable ["bis_fnc_curatorobjectedited_paraSoundTime",time + 10]
+                };
+
+                [_vehicle,_parachute] spawn {
+                    _vehicle = _this select 0;
+                    _parachute = _this select 1;
+
+                    waituntil {isnull _parachute || isnull _vehicle};
+                    _vehicle setdir direction _vehicle;
+                    deletevehicle _parachute;
+                };
+            };
+
+            if(_engineOn && {_vehicleType == "Plane"}) then {
+                _speed = 200;
+                _vehicle setVelocity [(sin _direction*_speed), (cos _direction*_speed),0.1];
+            };
+
+
+            if(count _damage > 0) then {
+                [_vehicle, _damage] call ALIVE_fnc_vehicleSetDamage;
+            };
+
+            if(count _ammo > 0) then {
+                [_vehicle, _ammo] call ALIVE_fnc_vehicleSetAmmo;
+            };
+
+            // set profile id on the unit
+            _vehicle setVariable ["profileID", _profileID];
+
+            // killed event handler
+            _eventID = _vehicle addMPEventHandler["MPKilled", ALIVE_fnc_profileKilledEventHandler];
+
+            // getin event handler
+            _vehicle addEventHandler ["getIn", ALIVE_fnc_profileGetInEventHandler];
+
+            // set profile as active and store a reference to the unit on the profile
+            [_logic,"vehicle",_vehicle] call ALIVE_fnc_hashSet;
+            [_logic,"active",true] call ALIVE_fnc_hashSet;
+
+            // create vehicle assignments from profile vehicle assignments
+            [_vehicleAssignments, _logic] call ALIVE_fnc_profileVehicleAssignmentsToVehicleAssignments;
+
+            // store the profile id on the active profiles index
+            [ALIVE_profileHandler,"setActive",[_profileID,_side,_logic]] call ALIVE_fnc_profileHandler;
+
+            // DEBUG -------------------------------------------------------------------------------------
+            if(_debug) then {
+                //["Profile [%1] Spawn - class: %2 type: %3 pos: %4",_profileID,_vehicleClass,_vehicleType,_position] call ALIVE_fnc_dump;
+                [_logic,"debug",true] call MAINCLASS;
+            };
+            // DEBUG -------------------------------------------------------------------------------------
+        };
+    };
+
+    case "despawn": {
+        private _vehicleDespawnType = [_logic,"spawnType",[]] call ALiVE_fnc_hashGet;
+        private _despawnPrevented = if (count _vehicleDespawnType > 0 && {_vehicleDespawnType select 0 == "preventDespawn"}) then {true} else {false};
+
+        // if not already inactive
+        private _active = _logic select 2 select 1;
+        if(_active) then {
+
+            // if any linked profiles have despawn prevented override _despawnPrevented variable
+            private _linked = [_logic] call ALIVE_fnc_vehicleAssignmentsGetLinkedProfiles;
+            if (count (_linked select 1) > 1) then {
+                {
+                    private _spawnType = [_x,"spawnType"] call ALIVE_fnc_hashGet;
+
+                    if (count _spawnType > 0) then {
+                        if (_spawnType select 0 == "preventDespawn") then {
+                            _despawnPrevented = true;
+                        };
+                    }
+                } forEach (_linked select 2);
+            };
+
+            if (!_despawnPrevented) then {
+
+                [_logic,"active",false] call ALIVE_fnc_hashSet;
+
+                [_logic] call ALIVE_fnc_vehicleAssignmentsToProfileVehicleAssignments;
+
+                // update profile before despawn
+                //[_logic,"position", getposATL _vehicle] call ALIVE_fnc_hashSet;
+                private _vehicle = _logic select 2 select 10;
+
+                [_logic,"position", getposATL _vehicle] call MAINCLASS;
+                [_logic,"despawnPosition", getposATL _vehicle] call ALIVE_fnc_hashSet;
+                [_logic,"direction", getDir _vehicle] call ALIVE_fnc_hashSet;
+                [_logic,"damage", _vehicle call ALIVE_fnc_vehicleGetDamage] call ALIVE_fnc_hashSet;
+                [_logic,"fuel", fuel _vehicle] call ALIVE_fnc_hashSet;
+                [_logic,"ammo", _vehicle call ALIVE_fnc_vehicleGetAmmo] call ALIVE_fnc_hashSet;
+                [_logic,"engineOn", isEngineOn _vehicle] call ALIVE_fnc_hashSet;
+                [_logic,"canFire", canFire _vehicle] call ALIVE_fnc_hashSet;
+                [_logic,"canMove", canMove _vehicle] call ALIVE_fnc_hashSet;
+                [_logic,"needReload", needReload _vehicle] call ALIVE_fnc_hashSet;
+                [_logic,"vehicle",objNull] call ALIVE_fnc_hashSet;
+
+                private _cargo = _logic select 2 select 27;
+                if (count _cargo > 0) then {
+                    [ALiVE_SYS_LOGISTICS,"clearContainer", _vehicle] call ALiVE_fnc_Logistics;
+                };
+
+                private _slingload = [_logic, "slingload", []] call ALIVE_fnc_HashGet;
+                if (count _slingload > 0) then {
+                    private ["_slingloadVehicle"];
+                    _slingloadVehicle = getSlingLoad _vehicle;
+
+                    if (count (_slingload select 1) > 0) then {
+                        [ALiVE_SYS_LOGISTICS,"clearContainer", _slingloadVehicle] call ALiVE_fnc_Logistics;
+                    };
+
+                    _vehicle setSlingLoad objNull;
+                    if (typeName (_slingLoad select 0) == "STRING") then {
+                        deleteVehicle _slingloadVehicle;
+                    };
+                };
+
+                // delete
+                deleteVehicle _vehicle;
+
+                // store the profile id on the in active profiles index
+                private _side = _logic select 2 select 3;
+                private _profileID = _logic select 2 select 4;
+                [ALIVE_profileHandler,"setInActive",[_profileID,_side,_logic]] call ALIVE_fnc_profileHandler;
+
+                // Indicate profile has been despawned and unlock for asynchronous waits
+                [_logic, "locked",false] call ALIVE_fnc_HashSet;
+
+                // DEBUG -------------------------------------------------------------------------------------
+                private _debug = _logic select 2 select 0;
+                if(_debug) then {
+                    //["Profile [%1] Despawn - pos: %2",_profileID,_position] call ALIVE_fnc_dump;
+                    [_logic,"debug",true] call MAINCLASS;
+                };
+                // DEBUG -------------------------------------------------------------------------------------
+
+            };
+        };
+    };
+
+    case "handleDeath": {
+        [_logic,"damage",1] call ALIVE_fnc_hashSet;
+
+        // remove all assignments for this vehicle
+        [_logic] call ALIVE_fnc_removeProfileVehicleAssignments;
+    };
+
+    case "destroy": {
+        private _debug = _logic select 2 select 0;      //[_logic,"debug"] call ALIVE_fnc_hashGet;
+        private _active = _logic select 2 select 1;     //[_logic,"active"] call ALIVE_fnc_hashGet;
+        private _vehicle = _logic select 2 select 10;   //[_logic,"vehicle"] call ALIVE_fnc_hashGet;
+        private _profileID = _logic select 2 select 4;  //[_logic,"profileID"] call ALIVE_fnc_hashGet;
+
+        // DEBUG -------------------------------------------------------------------------------------
+        if(_debug) then {
+            ["Profile [%1] Destroying",_profileID] call ALIVE_fnc_dump;
+        };
+        // DEBUG -------------------------------------------------------------------------------------
+
+        // clear assignments
+        [_logic,"clearVehicleAssignments"] call MAINCLASS;
+
+        // not already inactive
+        if (_active) then {
+
+            // delete
+            deleteVehicle _vehicle;
+        };
+
+        [ALIVE_profileHandler,"unregisterProfile", _logic] call ALIVE_fnc_profileHandler;
+
+        [_logic, "destroy"] call SUPERCLASS;
+    };
+
+    case "createMarkers": {
+        private _debugColor = [_logic,"debugColor","ColorGreen"] call ALIVE_fnc_hashGet;
+        private _typePrefix = "n";
+        switch([_logic,"side"] call ALIVE_fnc_hashGet) do {
             case "EAST":{
                 _debugColor = "ColorRed";
                 _typePrefix = "o";
@@ -136,824 +841,70 @@ _createMarkers = {
                 _debugColor = "ColorGreen";
                 _typePrefix = "n";
             };
-            default {
-                _debugColor = [_logic,"debugColor","ColorGreen"] call ALIVE_fnc_hashGet;
-                _typePrefix = "n";
-            };
         };
 
-        switch(_vehicleType) do {
+        private _debugIcon = switch([_logic,"objectType"] call ALIVE_fnc_hashGet) do {
             case "Car":{
-                _debugIcon = format["%1_recon",_typePrefix];
+                format ["%1_recon",_typePrefix];
             };
             case "Tank":{
-                _debugIcon = format["%1_armor",_typePrefix];
+                format ["%1_armor",_typePrefix];
             };
             case "Armored":{
-                _debugIcon = format["%1_armor",_typePrefix];
+                format ["%1_armor",_typePrefix];
             };
             case "Truck":{
-                _debugIcon = format["%1_recon",_typePrefix];
+                format ["%1_recon",_typePrefix];
             };
             case "Ship":{
-                _debugIcon = format["%1_unknown",_typePrefix];
+                format ["%1_unknown",_typePrefix];
             };
             case "Helicopter":{
-                _debugIcon = format["%1_air",_typePrefix];
+                format ["%1_air",_typePrefix];
             };
             case "Plane":{
-                _debugIcon = format["%1_plane",_typePrefix];
+                format ["%1_plane",_typePrefix];
             };
             case "StaticWeapon":{
-                _debugIcon = format["%1_mortar",_typePrefix];
+                format ["%1_mortar",_typePrefix];
             };
             default {
-                _debugIcon = "hd_dot";
+                "hd_dot"
             };
         };
 
-        _debugAlpha = 0.3;
-        if(_profileActive) then {
-            _debugAlpha = 1;
+        private _debugAlpha = if ([_logic,"active"] call ALIVE_fnc_hashGet) then { 1 } else { 0.3 };
+        private _markers = [];
+
+        private _position = [_logic,"position"] call ALIVE_fnc_hashGet;
+        if (count _position > 0) then {
+            private _profileID = [_logic,"profileID"] call ALIVE_fnc_hashGet;
+
+            private _m = createMarker [format[MTEMPLATE, _profileID], _position];
+            _m setMarkerShape "ICON";
+            _m setMarkerSize [0.6, 0.6];
+            _m setMarkerType _debugIcon;
+            _m setMarkerColor _debugColor;
+            _m setMarkerAlpha _debugAlpha;
+
+            _markers pushback _m;
         };
 
-        if(count _position > 0) then {
-                _m = createMarker [format[MTEMPLATE, _profileID], _position];
-                _m setMarkerShape "ICON";
-                _m setMarkerSize [0.6, 0.6];
-                _m setMarkerType _debugIcon;
-                _m setMarkerColor _debugColor;
-                _m setMarkerAlpha _debugAlpha;
+        [_logic,"debugMarkers",_markers] call ALIVE_fnc_hashSet;
+    };
 
-                _markers pushback _m;
+    case "deleteMarkers": {
+        {
+                deleteMarker _x;
+        } forEach ([_logic,"debugMarkers", []] call ALIVE_fnc_hashGet);
+    };
 
-                [_logic,"debugMarkers",_markers] call ALIVE_fnc_hashSet;
-        };
+    default {
+        _result = [_logic, _operation, _args] call SUPERCLASS;
+    };
+
 };
 
-switch(_operation) do {
-        case "init": {
-                /*
-                MODEL - no visual just reference data
-                - nodes
-                - center
-                - size
-                */
+TRACE_1("profileVehicle - output", _result);
 
-                if (isServer) then {
-                    // if server, initialise module game logic
-                    // nil these out they add a lot of code to the hash..
-                    [_logic,"super"] call ALIVE_fnc_hashRem;
-                    [_logic,"class"] call ALIVE_fnc_hashRem;
-                    //TRACE_1("After module init",_logic);
-
-                    // init the super class
-                    [_logic, "init"] call SUPERCLASS;
-
-                    // set defaults
-                    [_logic,"type","vehicle"] call ALIVE_fnc_hashSet;
-                    [_logic,"entitiesInCommandOf",[]] call ALIVE_fnc_hashSet; // select 2 select 8
-                    [_logic,"entitiesInCargoOf",[]] call ALIVE_fnc_hashSet; // select 2 select 9
-                    [_logic,"vehicle",objNull] call ALIVE_fnc_hashSet; // select 2 select 10
-                    [_logic,"vehicleClass",""] call ALIVE_fnc_hashSet; // select 2 select 11
-                    [_logic,"direction",""] call ALIVE_fnc_hashSet; // select 2 select 12
-                    [_logic,"fuel",1] call ALIVE_fnc_hashSet; // select 2 select 13
-                    [_logic,"ammo",[]] call ALIVE_fnc_hashSet; // select 2 select 14
-                    [_logic,"engineOn",false] call ALIVE_fnc_hashSet; // select 2 select 15
-                    [_logic,"damage",[]] call ALIVE_fnc_hashSet; // select 2 select 16
-                    [_logic,"canMove",true] call ALIVE_fnc_hashSet; // select 2 select 17
-                    [_logic,"canFire",true] call ALIVE_fnc_hashSet; // select 2 select 18
-                    [_logic,"needReload",0] call ALIVE_fnc_hashSet; // select 2 select 19
-                    [_logic,"despawnPosition",[0,0]] call ALIVE_fnc_hashSet; // select 2 select 20
-                    [_logic,"hasSimulated",false] call ALIVE_fnc_hashSet; // select 2 select 21
-                    [_logic,"spawnType",[]] call ALIVE_fnc_hashSet; // select 2 select 22
-                    [_logic,"faction",""] call ALIVE_fnc_hashSet; // select 2 select 23
-                    [_logic,"_rev",""] call ALIVE_fnc_hashSet; // select 2 select 24
-                    [_logic,"_id",""] call ALIVE_fnc_hashSet; // select 2 select 25
-                    [_logic,"busy",false] call ALIVE_fnc_hashSet; // select 2 select 26
-                    [_logic,"cargo",[]] call ALIVE_fnc_hashSet; // select 2 select 27
-                    [_logic,"slingload",[]] call ALIVE_fnc_hashSet; // select 2 select 28
-                    [_logic,"slung",[]] call ALIVE_fnc_hashSet; // select 2 select 28
-                };
-
-                /*
-                VIEW - purely visual
-                */
-
-                /*
-                CONTROLLER  - coordination
-                */
-        };
-        case "debug": {
-                if(typeName _args != "BOOL") then {
-                        _args = [_logic,"debug"] call ALIVE_fnc_hashGet;
-                } else {
-                        [_logic,"debug",_args] call ALIVE_fnc_hashSet;
-                };
-                ASSERT_TRUE(typeName _args == "BOOL",str _args);
-
-                 _logic call _deleteMarkers;
-
-                if(_args) then {
-                        _logic call _createMarkers;
-                };
-
-                _result = _args;
-        };
-        case "active": {
-                if(typeName _args == "BOOL") then {
-                        [_logic,"active",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"active"] call ALIVE_fnc_hashGet;
-        };
-        case "profileID": {
-                if(typeName _args == "STRING") then {
-                        [_logic,"profileID",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"profileID"] call ALIVE_fnc_hashGet;
-        };
-        case "side": {
-                if(typeName _args == "STRING") then {
-                        [_logic,"side",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"side"] call ALIVE_fnc_hashGet;
-        };
-        case "faction": {
-                if(typeName _args == "STRING") then {
-                        [_logic,"faction",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"faction"] call ALIVE_fnc_hashGet;
-        };
-        case "objectType": {
-                if(typeName _args == "STRING") then {
-                        [_logic,"objectType",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"objectType"] call ALIVE_fnc_hashGet;
-        };
-        case "vehicleClass": {
-                if(typeName _args == "STRING") then {
-                        [_logic,"vehicleClass",_args] call ALIVE_fnc_hashSet;
-                        [_logic,"objectType",_args call ALIVE_fnc_vehicleGetKindOf] call ALIVE_fnc_hashSet;
-                };
-                _result = _logic select 2 select 11; //[_logic,"vehicleClass"] call ALIVE_fnc_hashGet;
-        };
-        case "position": {
-                if(typeName _args == "ARRAY") then {
-
-                        if(count _args == 2) then  {
-                            _args pushback 0;
-                        };
-
-                        if!(((_args select 0) + (_args select 1)) == 0) then {
-                            private _spacialGrid = [ALiVE_profileSystem,"spacialGridProfiles"] call ALiVE_fnc_hashGet;
-
-                            private _currPos = _logic select 2 select 2;
-                            [_spacialGrid,"move", [_currPos, _args, _logic]] call ALiVE_fnc_spacialGrid;
-
-                            [_logic,"position",_args] call ALIVE_fnc_hashSet;
-
-                            if([_logic,"debug"] call ALIVE_fnc_hashGet) then {
-                                [_logic,"debug",true] call MAINCLASS;
-                            };
-
-                            //["VEHICLE %1 position: %2",_logic select 2 select 4,_args] call ALIVE_fnc_dump;
-
-                            // store position on handler position index
-                            _profileID = _logic select 2 select 4; //[_logic,"profileID"] call ALIVE_fnc_hashGet;
-                            [ALIVE_profileHandler, "setPosition", [_profileID, _args]] call ALIVE_fnc_profileHandler;
-
-                        };
-                };
-                _result = [_logic,"position"] call ALIVE_fnc_hashGet;
-        };
-        case "despawnPosition": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"despawnPosition",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"despawnPosition"] call ALIVE_fnc_hashGet;
-        };
-        case "direction": {
-                if(typeName _args == "SCALAR") then {
-                        [_logic,"direction",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"direction"] call ALIVE_fnc_hashGet;
-        };
-        case "damage": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"damage",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"damage"] call ALIVE_fnc_hashGet;
-        };
-        case "fuel": {
-                if(typeName _args == "SCALAR") then {
-                        [_logic,"fuel",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"fuel"] call ALIVE_fnc_hashGet;
-        };
-        case "ammo": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"ammo",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"ammo"] call ALIVE_fnc_hashGet;
-        };
-        case "engineOn": {
-                if(typeName _args == "BOOL") then {
-                        [_logic,"engineOn",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"engineOn"] call ALIVE_fnc_hashGet;
-        };
-        case "canFire": {
-                if(typeName _args == "BOOL") then {
-                        [_logic,"canFire",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"canFire"] call ALIVE_fnc_hashGet;
-        };
-        case "canMove": {
-                if(typeName _args == "BOOL") then {
-                        [_logic,"canMove",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"canMove"] call ALIVE_fnc_hashGet;
-        };
-        case "needReload": {
-                if(typeName _args == "SCALAR") then {
-                        [_logic,"needReload",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"needReload"] call ALIVE_fnc_hashGet;
-        };
-        case "vehicle": {
-                if(typeName _args == "OBJECT") then {
-                        [_logic,"vehicle",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"vehicle"] call ALIVE_fnc_hashGet;
-        };
-        case "spawnType": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"spawnType",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"spawnType"] call ALIVE_fnc_hashGet;
-        };
-        case "busy": {
-                if(typeName _args == "BOOL") then {
-                        [_logic,"busy",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"busy"] call ALIVE_fnc_hashGet;
-        };
-        case "cargo": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"cargo",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"cargo"] call ALIVE_fnc_hashGet;
-        };
-        case "slingload": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"slingload",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"slingload"] call ALIVE_fnc_hashGet;
-        };
-        case "slung": {
-                if(typeName _args == "ARRAY") then {
-                        [_logic,"slung",_args] call ALIVE_fnc_hashSet;
-                };
-                _result = [_logic,"slung"] call ALIVE_fnc_hashGet;
-        };
-        case "addVehicleAssignment": {
-                private ["_assignments","_key","_units","_unit","_group"];
-
-                if ((typeName _args == "ARRAY") && {!(isnil {_args select 1})}) then {
-                        _assignments = _logic select 2 select 7; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
-                        _key = _args select 1;
-                        [_assignments, _key, _args] call ALIVE_fnc_hashSet;
-
-                        // take assignments and determine if this entity is in command of any of them
-                        [_logic,"entitiesInCommandOf",[_assignments,_logic] call ALIVE_fnc_profileVehicleAssignmentsGetInCommand] call ALIVE_fnc_hashSet;
-
-                        // take assignments and determine if this entity is in cargo of any of them
-                        [_logic,"entitiesInCargoOf",[_assignments,_logic] call ALIVE_fnc_profileVehicleAssignmentsGetInCargo] call ALIVE_fnc_hashSet;
-                };
-        };
-        case "clearVehicleAssignments": {
-
-                // remove this vehicle from referenced entities
-                private _entitiesInCommandOf = [_logic,"entitiesInCommandOf",[]] call ALIVE_fnc_hashGet;
-                private _entitiesInCargoOf = [_logic,"entitiesInCargoOf",[]] call ALIVE_fnc_hashGet;
-                {
-                    private _entityProfile = [ALiVE_ProfileHandler,"getProfile",_x] call ALIVE_fnc_ProfileHandler;
-
-                    if (!isnil "_entityProfile") then {
-                        [_entityProfile,_logic] call ALIVE_fnc_removeProfileVehicleAssignment;
-                    };
-                } foreach (_entitiesInCommandOf + _entitiesInCargoOf);
-
-                // reset data
-                [_logic,"vehicleAssignments",[] call ALIVE_fnc_hashCreate] call ALIVE_fnc_hashSet;
-                [_logic,"entitiesInCommandOf",[]] call ALIVE_fnc_hashSet;
-                [_logic,"entitiesInCargoOf",[]] call ALIVE_fnc_hashSet;
-        };
-        case "mergePositions": {
-                private ["_position","_assignments"];
-
-                _profileID = _logic select 2 select 4; //[_logic,"profileID"] call ALIVE_fnc_hashGet;
-                _position = _logic select 2 select 2; //[_logic,"position"] call ALIVE_fnc_hashGet;
-                _assignments = _logic select 2 select 7; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
-
-                //["VEHICLE %1 mergePosition: %2",_logic select 2 select 4,_position] call ALIVE_fnc_dump;
-
-                if(count (_assignments select 1) > 0) then {
-                    [_assignments,_position] call ALIVE_fnc_profileVehicleAssignmentsSetAllPositions;
-                };
-        };
-        case "spawn": {
-                private ["_debug","_side","_vehicleClass","_vehicleType","_position","_side","_direction","_damage",
-                "_fuel","_ammo","_engineOn","_profileID","_active","_vehicleAssignments","_cargo","_cargoItems","_special","_vehicle","_eventID",
-                "_speed","_velocity","_paraDrop","_parachute","_soundFlyover","_locked","_slingload","_slinging"];
-
-                _debug = _logic select 2 select 0; //[_logic,"debug"] call ALIVE_fnc_hashGet;
-                _vehicleClass = _logic select 2 select 11; //[_logic,"vehicleClass"] call ALIVE_fnc_hashGet;
-                _vehicleType = _logic select 2 select 6; //[_logic,"objectType"] call ALIVE_fnc_hashGet;
-                _position = _logic select 2 select 2; //[_logic,"position"] call ALIVE_fnc_hashGet;
-                _side = _logic select 2 select 3; //[_logic,"side"] call ALIVE_fnc_hashGet;
-                _direction = _logic select 2 select 12; //[_logic,"direction"] call ALIVE_fnc_hashGet;
-                _damage = _logic select 2 select 16; //[_logic,"damage"] call ALIVE_fnc_hashGet;
-                _fuel = _logic select 2 select 13; //[_logic,"fuel"] call ALIVE_fnc_hashGet;
-                _ammo = _logic select 2 select 14; //[_logic,"ammo"] call ALIVE_fnc_hashGet;
-                _engineOn = _logic select 2 select 15; //[_logic,"engineOn"] call ALIVE_fnc_hashGet;
-                _profileID = _logic select 2 select 4; //[_logic,"profileID"] call ALIVE_fnc_hashGet;
-                _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet;
-                _vehicleAssignments = _logic select 2 select 7; //[_logic,"vehicleAssignments"] call ALIVE_fnc_hashGet;
-                _cargo = _logic select 2 select 27; //[_logic,"cargo"] call ALIVE_fnc_hashGet;
-
-                _slingload = [_logic, "slingload", []] call ALIVE_fnc_HashGet; //unindexed: _slingload = _logic select 2 select 28;
-                _slung = [_logic, "slung", []] call ALIVE_fnc_HashGet; //unindexed: _slung = _logic select 2 select 29;
-                _paraDrop = false;
-
-                _locked = [_logic, "locked",false] call ALIVE_fnc_HashGet;
-
-                // not already active and spawning has not yet been triggered
-                if (!_active && {!_locked}) then {
-
-                    //Indicate spawn has been triggered and lock profile during spawn in case it is an asynchronous call
-                    [_logic, "locked",true] call ALIVE_fnc_HashSet;
-
-                    // determine a suitable spawn position
-                    //["Profile [%1] Spawn - Get good spawn position",_profileID] call ALIVE_fnc_dump;
-                    //[true] call ALIVE_fnc_timer;
-                    [_logic] call ALIVE_fnc_profileGetGoodSpawnPosition;
-                    _position = _logic select 2 select 2; //[_entityProfile,"position"] call ALIVE_fnc_hashGet;
-                    _special = "NONE";
-                    //[] call ALIVE_fnc_timer;
-
-                    //["SPAWN VEHICLE [%1] pos: %2",_profileID,_position] call ALIVE_fnc_dump;
-
-                    // spawn the unit
-                    if (_vehicleType == "Helicopter" || {_vehicleType == "Plane"}) then {
-                        if(_engineOn) then {
-                            _special = "FLY";
-
-                            // Place them high enough so they don't crash
-                            if ((_position select 2) < 50) then {_position set [2,300]};
-                            if (_debug) then {
-                                ["SPAWN VEHICLE IN AIR [%1] pos: %2",_profileID,_position] call ALIVE_fnc_dump;
-                            };
-
-                        }else{
-                            _special = "CAN_COLLIDE";
-
-                            // Check to see if placed on carrier/ship
-                            if !([_position] call ALiVE_fnc_nearShip) then {
-                                _position set [2,0];
-                            } else {
-                               // _special = "NONE";
-                                if (_debug) then {
-                                    ["SPAWN VEHICLE ON SHIP [%1] pos: %2",_profileID,_position] call ALIVE_fnc_dump;
-                                };
-                            };
-                        };
-                    } else {
-
-                        if ((_position select 2) > 300) then {
-                            _paraDrop = true;
-
-                        }else{
-                            //_position = [_position, 0, 50, 5, 0, 5 , 0, [], [_position]] call BIS_fnc_findSafePos;
-
-                            _position set [2,0];
-                            //_special = "CAN_COLLIDE";
-                        };
-                    };
-
-                    _vehicle = createVehicle [_vehicleClass, _position, [], 0, _special];
-                    //_vehicle setPos _position;
-                    _vehicle setDir _direction;
-                    _vehicle setFuel _fuel;
-                    _vehicle engineOn _engineOn;
-                    //_vehicle setVehicleVarName _profileID;
-
-                    if(count _cargo > 0) then {
-                        _cargoItems = [];
-                        _cargoItems = _cargoItems + _cargo;
-                        [ALiVE_SYS_LOGISTICS,"fillContainer",[_vehicle,_cargoItems]] call ALiVE_fnc_Logistics;
-                    };
-
-                    // Profile is being slung by another profile
-                    If (_debug) then {
-                        ["VEHICLE %3 slingload: %1 slung: %2", _slingload, _slung, _profileID] call ALiVE_fnc_dump;
-                    };
-
-                    if(count _slingload > 0) then {
-
-                        private ["_slingloadClass","_slingloadVehicle"];
-
-                        If (_debug) then {
-                            ["SPAWNING SLINGLOAD VEHICLE %1 should be carrying %2", _profileID, _slingload] call ALiVE_fnc_dump;
-                        };
-
-                        _slinging = false;
-                        _slingLoadClass = _slingload select 0;
-
-                        if (typeName _slingLoadClass == "STRING") then {
-
-                            _slingloadVehicle = createvehicle [_slingLoadClass, position _vehicle ,[],100,"none"];
-                            _cargoItems = [];
-                            _cargoItems = _cargoItems + (_slingload select 1);
-                            if (count _cargoItems > 0) then {
-                                [ALiVE_SYS_LOGISTICS,"fillContainer",[_slingloadVehicle,_cargoItems]] call ALiVE_fnc_Logistics;
-                            };
-                            _slinging = _vehicle setSlingLoad _slingloadVehicle;
-
-                        } else {
-
-                            // Another profile is being slingloaded
-                            if (typeName _slingLoadClass == "ARRAY") then {
-                                // Profile is being slung by another profile
-                                If (_debug) then {
-                                    ["HELI WILL TRY TO SLINGLOAD %1", _slingloadClass select 0] call ALiVE_fnc_dump;
-                                };
-
-                                private _slingloadProfile = [ALIVE_profileHandler, "getProfile", _slingloadClass select 0] call ALIVE_fnc_profileHandler;
-
-                                if (!isNil "_slingloadProfile") then {
-                                    private _slActive = _slingLoadProfile select 2 select 1;
-
-                                    if (typeName _slActive == "BOOL" && _slActive) then {
-                                        // Attach the slingload to the vehicle
-                                        _slinging = _vehicle setSlingLoad (_slingloadProfile select 2 select 10); // if profile is active, then slingload vehicle
-
-                                        if (!_slinging) then {
-                                            If (_debug) then {
-                                                ["%1 FAILED ATTACH %2", _profileID, (_slingloadProfile select 2 select 10)] call ALiVE_fnc_dump;
-                                            };
-                                            [_logic, "slingloading", false] call ALIVE_fnc_hashSet;
-                                            [_logic, "slingload", []] call ALIVE_fnc_profileVehicle;
-                                            [_slingloadProfile,"slung",[]] call ALIVE_fnc_profileVehicle;
-                                        };
-                                    };
-                                    if (typeName _slActive == "BOOL" && !_slActive) then {
-                                        [_slingloadProfile,"spawn"] spawn ALIVE_fnc_profileVehicle;
-                                    };
-                                } else {
-                                    If (_debug) then {
-                                        ["%1 FAILED ATTACH AS TARGET DESTROYED?", _profileID] call ALiVE_fnc_dump;
-                                    };
-                                    [_logic, "slingloading", false] call ALIVE_fnc_hashSet;
-                                    [_logic, "slingload", []] call ALIVE_fnc_profileVehicle;
-                                };
-
-                            };
-                        };
-
-                        If (_debug) then {
-                            ["SLINGLOAD VEHICLE %1 is slinging %2 : ", _profileID, _slinging, getSlingLoad _vehicle] call ALiVE_fnc_dump;
-                        };
-
-                        if (_slinging) then {
-                            [_logic, "slingloading", true] call ALIVE_fnc_hashSet;
-                        } else {
-                            [_logic, "slingloading", false] call ALIVE_fnc_hashSet;
-                        };
-                    };
-
-                    if(count _slung > 0) then {
-                        private ["_slingloadClass","_slungActive"];
-
-                        If (_debug) then {
-                            ["SPAWNING SLINGLOADED VEHICLE %1 - to be slung by %2", _profileID, _slung] call ALiVE_fnc_dump;
-                        };
-
-                        _slungActive = false;
-                        _slingLoadClass = _slung select 0;
-
-                        if (typeName _slingLoadClass == "ARRAY") then {
-
-                            _slingloadClass = [ALIVE_profileHandler, "getProfile", _slingloadClass select 0] call ALIVE_fnc_profileHandler;
-                            private "_slActive";
-                            _slActive = _slingLoadClass select 2 select 1;
-                            _slingloading = [_slingLoadClass,"slinging",false] call ALIVE_fnc_hashGet;
-
-                            if (typeName _slActive == "BOOL" && _slActive && !_slingloading) then {
-                                If (_debug) then {
-                                    ["ATTEMPTING TO ATTACH VEHICLE %1 (%3) to %2", _profileID, _slingloadClass select 2 select 4, _vehicle] call ALiVE_fnc_dump;
-                                };
-                                _slungActive = (_slingloadClass select 2 select 10) setSlingLoad _vehicle; // if profile is active, then slingload vehicle
-
-                                 if (!_slungActive) then {
-                                    If (_debug) then {
-                                        ["FAILED ATTACH %1", getSlingLoad (_slingloadClass select 2 select 10)] call ALiVE_fnc_dump;
-                                    };
-                                     // Something went wrong, remove slingloading info from profiles
-                                    [_slingloadClass, "slingloading", false] call ALIVE_fnc_hashSet;
-                                    [_slingloadClass, "slingload", []] call ALIVE_fnc_profileVehicle;
-                                    [_logic,"slung",[]] call ALIVE_fnc_profileVehicle;
-                                };
-                            };
-                            If (_debug) then {
-                                ["SLINGLOADED VEHICLE %1 is being slung %2 : %3", _profileID, _slungActive, getSlingLoad (_slingloadClass select 2 select 10)] call ALiVE_fnc_dump;
-                            };
-                        };
-
-                        if (_slungActive) then {
-                            [_slingloadClass, "slingloading", true] call ALIVE_fnc_hashSet;
-                            [_logic,"spawnType",["preventDespawn"]] call ALIVE_fnc_profileVehicle;
-                        } else {
-                            [_slingloadClass, "slingloading", false] call ALIVE_fnc_hashSet;
-                        };
-                    };
-
-                    if(_paraDrop) then {
-                        _parachute = createvehicle ["B_Parachute_02_F",position _vehicle ,[],0,"none"];
-                        _vehicle attachto [_parachute,[0,0,(abs ((boundingbox _vehicle select 0) select 2))]];
-
-                        _parachute setpos position _vehicle;
-                        _parachute setdir direction _vehicle;
-                        _parachute setvelocity [0,0,-1];
-
-                        if (time - (missionnamespace getvariable ["bis_fnc_curatorobjectedited_paraSoundTime",0]) > 0) then {
-                            _soundFlyover = selectRandom ["BattlefieldJet1","BattlefieldJet2"];
-                            [_parachute,_soundFlyover,"say3d"] remoteExec ["bis_fnc_sayMessage"];
-                            missionnamespace setvariable ["bis_fnc_curatorobjectedited_paraSoundTime",time + 10]
-                        };
-
-                        [_vehicle,_parachute] spawn {
-                            _vehicle = _this select 0;
-                            _parachute = _this select 1;
-
-                            waituntil {isnull _parachute || isnull _vehicle};
-                            _vehicle setdir direction _vehicle;
-                            deletevehicle _parachute;
-                        };
-                    };
-
-                    if(_engineOn && {_vehicleType == "Plane"}) then {
-                        _speed = 200;
-                        _vehicle setVelocity [(sin _direction*_speed), (cos _direction*_speed),0.1];
-                    };
-
-
-                    if(count _damage > 0) then {
-                        [_vehicle, _damage] call ALIVE_fnc_vehicleSetDamage;
-                    };
-
-                    if(count _ammo > 0) then {
-                        [_vehicle, _ammo] call ALIVE_fnc_vehicleSetAmmo;
-                    };
-
-                    // set profile id on the unit
-                    _vehicle setVariable ["profileID", _profileID];
-
-                    // killed event handler
-                    _eventID = _vehicle addMPEventHandler["MPKilled", ALIVE_fnc_profileKilledEventHandler];
-
-                    // getin event handler
-                    _vehicle addEventHandler ["getIn", ALIVE_fnc_profileGetInEventHandler];
-
-                    // set profile as active and store a reference to the unit on the profile
-                    [_logic,"vehicle",_vehicle] call ALIVE_fnc_hashSet;
-                    [_logic,"active",true] call ALIVE_fnc_hashSet;
-
-                    // create vehicle assignments from profile vehicle assignments
-                    [_vehicleAssignments, _logic] call ALIVE_fnc_profileVehicleAssignmentsToVehicleAssignments;
-
-                    // store the profile id on the active profiles index
-                    [ALIVE_profileHandler,"setActive",[_profileID,_side,_logic]] call ALIVE_fnc_profileHandler;
-
-                    // DEBUG -------------------------------------------------------------------------------------
-                    if(_debug) then {
-                        //["Profile [%1] Spawn - class: %2 type: %3 pos: %4",_profileID,_vehicleClass,_vehicleType,_position] call ALIVE_fnc_dump;
-                        [_logic,"debug",true] call MAINCLASS;
-                    };
-                    // DEBUG -------------------------------------------------------------------------------------
-                };
-        };
-        case "despawn": {
-                private ["_debug","_active","_side","_vehicle","_inAir","_profileID","_cargo","_position","_despawnPrevented","_vehicleDespawnType","_linked","_spawnType","_slingload"];
-
-                _debug = _logic select 2 select 0; //[_logic,"debug"] call ALIVE_fnc_hashGet;
-                _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet;
-                _side = _logic select 2 select 3; //[_logic,"side"] call ALIVE_fnc_hashGet;
-                _vehicle = _logic select 2 select 10; //[_logic,"vehicle"] call ALIVE_fnc_hashGet;
-                _profileID = _logic select 2 select 4; //[_logic,"profileID"] call ALIVE_fnc_hashGet;
-                _cargo = _logic select 2 select 27; //[_logic,"cargo"] call ALIVE_fnc_hashGet;
-                _slingload = [_logic, "slingload", []] call ALIVE_fnc_HashGet; //unindexed: _slingload = _logic select 2 select 28;
-                _slung = [_logic, "slung", []] call ALIVE_fnc_HashGet; //unindexed: _slung = _logic select 2 select 29;
-				_vehicleDespawnType = [_logic,"spawnType",[]] call ALiVE_fnc_hashGet;
-                _despawnPrevented = if (count _vehicleDespawnType > 0 && {_vehicleDespawnType select 0 == "preventDespawn"}) then {true} else {false};
-
-                // not already inactive
-                if(_active) then {
-
-                    // if any linked profiles have despawn prevented override _despawnPrevented variable
-                    _linked = [_logic] call ALIVE_fnc_vehicleAssignmentsGetLinkedProfiles;
-                    //_linked call ALIVE_fnc_inspectHash;
-                    if(count (_linked select 1) > 1) then {
-                        {
-                            _spawnType = [_x,"spawnType"] call ALIVE_fnc_hashGet;
-                            if(count _spawnType > 0) then {
-                                if(_spawnType select 0 == "preventDespawn") then {
-                                    _despawnPrevented = true;
-                                };
-                            }
-                        } forEach (_linked select 2);
-                    };
-
-                    if!(_despawnPrevented) then {
-
-                        [_logic,"active",false] call ALIVE_fnc_hashSet;
-
-                        [_logic] call ALIVE_fnc_vehicleAssignmentsToProfileVehicleAssignments;
-
-                        // update profile before despawn
-                        //[_logic,"position", getposATL _vehicle] call ALIVE_fnc_hashSet;
-                        [_logic,"position", getposATL _vehicle] call MAINCLASS;
-                        [_logic,"despawnPosition", getposATL _vehicle] call ALIVE_fnc_hashSet;
-                        [_logic,"direction", getDir _vehicle] call ALIVE_fnc_hashSet;
-                        [_logic,"damage", _vehicle call ALIVE_fnc_vehicleGetDamage] call ALIVE_fnc_hashSet;
-                        [_logic,"fuel", fuel _vehicle] call ALIVE_fnc_hashSet;
-                        [_logic,"ammo", _vehicle call ALIVE_fnc_vehicleGetAmmo] call ALIVE_fnc_hashSet;
-                        [_logic,"engineOn", isEngineOn _vehicle] call ALIVE_fnc_hashSet;
-                        [_logic,"canFire", canFire _vehicle] call ALIVE_fnc_hashSet;
-                        [_logic,"canMove", canMove _vehicle] call ALIVE_fnc_hashSet;
-                        [_logic,"needReload", needReload _vehicle] call ALIVE_fnc_hashSet;
-                        [_logic,"vehicle",objNull] call ALIVE_fnc_hashSet;
-
-                        if(count _cargo > 0) then {
-                            [ALiVE_SYS_LOGISTICS,"clearContainer",_vehicle] call ALiVE_fnc_Logistics;
-                        };
-
-                        if(count _slingload > 0) then {
-                            private ["_slingloadVehicle"];
-                            _slingloadVehicle = getSlingLoad _vehicle;
-
-                            if (count (_slingload select 1) > 0) then {
-                                [ALiVE_SYS_LOGISTICS,"clearContainer",_slingloadVehicle] call ALiVE_fnc_Logistics;
-                            };
-
-                            _vehicle setSlingLoad objNull;
-                            if (typeName (_slingLoad select 0) == "STRING") then {
-                                deleteVehicle _slingloadVehicle;
-                            };
-                        };
-
-                        // delete
-                        deleteVehicle _vehicle;
-
-                        // store the profile id on the in active profiles index
-                        [ALIVE_profileHandler,"setInActive",[_profileID,_side,_logic]] call ALIVE_fnc_profileHandler;
-
-                        // Indicate profile has been despawned and unlock for asynchronous waits
-                        [_logic, "locked",false] call ALIVE_fnc_HashSet;
-
-                        // DEBUG -------------------------------------------------------------------------------------
-                        if(_debug) then {
-                            //["Profile [%1] Despawn - pos: %2",_profileID,_position] call ALIVE_fnc_dump;
-                            [_logic,"debug",true] call MAINCLASS;
-                        };
-                        // DEBUG -------------------------------------------------------------------------------------
-
-                    };
-                };
-        };
-        case "handleDeath": {
-                [_logic,"damage",1] call ALIVE_fnc_hashSet;
-
-                // remove all assignments for this vehicle
-                [_logic] call ALIVE_fnc_removeProfileVehicleAssignments;
-        };
-        case "destroy": {
-            private ["_debug","_active","_vehicle","_profileID"];
-
-            _debug = _logic select 2 select 0; //[_logic,"debug"] call ALIVE_fnc_hashGet;
-            _active = _logic select 2 select 1; //[_logic,"active"] call ALIVE_fnc_hashGet;
-            _vehicle = _logic select 2 select 10; //[_logic,"vehicle"] call ALIVE_fnc_hashGet;
-            _profileID = _logic select 2 select 4; //[_logic,"profileID"] call ALIVE_fnc_hashGet;
-
-            // DEBUG -------------------------------------------------------------------------------------
-            if(_debug) then {
-                ["Profile [%1] Destroying",_profileID] call ALIVE_fnc_dump;
-            };
-            // DEBUG -------------------------------------------------------------------------------------
-
-            // clear assignments
-            [_logic,"clearVehicleAssignments"] call MAINCLASS;
-
-            // not already inactive
-            if(_active) then {
-
-                // delete
-                deleteVehicle _vehicle;
-            };
-
-            [ALIVE_profileHandler, "unregisterProfile", _logic] call ALIVE_fnc_profileHandler;
-
-            [_logic, "destroy"] call SUPERCLASS;
-        };
-        case "createMarker": {
-                private ["_markers","_m","_position","_profileID","_color","_icon","_alpha","_profileSide","_vehicleType","_profileActive","_typePrefix"];
-
-                _alpha = _args param [0, 0.5, [1]];
-
-                _markers = [];
-
-                _position = [_logic,"position"] call ALIVE_fnc_hashGet;
-                _profileID = [_logic,"profileID"] call ALIVE_fnc_hashGet;
-                _profileSide = [_logic,"side"] call ALIVE_fnc_hashGet;
-                _vehicleType = [_logic,"objectType"] call ALIVE_fnc_hashGet;
-                _profileActive = [_logic,"active"] call ALIVE_fnc_hashGet;
-
-                switch(_profileSide) do {
-                    case "EAST":{
-                        _color = "ColorRed";
-                        _typePrefix = "o";
-                    };
-                    case "WEST":{
-                        _color = "ColorBlue";
-                        _typePrefix = "b";
-                    };
-                    case "CIV":{
-                        _color = "ColorYellow";
-                        _typePrefix = "n";
-                    };
-                    case "GUER":{
-                        _color = "ColorGreen";
-                        _typePrefix = "n";
-                    };
-                    default {
-                        _color = [_logic,"debugColor","ColorGreen"] call ALIVE_fnc_hashGet;
-                        _typePrefix = "n";
-                    };
-                };
-
-                switch(_vehicleType) do {
-                    case "Car":{
-                        _icon = format["%1_recon",_typePrefix];
-                    };
-                    case "Tank":{
-                        _icon = format["%1_armor",_typePrefix];
-                    };
-                    case "Armored":{
-                        _icon = format["%1_armor",_typePrefix];
-                    };
-                    case "Truck":{
-                        _icon = format["%1_recon",_typePrefix];
-                    };
-                    case "Ship":{
-                        _icon = format["%1_unknown",_typePrefix];
-                    };
-                    case "Helicopter":{
-                        _icon = format["%1_air",_typePrefix];
-                    };
-                    case "Plane":{
-                        _icon = format["%1_plane",_typePrefix];
-                    };
-                    case "StaticWeapon":{
-                        _icon = format["%1_mortar",_typePrefix];
-                    };
-                    default {
-                        _icon = "hd_dot";
-                    };
-                };
-
-                if(count _position > 0) then {
-                    _m = createMarker [format[MTEMPLATE, format["%1_debug",_profileID]], _position];
-                    _m setMarkerShape "ICON";
-                    _m setMarkerSize [0.6, 0.6];
-                    _m setMarkerType _icon;
-                    _m setMarkerColor _color;
-                    _m setMarkerAlpha _alpha;
-
-                    _markers pushback _m;
-
-                    [_logic,"markers",_markers] call ALIVE_fnc_hashSet;
-                };
-
-                _result = _markers;
-        };
-        case "deleteMarker": {
-                {
-                    deleteMarker _x;
-                } forEach ([_logic,"markers", []] call ALIVE_fnc_hashGet);
-        };
-        default {
-                _result = [_logic, _operation, _args] call SUPERCLASS;
-        };
-};
-TRACE_1("profileVehicle - output",_result);
-_result;
+_result

--- a/addons/x_lib/functions/data/fnc_spacialGrid.sqf
+++ b/addons/x_lib/functions/data/fnc_spacialGrid.sqf
@@ -167,6 +167,7 @@ switch (_operation) do {
 
         private _center = _args select 0;
         private _radius = _args select 1;
+        private _filter2D = _args param [2, false];
 
         private _minCoords = [_logic,"posToCoords", [(_center select 0) - _radius, (_center select 1) - _radius]] call MAINCLASS;
         private _maxCoords = [_logic,"posToCoords", [(_center select 0) + _radius, (_center select 1) + _radius]] call MAINCLASS;
@@ -187,7 +188,11 @@ switch (_operation) do {
             };
         };
 
-        _result = _result select {((_x select 0) distance _center) <= _radius};
+        if (!_filter2D) then {
+            _result = _result select {((_x select 0) distance _center) <= _radius};
+        } else {
+            _result = _result select {((_x select 0) distance2D _center) <= _radius};
+        };
 
     };
 

--- a/addons/x_lib/functions/data/fnc_spacialGrid.sqf
+++ b/addons/x_lib/functions/data/fnc_spacialGrid.sqf
@@ -35,9 +35,9 @@ switch (_operation) do {
 
     case "create": {
 
-		private _origin = _args select 0;
-		private _gridSize = _args select 1;
-		private _sectorSize = _args select 2;
+        private _origin = _args select 0;
+        private _gridSize = _args select 1;
+        private _sectorSize = _args select 2;
 
         private _gridSectorLength = ceil (_gridSize / _sectorSize);
 
@@ -47,24 +47,24 @@ switch (_operation) do {
                 // [j, i]
                 _sectors pushback [];
 
-				/*
-				_markerstr = createMarker [str random 10000, [((_j * _sectorSize) + (_origin select 0)), ((_i * _sectorSize) + (_origin select 1))]];
-				_markerstr setMarkerShape "ICON";
-				_markerstr setMarkerType "hd_dot";
-				_markerstr setMarkerSize [2,2];
-				_markerstr setmarkercolor "colorred";
-				*/
+                /*
+                _markerstr = createMarker [str random 10000, [((_j * _sectorSize) + (_origin select 0)), ((_i * _sectorSize) + (_origin select 1))]];
+                _markerstr setMarkerShape "ICON";
+                _markerstr setMarkerType "hd_dot";
+                _markerstr setMarkerSize [2,2];
+                _markerstr setmarkercolor "colorred";
+                */
             };
         };
 
         _result = [
             [
-                ["origin", _origin],			// select 2 select 0
-                ["sectorSize", _sectorSize],	// select 2 select 1
-                ["gridSize", _gridSize],		// select 2 select 2
-                ["minSector", [0,0]],			// select 2 select 3
-                ["maxSector", [_gridSectorLength,_gridSectorLength]],	// select 2 select 4
-                ["sectors", _sectors]			// select 2 select 5
+                ["origin", _origin],            // select 2 select 0
+                ["sectorSize", _sectorSize],    // select 2 select 1
+                ["gridSize", _gridSize],        // select 2 select 2
+                ["minSector", [0,0]],           // select 2 select 3
+                ["maxSector", [_gridSectorLength,_gridSectorLength]],   // select 2 select 4
+                ["sectors", _sectors]           // select 2 select 5
             ]
         ] call ALiVE_fnc_hashCreate;
 
@@ -74,7 +74,7 @@ switch (_operation) do {
 
         private _gridOrigin = _logic select 2 select 0;
         private _sectorSize = _logic select 2 select 1;
-		private _maxSector = _logic select 2 select 4;
+        private _maxSector = _logic select 2 select 4;
 
         if (
             (_args select 0) >= (_gridOrigin select 0) &&
@@ -82,11 +82,11 @@ switch (_operation) do {
             {(_args select 0) < ((_gridOrigin select 0) + (_sectorSize * (_maxSector select 0)))} &&
             {(_args select 1) < ((_gridOrigin select 1) + (_sectorSize * (_maxSector select 1)))}
         ) then {
-			// offset position to accomodate negative values
-			_args = [
-				(_args select 0) + (abs (_gridOrigin select 0)),
-				(_args select 1) + (abs (_gridOrigin select 1))
-			];
+            // offset position to accomodate negative values
+            _args = [
+                (_args select 0) + (abs (_gridOrigin select 0)),
+                (_args select 1) + (abs (_gridOrigin select 1))
+            ];
 
             _result = [floor ((_args select 0) / _sectorSize), floor ((_args select 1) / _sectorSize)];
         } else {
@@ -98,12 +98,12 @@ switch (_operation) do {
     case "coordsToSector": {
 
         if !(_args isEqualTo [-1,-1]) then {
-			private _sectorsInColumn = (_logic select 2 select 4) select 0;
+            private _sectorsInColumn = (_logic select 2 select 4) select 0;
             private _index = (_args select 0) + ((_args select 1) * _sectorsInColumn);
             _result = (_logic select 2 select 5) select _index;
         } else {
-			_result = nil;
-		};
+            _result = nil;
+        };
 
     };
 
@@ -114,9 +114,9 @@ switch (_operation) do {
         {
             private _coords = [_logic,"posToCoords", _x select 0] call MAINCLASS;
 
-			if !(_coords isEqualTo [-1,-1]) then {
-				([_logic,"coordsToSector", _coords] call MAINCLASS) pushback _x;
-			};
+            if !(_coords isEqualTo [-1,-1]) then {
+                ([_logic,"coordsToSector", _coords] call MAINCLASS) pushback _x;
+            };
         } foreach _points;
 
     };
@@ -129,8 +129,8 @@ switch (_operation) do {
 
         private _coords = [_logic,"posToCoords", _point select 0] call MAINCLASS;
 
-		if !(_coords isEqualTo [-1,-1]) then {
-			private _sector = [_logic,"coordsToSector", _coords] call MAINCLASS;
+        if !(_coords isEqualTo [-1,-1]) then {
+            private _sector = [_logic,"coordsToSector", _coords] call MAINCLASS;
             private _index = (_sector find _point);
 
             if (_index != -1) then {
@@ -138,15 +138,15 @@ switch (_operation) do {
                 _result = true;
             };
 
-		};
+        };
 
     };
 
     case "move": {
 
-		private _oldPos = _args select 0;
-		private _newPos = _args select 1;
-		private _data = _args select 2;
+        private _oldPos = _args select 0;
+        private _newPos = _args select 1;
+        private _data = _args select 2;
 
         if ([_logic,"remove", [_oldPos,_data]] call MAINCLASS) then {
             [_logic,"insert", [[_newPos,_data]]] call MAINCLASS;
@@ -168,26 +168,26 @@ switch (_operation) do {
         private _center = _args select 0;
         private _radius = _args select 1;
 
-		private _minCoords = [_logic,"posToCoords", [(_center select 0) - _radius, (_center select 1) - _radius]] call MAINCLASS;
-		private _maxCoords = [_logic,"posToCoords", [(_center select 0) + _radius, (_center select 1) + _radius]] call MAINCLASS;
+        private _minCoords = [_logic,"posToCoords", [(_center select 0) - _radius, (_center select 1) - _radius]] call MAINCLASS;
+        private _maxCoords = [_logic,"posToCoords", [(_center select 0) + _radius, (_center select 1) + _radius]] call MAINCLASS;
 
         private _maxSector = _logic select 2 select 4;
         private _sectors = _logic select 2 select 5;
 
         _result = [];
 
-		// constrict sector indexes to grid bounds
-		_minCoords = _minCoords apply {_x max 0};
-		_maxCoords = _maxCoords apply {_x min ((_maxSector select 0) + 1)};
+        // constrict sector indexes to grid bounds
+        _minCoords = _minCoords apply {_x max 0};
+        _maxCoords = _maxCoords apply {_x min ((_maxSector select 0) + 1)};
 
-		for "_y" from (_minCoords select 1) to (_maxCoords select 1) do {
-			for "_x" from (_minCoords select 0) to (_maxCoords select 0) do {
-				private _sector = [_logic,"coordsToSector", [_x,_y]] calL MAINCLASS;
-				_result append _sector;
-			};
-		};
+        for "_y" from (_minCoords select 1) to (_maxCoords select 1) do {
+            for "_x" from (_minCoords select 0) to (_maxCoords select 0) do {
+                private _sector = [_logic,"coordsToSector", [_x,_y]] calL MAINCLASS;
+                _result append _sector;
+            };
+        };
 
-		_result = _result select {((_x select 0) distance _center) <= _radius};
+        _result = _result select {((_x select 0) distance _center) <= _radius};
 
     };
 

--- a/addons/x_lib/functions/oop/fnc_BaseClassHash.sqf
+++ b/addons/x_lib/functions/oop/fnc_BaseClassHash.sqf
@@ -36,8 +36,6 @@ Wolffy.au
 Peer reviewed:
 nil
 ---------------------------------------------------------------------------- */
-private ["_result"];
-
 if(
     isNil "_this" ||
     {typeName _this != "ARRAY"} ||
@@ -55,20 +53,20 @@ params [
     ["_operation", "", [""]],
     ["_args", objNull, [objNull,[],"",0,true,false]]
 ];
-_result = true;
+
+private _result = true;
 
 switch(_operation) do {
-    default {
-        private["_err"];
-        _err = format["%1 does not support ""%2"" operation", _logic, _operation];
-        _err call ALiVE_fnc_logger;
-    };
+
     case "create": {
         // Create a module object for settings and persistence
-        _logic = [] call CBA_fnc_hashCreate;
-        [_logic, "class", ALIVE_fnc_baseClassHash] call ALIVE_fnc_hashSet;
-        _result = _logic;
+        _result = [
+            [
+                ["class", ALIVE_fnc_baseClassHash]
+            ]
+        ] call ALiVE_fnc_hashCreate;
     };
+
     case "destroy": {
         {
             [_logic, _x] call ALIVE_fnc_hashRem;
@@ -76,6 +74,14 @@ switch(_operation) do {
 
         _logic = nil;
     };
+
+    default {
+        private _err = format["%1 does not support ""%2"" operation", _logic, _operation];
+        _err call ALiVE_fnc_logger;
+    };
+
 };
+
 TRACE_1("baseClassHash - output",_result);
+
 _result;


### PR DESCRIPTION
# What

Finding profiles within a radius of an area is currently a costly operation, one that involves a massive loop over all profiles. This pull request will integrate a uniform grid as a spacial partitioning structure in order to introduce a broad-phase form of collision detection that will allow us to quickly reduce our sample of profiles which will be run through the distance command.

<hr>

# How to use

Any module that modifies a profile's position, must call directly to the `position` method of either the profileEntity or profileVehicle class. These methods handle the updating of the object's position inside the uniform grid.

<hr>

# Results

Here is the debug console results of two queries, using the same set of sample data.

Original:
```
Result:
1.89036 ms

Cycles:
529/10000

Code:
[getPos player, 1000] call ALIVE_fnc_getNearProfiles
```

New:
```
Result:
0.0726 ms

Cycles:
10000/10000

Code:
[getPos player, 1000] call ALIVE_fnc_getNearProfiles
```
