### PR TITLE
[sys_profile] Flying planes spawn more reliably

### DIFF
--- a/addons/sys_profile/fnc_profileGetGoodSpawnPosition.sqf
+++ b/addons/sys_profile/fnc_profileGetGoodSpawnPosition.sqf
@@ -198,15 +198,6 @@ switch(_type) do {
                         [_vehicleProfile,"position",_spawnPosition] call ALIVE_fnc_profileVehicle;
                         [_vehicleProfile,"mergePositions"] call ALIVE_fnc_profileVehicle;
 
-                        // vehicle is already spawned, move it..
-
-                        if (_vehicleProfile select 2 select 1) then {
-                            _vehicle = _vehicleProfile select 2 select 10;
-                            if!(isNil '_vehicle') then {
-                                _vehicle setPos _spawnPosition;
-                            };
-                        };
-
                         //["LEAD POS: %1",_spawnPosition] call ALIVE_fnc_dump;
                         //[_spawnPosition,"LEAD",_profileID] call _createMarker;
 
@@ -252,21 +243,6 @@ switch(_type) do {
                             [_vehicleProfile,"position",_position] call ALIVE_fnc_profileVehicle;
                             [_vehicleProfile,"mergePositions"] call ALIVE_fnc_profileVehicle;
 
-                            // vehicle is already spawned, move it..
-
-                            if (_vehicleProfile select 2 select 1) then {
-                                _vehicle = _vehicleProfile select 2 select 10;
-                                if !(isNil '_vehicle') then {
-                                    _vehicle setPos _position;
-                                };
-                            };
-
-                            /*
-                            if(_inAir) then {
-                                [_vehicleProfile,"engineOn", true] call ALIVE_fnc_profileVehicle;
-                            };
-                            */
-
                         } forEach _vehicles;
 
                     } else {
@@ -275,21 +251,6 @@ switch(_type) do {
                             [_vehicleProfile,"position",_spawnPosition] call ALIVE_fnc_profileVehicle;
                             //[_vehicleProfile,"direction",_direction] call ALIVE_fnc_profileVehicle;
                             [_vehicleProfile,"mergePositions"] call ALIVE_fnc_profileVehicle;
-
-                            // vehicle is already spawned, move it..
-
-                            if (_vehicleProfile select 2 select 1) then {
-                                _vehicle = _vehicleProfile select 2 select 10;
-                                if !(isNil '_vehicle') then {
-                                    _vehicle setPos _spawnPosition;
-                                };
-                            };
-
-                            /*
-                            if(_inAir) then {
-                                [_vehicleProfile,"engineOn", true] call ALIVE_fnc_profileVehicle;
-                            };
-                            */
                         };
                     };
                 };

--- a/addons/sys_profile/fnc_profileSimulator.sqf
+++ b/addons/sys_profile/fnc_profileSimulator.sqf
@@ -201,8 +201,13 @@ if (!_simAttacks) then {
                                 if (!isnil "_profilePosition" && {!(_profilePosition isEqualTo [])} && {!isnil "_destination"}) then {
 
                                     // add z-index since some profiles dont one defined
-                                    _profilePosition set [2,0];
-                                    _destination set [2,0];
+                                    if ((count _profilePosition) == 2) then {
+                                        _profilePosition pushBack 0;
+                                    };
+
+                                    if ((count _destination) == 2) then {
+                                        _destination pushBack 0;
+                                    };
 
                                     private _executeStatements = false;
 
@@ -223,6 +228,11 @@ if (!_simAttacks) then {
                                                 _waypointsCompleted = [];
                                             };
                                         };
+                                    };
+
+                                    // getPos above returns AGL
+                                    if (surfaceIsWater _newPosition) then {
+                                        _newPosition = ASLtoATL _newPosition;
                                     };
 
                                     // if distance to wp destination is within completion radius

--- a/addons/sys_profile/fnc_profileVehicle.sqf
+++ b/addons/sys_profile/fnc_profileVehicle.sqf
@@ -498,11 +498,25 @@ switch (_operation) do {
             };
 
             _vehicle = createVehicle [_vehicleClass, _position, [], 0, _special];
-            //_vehicle setPos _position;
             _vehicle setDir _direction;
             _vehicle setFuel _fuel;
             _vehicle engineOn _engineOn;
-            //_vehicle setVehicleVarName _profileID;
+
+            // FLY ignores height on vehicle creation, reset position
+            if (_special isEqualTo "FLY")  then {
+                _vehicle setPosATL _position;
+
+                // give airplane a push. changing direction, position
+                // reset its velocity
+                if (_vehicleType isEqualTo "Plane") then {
+                    _speed = 200;
+                    _vehicle setVelocity [
+                        (sin _direction) * _speed,
+                        (cos _direction) * _speed,
+                        0.1
+                    ];
+                };
+            };
 
             if(count _cargo > 0) then {
                 _cargoItems = [];
@@ -657,12 +671,6 @@ switch (_operation) do {
                     deletevehicle _parachute;
                 };
             };
-
-            if(_engineOn && {_vehicleType == "Plane"}) then {
-                _speed = 200;
-                _vehicle setVelocity [(sin _direction*_speed), (cos _direction*_speed),0.1];
-            };
-
 
             if(count _damage > 0) then {
                 [_vehicle, _damage] call ALIVE_fnc_vehicleSetDamage;


### PR DESCRIPTION
-Planes were spawned too close to the ground. This is an engine problem as
height is ignored on createVehicle with "FLY." Planes are given a boost
directly after spawning to better workaround nose dive issue.

-ALIVE_fnc_profileGetGoodSpawnPosition no longer sets position of profiles.
Only returns a position.

-Minor fixes to ensure profile position is in ATL

Workaround fix for #521