### PR TITLE
[mil_c2istar] Toggle tasking on custom mil obj

### DIFF
--- a/addons/fnc_analysis/fnc_battlefieldAnalysis.sqf
+++ b/addons/fnc_analysis/fnc_battlefieldAnalysis.sqf
@@ -453,9 +453,13 @@ switch(_operation) do {
         _result = [_logic, "casualtySectors"] call ALIVE_fnc_hashGet;
     };
     case "getClustersOwnedBySide": {
-        private["_side","_clustersOwnedBySide","_activeSectors","_clusters","_owner","_sectorData"];
+        private["_clustersOwnedBySide","_activeSectors","_clusters","_owner","_sectorData"];
 
-        _side = _args select 0;
+        _args params [
+            "_side",
+            ["_checkMilCustom", false]
+        ];
+
         _clustersOwnedBySide = [];
 
         _side = if (typeName _side == "SIDE") then {str(_side)} else {_side};
@@ -470,14 +474,26 @@ switch(_operation) do {
             if !(isnil "_sectorData") then {
                 _clusters = [_sectorData,"activeClusters"] call ALIVE_fnc_hashGet;
 
-                {
+                private _clusterID = _clusters select 1 select 0;
 
+                {
                     _owner = [_x,"owner"] call ALIVE_fnc_hashGet;
                     _owner = if (typeName _owner == "SIDE") then {str(_owner)} else {_owner};
                     if (_owner == "GUER") then {_owner = "INDEP"};
 
                     if (_owner == _side) then {
-                        _clustersOwnedBySide pushback _x;
+                        private _allowPlayerTasking = true;
+
+                        if (_checkMilCustom) then {
+                            if (!isNil "ALIVE_clustersMilCustom" && {[ALIVE_clustersMilCustom, _clusterID] call CBA_fnc_hashHasKey}) then {
+                                private _clusterData = [ALIVE_clustersMilCustom, _clusterID] call ALIVE_fnc_hashGet;
+                                _allowPlayerTasking = [_clusterData, "allowPlayerTasking", true] call ALIVE_fnc_hashGet;
+                            };
+                        };
+
+                        if (_allowPlayerTasking) then {
+                            _clustersOwnedBySide pushback _x;
+                        };
                     };
                 } forEach (_clusters select 2);
             };
@@ -486,10 +502,14 @@ switch(_operation) do {
         _result = _clustersOwnedBySide;
     };
     case "getClustersOwnedBySideAndType": {
-        private["_side","_type","_clustersOwnedBySide","_activeSectors","_clusters","_owner","_clusterType","_sectorData"];
+        private["_clustersOwnedBySide","_activeSectors","_clusters","_owner","_clusterType","_sectorData"];
 
-        _side = _args select 0;
-        _type = _args select 1;
+        _args params [
+            "_side",
+            "_type",
+            ["_checkMilCustom", false]
+        ];
+
         _clustersOwnedBySide = [];
 
         _side = if (typeName _side == "SIDE") then {str(_side)} else {_side};
@@ -503,6 +523,8 @@ switch(_operation) do {
 
             if !(isnil "_sectorData") then {
                 _clusters = [_sectorData,"activeClusters"] call ALIVE_fnc_hashGet;
+
+                private _clusterID = _clusters select 1 select 0;
 
                 {
                     _owner = [_x,"owner"] call ALIVE_fnc_hashGet;
@@ -512,7 +534,18 @@ switch(_operation) do {
                     if (_owner == "GUER") then {_owner = "INDEP"};
 
                     if (_owner == _side && {_type == _clusterType}) then {
-                        _clustersOwnedBySide pushback _x;
+                        private _allowPlayerTasking = true;
+
+                        if (_checkMilCustom) then {
+                            if (!isNil "ALIVE_clustersMilCustom" && {[ALIVE_clustersMilCustom, _clusterID] call CBA_fnc_hashHasKey}) then {
+                                private _clusterData = [ALIVE_clustersMilCustom, _clusterID] call ALIVE_fnc_hashGet;
+                                _allowPlayerTasking = [_clusterData, "allowPlayerTasking", true] call ALIVE_fnc_hashGet;
+                            };
+                        };
+
+                        if (_allowPlayerTasking) then {
+                            _clustersOwnedBySide pushback _x;
+                        };
                     };
                 } forEach (_clusters select 2);
 

--- a/addons/mil_c2istar/tasks/fnc_taskMilAssault.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskMilAssault.sqf
@@ -63,7 +63,8 @@ switch (_taskState) do {
         // establish the location for the task
         // get enemy occupied cluster position
 
-        _targetPosition = [_taskLocation,_taskLocationType,_taskEnemySide,"MIL"] call ALIVE_fnc_taskGetSideCluster;
+        // true = ignore custom military objectives that do not allow player tasking
+        _targetPosition = [_taskLocation,_taskLocationType,_taskEnemySide,"MIL",true] call ALIVE_fnc_taskGetSideCluster;
 
         // ["pl %1 tar %2",getpos player, _targetPosition] call ALiVE_fnc_DumpR;
 

--- a/addons/mil_c2istar/tasks/fnc_taskMilDefence.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskMilDefence.sqf
@@ -63,7 +63,8 @@ switch (_taskState) do {
         // establish the location for the task
         // get friendly occupied cluster position
 
-        _targetPosition = [_taskLocation,_taskLocationType,_taskSide,"MIL"] call ALIVE_fnc_taskGetSideCluster;
+        // true = ignore custom military objectives that do not allow player tasking
+        _targetPosition = [_taskLocation,_taskLocationType,_taskSide,"MIL",true] call ALIVE_fnc_taskGetSideCluster;
 
         if(count _targetPosition == 0 || {_taskLocationType == "Map" && {_targetPosition distance _taskLocation > 1000}}) then {
             private ["_category","_compType"];

--- a/addons/mil_c2istar/utils/fnc_taskGetSideCluster.sqf
+++ b/addons/mil_c2istar/utils/fnc_taskGetSideCluster.sqf
@@ -8,6 +8,9 @@ Description:
 Get a enemy cluster for a task
 
 Parameters:
+checkMilCustom: bool. Check if custom military objectives allows player tasking.
+    true: ignore custom military objectives that do not allow player tasking.
+    false: assume all objectives allow player tasking.
 
 Returns:
 
@@ -22,19 +25,21 @@ Author:
 ARJay
 ---------------------------------------------------------------------------- */
 
-private ["_taskLocation","_taskLocationType","_side","_type","_sideClusters","_targetPosition","_debug","_result","_nextState","_sortedClusters"];
+private ["_sideClusters","_targetPosition","_debug","_result","_nextState","_sortedClusters"];
 
-_taskLocation = _this select 0;
-_taskLocationType = _this select 1;
-_side = _this select 2;
-_type = if(count _this > 3) then {_this select 3} else {""};
+params [
+    "_taskLocation",
+    "_taskLocationType",
+    "_side",
+    ["_type", ""],
+    ["_checkMilCustom", false]
+];
 
 if(_type != "") then {
-    _sideClusters = [ALIVE_battlefieldAnalysis,"getClustersOwnedBySideAndType",[[_side] call ALIVE_fnc_sideTextToObject,_type]] call ALIVE_fnc_battlefieldAnalysis;
+    _sideClusters = [ALIVE_battlefieldAnalysis,"getClustersOwnedBySideAndType",[[_side] call ALIVE_fnc_sideTextToObject, _type, _checkMilCustom]] call ALIVE_fnc_battlefieldAnalysis;
 }else{
-    _sideClusters = [ALIVE_battlefieldAnalysis,"getClustersOwnedBySide",[[_side] call ALIVE_fnc_sideTextToObject]] call ALIVE_fnc_battlefieldAnalysis;
+    _sideClusters = [ALIVE_battlefieldAnalysis,"getClustersOwnedBySide",[[_side] call ALIVE_fnc_sideTextToObject, _checkMilCustom]] call ALIVE_fnc_battlefieldAnalysis;
 };
-
 
 _targetPosition = [];
 

--- a/addons/mil_placement_custom/CfgVehicles.hpp
+++ b/addons/mil_placement_custom/CfgVehicles.hpp
@@ -200,6 +200,25 @@ class CfgVehicles {
                                         };
                                 };
                         };
+                        class allowPlayerTasking
+                        {
+                            displayName = "$STR_ALIVE_CMP_ALLOW_PLAYER_TASK";
+                            description = "$STR_ALIVE_CMP_ALLOW_PLAYER_TASK_COMMENT";
+                            class Values
+                            {
+                                class Yes
+                                {
+                                    name = "Yes";
+                                    value = true;
+                                    default = 1;
+                                };
+                                class No
+                                {
+                                    name = "No";
+                                    value = false;
+                                };
+                            };
+                        };
                 };
                 class ModuleDescription
                 {

--- a/addons/mil_placement_custom/fnc_CMP.sqf
+++ b/addons/mil_placement_custom/fnc_CMP.sqf
@@ -233,6 +233,29 @@ switch(_operation) do {
         _result = [_logic,_operation,_args,DEFAULT_OBJECTIVES] call ALIVE_fnc_OOsimpleOperation;
     };
 
+    case "allowPlayerTasking": {
+        if (typeName _args == "BOOL") then {
+            _logic setVariable ["allowPlayerTasking", _args];
+        } else {
+            _args = _logic getVariable ["allowPlayerTasking", true];
+        };
+
+        if (typeName _args == "STRING") then {
+            if (_args == "true") then {
+                _args = true;
+            }
+            else {
+                _args = false;
+            };
+
+            _logic setVariable ["allowPlayerTasking", _args];
+        };
+
+        ASSERT_TRUE(typeName _args == "BOOL",str _args);
+
+        _result = _args;
+    };
+
     // Main process
     case "init": {
 
@@ -270,6 +293,10 @@ switch(_operation) do {
                 [true] call ALIVE_fnc_timer;
             };
             // DEBUG -------------------------------------------------------------------------------------
+
+            if (isNil "ALIVE_clustersMilCustom") then {
+                ALIVE_clustersMilCustom = [] call ALIVE_fnc_hashCreate;
+            };
 
             // instantiate static vehicle position data
             if(isNil "ALIVE_groupConfig") then {
@@ -340,6 +367,7 @@ switch(_operation) do {
             private _side = _factionSideNumber call ALIVE_fnc_sideNumberToText;
             private _countProfiles = 0;
             private _position = position _logic;
+            private _allowPlayerTasking = [_logic, "allowPlayerTasking"] call MAINCLASS;
 
             // Load static data
             call ALiVE_fnc_staticDataHandler;
@@ -375,6 +403,7 @@ switch(_operation) do {
             if(_debug) then {
                 ["ALIVE CMP [%1] - Size: %1 Priority: %2",_size,_priority] call ALIVE_fnc_dump;
                 ["ALIVE CMP [%1] - SideNum: %1 Side: %2 Faction: %3 Composition: %4",_factionSideNumber,_side,_faction,_composition] call ALIVE_fnc_dump;
+                ["ALIVE CMP Allow player tasking: %1", _allowPlayerTasking] call ALIVE_fnc_dump;
             };
             // DEBUG -------------------------------------------------------------------------------------
 
@@ -404,10 +433,12 @@ switch(_operation) do {
             [_cluster,"size", _size] call ALIVE_fnc_hashSet;
             [_cluster,"type", "MIL"] call ALIVE_fnc_hashSet;
             [_cluster,"priority", _priority] call ALIVE_fnc_hashSet;
+            [_cluster,"allowPlayerTasking", _allowPlayerTasking] call ALIVE_fnc_hashSet;
             [_cluster,"debug", _debug] call ALIVE_fnc_cluster;
 
             [_logic, "objectives", [_cluster]] call MAINCLASS;
 
+            [ALIVE_clustersMilCustom, _objectiveName, _cluster] call ALIVE_fnc_hashSet;
 
             if(ALIVE_loadProfilesPersistent) exitWith {
 

--- a/addons/mil_placement_custom/stringtable.xml
+++ b/addons/mil_placement_custom/stringtable.xml
@@ -101,4 +101,10 @@
 <Key ID="STR_ALIVE_CMP_READINESS_LEVEL_COMMENT">
     <Original>The amount of troops that will be on duty and patrolling</Original>
 </Key>
+<Key ID="STR_ALIVE_CMP_ALLOW_PLAYER_TASK">
+    <Original>Allow player tasking:</Original>
+</Key>
+<Key ID="STR_ALIVE_CMP_ALLOW_PLAYER_TASK_COMMENT">
+    <Original>MilAssault/MilDefend C2ISTAR tasks</Original>
+</Key>
 </Container></Package></Project>


### PR DESCRIPTION
-New module parameter added to custom military objectives
--Allows mission maker to disable C2ISTAR MilAssault/MilDefend player tasking
on custom military objectives
-New global variable ALIVE_clustersMilCustom to track custom military
objectives
--Allow access to custom military objective clusters without
coupling the code too much

(Hacky) fix for #542