### PR TITLE
Added isnil check on attempts to retrieve _profile

### DIFF
--- a/addons/mil_command/fnc_ambientMovement.sqf
+++ b/addons/mil_command/fnc_ambientMovement.sqf
@@ -31,6 +31,7 @@ if (isnil "_profile") exitWith {
 };
 
 // Get profile data 
+if (isnil "_profile") exitWith {};
 private _pos = [_profile,"position"] call ALiVE_fnc_HashGet;
 private _waypoints = [_profile,"waypoints",[]] call ALiVE_fnc_HashGet;
 private _vehiclesInCommandOf = [_profile,"vehiclesInCommandOf",[]] call ALIVE_fnc_HashGet;

--- a/addons/mil_command/fnc_garrison.sqf
+++ b/addons/mil_command/fnc_garrison.sqf
@@ -37,6 +37,7 @@ if (_args isEqualType []) then {
     _onlyProfiles = (_args param [1, "false", [""]]) == "true";
 };
 
+if (isnil "_profile") exitWith {};
 _id = [_profile,"profileID","error"] call ALiVE_fnc_HashGet;
 _pos = [_profile,"position"] call ALiVE_fnc_HashGet;
 _type = [_profile,"type",""] call ALiVE_fnc_HashGet;

--- a/addons/mil_intelligence/fnc_G2.sqf
+++ b/addons/mil_intelligence/fnc_G2.sqf
@@ -266,15 +266,17 @@ switch(_operation) do {
 
     case "buildSpotrepForProfile": {
         _args params ["_profile","_timeSinceSeen"];
-
+        
         if (_profile isequaltype "") then {
             _profile = [ALiVE_profileHandler,"getProfile", _profile] call ALiVE_fnc_profileHandler;
         };
 
+        //Sanitize _profile, it may be dead and unregistered, thus returning null.
+        if (isnil "_profile") exitWith {};
+
         private _profileID = _profile select 2 select 4;
         private _side = _profile select 2 select 3;
         private _position = _profile select 2 select 2;
-
         private _faction = [_profile,"faction"] call ALiVE_fnc_hashGet;
 
         private _entityType = _profile select 2 select 5;

--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -543,6 +543,8 @@ switch(_operation) do {
 
             {
                 private _spotrepData = [_G2,"buildSpotrepForProfile", [_x,0]] call ALiVE_fnc_G2;
+                //If the profile was dead when trying to process ALive_fnc_G2, spotrepdata would return null, skip this profile
+                if (isnil "_spotrepData") then { continue };
                 [_G2,"createSpotrep", _spotrepData] call ALiVE_fnc_G2;
             } foreach _profiles;
         };
@@ -697,26 +699,28 @@ switch(_operation) do {
             _size = _args select 1;
             _type = _args select 2;
 
+            _section = [];
+            _profileIDs = [];
+            _profiles = [];
+            _dist = 1000;
+            
+            _profile = [ALiVE_ProfileHandler,"getProfile",_target] call ALiVE_fnc_ProfileHandler;
+            //Attempt to solve the error resulting from the race condition between the profile death and this call
+            if (isnil "_profile") exitwith {_result = _section}; //Exit early
+            
             _side = [_logic,"side"] call ALiVE_fnc_HashGet;
             _factions = [_logic,"factions"] call ALiVE_fnc_HashGet;
             _sides = [_logic,"sidesenemy",["EAST"]] call ALiVE_fnc_HashGet;
             _knownE = [_logic,"knownentities",[]] call ALiVE_fnc_HashGet;
             _attackedE = [_logic,"attackedentities",[]] call ALiVE_fnc_HashGet;
             _reserved = [_logic,"ProfileIDsReserve",[]] call ALiVE_fnc_HashGet;
-            _profile = [ALiVE_ProfileHandler,"getProfile",_target] call ALiVE_fnc_ProfileHandler;
             _pos = [_profile,"position"] call ALiVE_fnc_HashGet;
 
 	        _vehicles = ([_profile,"vehicleAssignments",[[],[]]] call ALIVE_fnc_hashGet) select 1;
 	        if (count _vehicles > 0) then {
 	        	_vehicleProfile = [ALiVE_ProfileHandler,"getProfile",_vehicles select 0] call ALiVE_fnc_ProfileHandler;
-	        };
+            };
 
-            _section = [];
-            _profileIDs = [];
-            _profiles = [];
-            _dist = 1000;
-
-            if (isnil "_profile") exitwith {_result = _section};
 
            {
                 _proIDs = [ALIVE_profileHandler, "getProfilesBySide",_x] call ALIVE_fnc_profileHandler;
@@ -2449,7 +2453,9 @@ switch(_operation) do {
                 };
 			} foreach _controlledProfileIDs;
 
-            [_logic,"createSpotrepForProfiles", _knownEntities apply { _x select 0}] call MAINCLASS;
+            _knownEntitiesIds = _knownEntities apply { _x select 0};
+
+            [_logic,"createSpotrepForProfiles", _knownEntitiesIds] call MAINCLASS;
 
 			[_logic,"knownentities", _knownEntities] call ALiVE_fnc_HashSet;
 


### PR DESCRIPTION
This is an attempt to reduce the effects of the race condition.

Since units profiles are unregistered upon death by an event handler, opcom and intelligence may try to act upon already unregistered profiles.

This would generate an error spam on fnc_G2.sqf and also rarely stall opcom.

Since the profiles are returned as new instances, a workaround is to check if the returned value was null, otherwise it's pretty safe to go ahead.