### PR TITLE
Fixed mechanized/armored units not moving after spawning [issue 720]

### DIFF
--- a/addons/sys_profile/fnc_profileEntity.sqf
+++ b/addons/sys_profile/fnc_profileEntity.sqf
@@ -1076,17 +1076,17 @@ switch(_operation) do {
             [_logic,"units", _units] call ALIVE_fnc_hashSet;
             [_logic,"active", true] call ALIVE_fnc_hashSet;
 
-            //["Profile [%1] Spawn - Create Waypoints",_profileID] call ALIVE_fnc_dump;
-            //[true] call ALIVE_fnc_timer;
-            // create waypoints from profile waypoints
-            _waypoints append _waypointsCompleted;
-            [_waypoints, _group] call ALIVE_fnc_profileWaypointsToWaypoints;
-            //[] call ALIVE_fnc_timer;
-
             //["Profile [%1] Spawn - Create Vehicle Assignments",_profileID] call ALIVE_fnc_dump;
             //[true] call ALIVE_fnc_timer;
             // create vehicle assignments from profile vehicle assignments
             [_vehicleAssignments, _logic] call ALIVE_fnc_profileVehicleAssignmentsToVehicleAssignments;
+            //[] call ALIVE_fnc_timer;
+			
+			//["Profile [%1] Spawn - Create Waypoints",_profileID] call ALIVE_fnc_dump;
+            //[true] call ALIVE_fnc_timer;
+            // create waypoints from profile waypoints
+            _waypoints append _waypointsCompleted;
+            [_waypoints, _group] call ALIVE_fnc_profileWaypointsToWaypoints;
             //[] call ALIVE_fnc_timer;
 
             //["Profile [%1] Spawn - Process Commands",_profileID] call ALIVE_fnc_dump;


### PR DESCRIPTION
#720 

In fnc_profileEntity.sqf, under the "spawn" case, the profile waypoints were created before the vehicle assignments. Due to this, mechanized and armored profiles get stuck right after spawning, because they have a move waypoint before the entire crew is inside the vehicle.

All I did was change the order in which these two functions execute. Now waypoints are created after vehicle assignments. All vehicles now move normally after spawning. It's a very simple fix, shouldn't affect anything else.