### PR TITLE
Prevent additional backpacks

### DIFF
--- a/addons/sys_player/playerData.hpp
+++ b/addons/sys_player/playerData.hpp
@@ -238,6 +238,7 @@ GVAR(LOADOUT_DATA) = [
         _target selectWeapon _weap;
         _magazines;},
      {
+        removeBackpack (_this select 0);
         (_this select 0) addbackpack "B_Bergen_mcamo"; // as a place to put items temporarily
         {
             [(_this select 0), _x] call addItemToUniformOrVest;


### PR DESCRIPTION
Additional backpacks spawn on player restore previous state, and
probably other player state loads