### PR TITLE
[mil_opcom] Fix enemy scanning returning wrong results

### DIFF
--- a/addons/mil_opcom/opcom.fsm
+++ b/addons/mil_opcom/opcom.fsm
@@ -1,4 +1,4 @@
-/*%FSM<COMPILE "C:\Program Files (x86)\Bohemia Interactive\Tools\FSM Editor Personal Edition\scriptedFSM.cfg, opcom">*/
+/*%FSM<COMPILE "scriptedFSM.cfg, opcom">*/
 /*%FSM<HEAD>*/
 /*
 item0[] = {"INIT",0,250,-717.630066,-1005.371277,-627.630066,-955.371338,0.000000,"INIT"};
@@ -24,7 +24,7 @@ item19[] = {"NOT_BUSY_1",2,250,-520.941284,16.271149,-430.941254,66.271149,0.000
 item20[] = {"COLLECT_TO_QUEUE",2,250,-599.758545,-647.769531,-509.758667,-597.769531,0.000000,"COLLECT" \n "TO QUEUE"};
 item21[] = {"ENTRIES_IN_QUEUE",4,218,-598.921387,-529.275208,-508.921387,-479.275299,2.000000,"ENTRIES" \n "IN QUEUE"};
 item22[] = {"ANALYZE_Conditio",4,218,-1203.018188,-310.200287,-1113.017944,-260.200104,0.000000,"ANALYZE" \n "Conditions"};
-item23[] = {"PERFORM_ANALYSIS",2,250,-1205.917603,-535.859314,-1115.917603,-485.859314,0.000000,"PERFORM" \n "ANALYSIS"};
+item23[] = {"PERFORM_ANALYSIS",2,4346,-1205.917603,-535.859314,-1115.917603,-485.859314,0.000000,"PERFORM" \n "ANALYSIS"};
 item24[] = {"ANALYSIS_DONE",4,218,-1209.427368,-599.538696,-1119.427368,-549.538696,0.000000,"ANALYSIS" \n "DONE"};
 item25[] = {"RESET",2,250,-1210.631958,-838.320801,-1120.631958,-788.320801,0.000000,"RESET"};
 item26[] = {"PERFORM_CLEANUP",2,250,-1201.964966,-382.972961,-1111.964966,-332.972961,0.000000,"PERFORM" \n "CLEANUP"};
@@ -37,7 +37,7 @@ item32[] = {"",7,210,-1164.081909,36.036972,-1156.081909,44.036972,0.000000,""};
 item33[] = {"PERFORM_POSTANAL",2,250,-1209.788086,-683.964172,-1119.788086,-633.964172,0.000000,"PERFORM" \n "POSTANALYSIS"};
 item34[] = {"POST_ANALYSIS_DO",4,218,-1208.969116,-760.668579,-1118.969116,-710.668579,0.000000,"POST" \n "ANALYSIS" \n "DONE"};
 item35[] = {"QRF_Conditions",4,218,-133.845856,-306.268250,-43.845856,-256.268250,0.000000,"QRF" \n "Conditions"};
-item36[] = {"REQUEST_QRF",2,4346,-133.738892,-834.303589,-43.738892,-784.303650,0.000000,"REQUEST" \n "QRF"};
+item36[] = {"REQUEST_QRF",2,250,-133.738892,-834.303589,-43.738892,-784.303650,0.000000,"REQUEST" \n "QRF"};
 item37[] = {"RECON_Conditions",4,218,9.105785,-308.301544,99.105774,-258.301483,0.000000,"RECON" \n "Conditions"};
 item38[] = {"REQUEST_RECON",2,250,10.006296,-836.706787,100.006363,-786.706909,0.000000,"REQUEST" \n "RECON"};
 item39[] = {"OCA_Conditions",4,218,150.274902,-304.513031,240.274811,-254.513000,0.000000,"OCA" \n "Conditions"};
@@ -110,8 +110,8 @@ link51[] = {37,38};
 link52[] = {38,6};
 link53[] = {39,40};
 link54[] = {40,6};
-globals[] = {0.000000,0,0,0,0,640,480,1,94,6316128,1,-923.593384,166.432739,338.718018,-1155.853882,680,935,1};
-window[] = {0,-1,-1,-32000,-32000,1111,1866,3798,19,1,697};
+globals[] = {0.000000,0,0,0,0,640,480,1,94,6316128,1,-1249.862305,-687.782349,-287.340149,-988.072754,677,844,1};
+window[] = {2,-1,-1,-32000,-32000,1186,163,2095,94,3,699};
 *//*%FSM</HEAD>*/
 class FSM
 {
@@ -890,7 +890,7 @@ class FSM
                          "        //ANALYSISDONE = false; [_OPCOM_HANDLER,_sidesFriendly,_sidesEnemy] execFSM ""\x\alive\addons\mil_opcom\analyze.fsm"";" \n
                          "        _clusterOccupationAnalysis = [_OPCOM_HANDLER,""analyzeclusteroccupation"",[_sidesFriendly,_sidesEnemy]] spawn ALiVE_fnc_OPCOM;" \n
                          "        _troopsAnalysis = [_OPCOM_HANDLER,""scantroops""] spawn ALiVE_fnc_OPCOM;" \n
-                         "        _enemyScan = [_OPCOM_HANDLER,""scanallenemies""] spawn ALIVE_fnc_OPCOM;" \n
+                         "        _enemyScan = [_OPCOM_HANDLER,""scanFriendliesForNearEnemies""] spawn ALIVE_fnc_OPCOM;" \n
                          "	};" \n
                          "};"/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;

--- a/addons/mil_opcom/tacom.fsm
+++ b/addons/mil_opcom/tacom.fsm
@@ -1,4 +1,4 @@
-/*%FSM<COMPILE "C:\Program Files (x86)\Bohemia Interactive\Tools\FSM Editor Personal Edition\scriptedFSM.cfg, tacom">*/
+/*%FSM<COMPILE "scriptedFSM.cfg, tacom">*/
 /*%FSM<HEAD>*/
 /*
 item0[] = {"INIT",0,250,-191.791229,-248.493942,-101.791237,-198.494003,0.000000,"INIT"};
@@ -83,8 +83,8 @@ link36[] = {24,25};
 link37[] = {25,26};
 link38[] = {26,10};
 link39[] = {27,28};
-globals[] = {0.000000,0,0,0,0,640,480,1,81,6316128,1,-666.800781,293.326508,1822.189453,-310.159912,421,935,1};
-window[] = {0,-1,-1,-1,-1,1097,310,1477,5,1,438};
+globals[] = {0.000000,0,0,0,0,640,480,1,81,6316128,1,-413.835663,1.199860,638.361816,-25.066154,528,844,1};
+window[] = {2,-1,-1,-32000,-32000,1121,201,1368,29,3,550};
 *//*%FSM</HEAD>*/
 class FSM
 {
@@ -232,7 +232,6 @@ class FSM
                          "		    //[""Analyze internal | %1 | %2"",time,_lastEnemyScan] call ALiVE_fnc_DumpR;" \n
                          "" \n
                          "            if (time - _lastEnemyScan > 60) then {" \n
-                         "" \n
                          "                [_OPCOM_HANDLER,""scanallenemies""] spawn ALIVE_fnc_OPCOM;" \n
                          "" \n
                          "                _targets = [_OPCOM_HANDLER,""knownentities"",[]] call ALiVE_fnc_HashGet;" \n
@@ -305,7 +304,7 @@ class FSM
                          "                case (""defend"") : {" \n
                          "                    //Define defense conditions" \n
                          "                    //Detect near enemies" \n
-                         "                    _nearEnemies = []; {private [""_nE""]; _nE = [_objective,""entitiesnearsector"",[_pos,_x,false]] call AliVE_fnc_OPCOM; _nearEnemies = _nearEnemies + _nE} foreach _sidesEnemy;" \n
+                         "                    _nearEnemies = [_objective,""findProfilesNearPosition"",[_pos,_sidesEnemy,false]] call AliVE_fnc_OPCOM;" \n
                          "                    " \n
                          "                    //Defend until no enemies are near" \n
                          "                    if (count _nearEnemies > 0) then {" \n
@@ -362,7 +361,7 @@ class FSM
                          "                    };" \n
                          "				//All groups are in position" \n
                          "                        //Scan for visible enemies (done only once on recon for performance sake - regulary scan every 2 minutes done by OPCOM)" \n
-                         "                        _danger = count ([_OPCOM_HANDLER,""scanenemies"",_posP] call ALiVE_fnc_OPCOM);" \n
+                         "                        _danger = count ([_OPCOM_HANDLER,""scanForNearEnemies"", [_posP, true]] call ALiVE_fnc_OPCOM);" \n
                          "" \n
                          "                        // TBD: Calculate danger level depending on recon outcome (sector analysis)" \n
                          "                        [_objective,""danger"",_danger] call AliVE_fnc_HashSet;" \n
@@ -403,9 +402,9 @@ class FSM
                          "                };" \n
                          "                case (""defend"") : {" \n
                          "                    if !([_OPCOM_HANDLER,""synchronizeorders"",_ProfileID] call ALiVE_fnc_OPCOM) exitwith {" \n
-                         "                        // debug ---------------------------------------" \n
-                         "                        if(_debug) then { [""TACOM %1 regrouping! Waiting for %2 groups!"",_ProfileID,({_objectiveID == (_x select 2)} count ([_OPCOM_HANDLER,""pendingorders"",[]] call ALiVE_fnc_HashGet))] call ALIVE_fnc_dumpR; };" \n
-                         "                        // debug ---------------------------------------" \n
+                         "                        if (_debug) then {" \n
+                         "									[""TACOM %1 regrouping! Waiting for %2 groups!"",_ProfileID,({_objectiveID == (_x select 2)} count ([_OPCOM_HANDLER,""pendingorders"",[]] call ALiVE_fnc_HashGet))] call ALIVE_fnc_dumpR;" \n
+                         "								};" \n
                          "                    };" \n
                          "                " \n
                          "                        //analyse" \n


### PR DESCRIPTION
Previously, the danger value for an objective was set to the value of _all_ known entities. This change fixes it so the danger value of an objective is only the number of enemies within a radius around the objective.

This PR also brings some performance improvements to enemy scanning.