### PR TITLE
[sys_marker] Fix for stacked Ctrl EventHandlers

### DIFF
--- a/addons/sys_marker/fnc_marker.sqf
+++ b/addons/sys_marker/fnc_marker.sqf
@@ -343,7 +343,7 @@ switch (_operation) do {
                     _control = _display displayCtrl MAP_CONTROL;
                     _control ctrlAddEventHandler ["MouseButtonClick", "[ALiVE_SYS_marker,'mouseButton',[player, _this]] call ALiVE_fnc_marker;"];
                     _control ctrlAddEventHandler ["MouseButtonDblClick", "if !(ALIVE_SYS_MARKER_HINT) then { hintSilent 'Only ALIVE Advanced Markers will be stored. Default BIS markers are not supported by ALIVE. CTRL-MOUSE BUTTON to create an Advanced Marker.'; ALIVE_SYS_MARKER_HINT = true;};"];
-                       _control ctrlAddEventHandler ["draw", "[ALiVE_SYS_marker,'draw',[player, _this]] call ALiVE_fnc_marker;"];
+                    _control ctrlAddEventHandler ["draw", "[ALiVE_SYS_marker,'draw',[player, _this]] call ALiVE_fnc_marker;"];
                     _control ctrlAddEventHandler ["MouseMoving", {[ALiVE_SYS_marker,"mouseMoving",[player, _this]] call ALiVE_fnc_marker;}];
 
                     _display displayAddEventHandler ["keyDown", {[ALiVE_SYS_marker,"keyDown",[player, _this]] call ALiVE_fnc_marker;}];
@@ -524,7 +524,7 @@ switch (_operation) do {
                 _result = false;
 
             } else {
-                _result = true;
+                _result = false;
             };
         };
 


### PR DESCRIPTION
#718 

**Summary:**
Control Event Handlers are stackable and are processed in reverse order (i.e. last added: processed first, first added: processed last). In this instance, ALiVEs EH's are processed first as they're declared last. Issue is that as soon as one of the processed event handlers returns a `true` response, no further stacked executions take place.


**Replication Code**
```sqf

fnc_test1 = {
 diag_log "[ALiVE-TEST] - Test 1 - Success!";
 _result = true;
 _result;
};

fnc_test2 = {
 diag_log "[ALiVE-TEST] - Test 2 - Success!";
};

_control = finddisplay 12 displayctrl 51; 
 
_control ctrladdeventhandler ["mousebuttonclick","[] call fnc_test2"];
_control ctrladdeventhandler ["mousebuttonclick","[] call fnc_test1"]; 

```

**Replication Output**
```
17:37:23 "[ALiVE-TEST] - Test 1 - Success!"
17:37:23 [ACRE] (sys_io) INFO: Pipe error: Read CreateFileA WinErrCode: 2
17:37:28 ALiVE has hooked abort button: B Alpha 1-3:1 (Trap)
17:37:28 ALiVE has hooked abort button: B Alpha 1-3:1 (Trap)
```

**Commits**
- Changed return response to `false` within `ALiVE_fnc_marker` for when `mouseButton` is called however `Ctrl` or `Alt` are not pressed. (This should always have been false I believe).
- Fixed small spacing issue.
- Can't identify any further impact of changing this value.

