### PR TITLE
[sup_combatsupport] Fixes ALiVEOS/ALiVE.OS#523

### DIFF
--- a/addons/x_lib/functions/config/fnc_getArtyMagazineType.sqf
+++ b/addons/x_lib/functions/config/fnc_getArtyMagazineType.sqf
@@ -35,12 +35,7 @@ _class    = "B_MBT_01_arty_F"
 _type = _this select 1;
 private _weaponType = typeof(vehicle _class);
 
-private _weapon = [configfile >> "CfgVehicles" >> _weaponType >> "Turrets" >> "MainTurret" >> "weapons"] call ALiVE_fnc_getConfigValue;
-
-_weaponClass = _weapon select 0;
-
-private _mags =[];
-_mags = _weaponClass call ALIVE_fnc_configGetWeaponMagazines;
+_mags = [configfile >> "CfgVehicles" >> _weaponType >> "Turrets" >> "MainTurret" >> "magazines"] call ALiVE_fnc_getConfigValue;
 
 private _ords=[];
 private _ord="";

--- a/addons/x_lib/functions/config/fnc_getArtyRounds.sqf
+++ b/addons/x_lib/functions/config/fnc_getArtyRounds.sqf
@@ -6,12 +6,7 @@ if(_class isEqualTo "BUS_MotInf_MortTeam") then {
 _class    = "B_MBT_01_arty_F"
 };
 
-_weapon = [configfile >> "CfgVehicles" >> _class >> "Turrets" >> "MainTurret" >> "weapons"] call ALiVE_fnc_getConfigValue;
-
-_weaponClass = _weapon select 0;
-
-private _mags =[];
-_mags = _weaponClass call ALIVE_fnc_configGetWeaponMagazines;
+_mags = [configfile >> "CfgVehicles" >> _class >> "Turrets" >> "MainTurret" >> "magazines"] call ALiVE_fnc_getConfigValue;
 
 private _roundsAvail =[];
 


### PR DESCRIPTION
Artillery ammo is now grabbed from the main turret's magazine array in the vehicle config file. This change ensures the correct shells are returned for each faction's artillery pieces. Note, the tanks DLC introduced separate shells for OPFOR artillery pieces.