### PR TITLE
Fix 2 OPCOM bugs, snap waypoints to roads

### DIFF
--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -1507,7 +1507,7 @@ switch(_operation) do {
                     _state = [_x,"opcom_state",""] call ALiVE_fnc_HashGet;
 
                     if (_orders in ["attack","defend"]) then {_AO pushback _x} else {
-                        if (_state in ["reserving","idle"]) then {
+                        if (_state in ["reserve","reserving","idle"]) then {
                             _FOB pushback _x;
                         };
                     };

--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -1271,7 +1271,7 @@ switch(_operation) do {
                 private _objective = [_logic,"getobjectivebyid", _objectiveID] call ALiVE_fnc_OPCOM;
                 private _debug = [_logic,"debug",false] call ALiVE_fnc_HashGet;
 
-                private _previousTacomState = [_objective,"tacom_state"] call ALiVE_fnc_hashGet;
+                private _previousTacomState = [_objective,"tacom_state","none"] call ALiVE_fnc_hashGet;
 
                 [_objective,"tacom_state", "none"] call AliVE_fnc_HashSet;
                 [_objective,"opcom_state", "unassigned"] call AliVE_fnc_HashSet;

--- a/addons/sys_profile/fnc_profileWaypointToWaypoint.sqf
+++ b/addons/sys_profile/fnc_profileWaypointToWaypoint.sqf
@@ -46,6 +46,18 @@ private _attachVehicle = [_profileWaypoint,"attachVehicle"] call ALIVE_fnc_hashG
 private _waypointStatements = [_profileWaypoint,"statements"] call ALIVE_fnc_hashGet;
 private _waypointName = [_profileWaypoint,"name"] call ALiVE_fnc_hashGet;
 
+// If the leader is in a land vehicle, snap waypoints to nearest road within 200m
+if (
+    !isNull (assignedVehicle leader _group) &&
+    (assignedVehicle leader _group) isKindOf "LandVehicle"
+) then {
+    private _road = [_position, 200] call BIS_fnc_nearestRoad;
+    if !(isNull _road) then {
+        _position = (getPos _road) select [0, 2];
+	_radius = -1;
+    };
+};
+
 _position set [2,0];
 
 private _waypoint = _group addWaypoint [_position, _radius];


### PR DESCRIPTION
The OPCOM changes are just bugfixes. The waypoints are a bit different. I noticed that the waypoints created by ALiVE tends to make vehicles drive off roads for no reason. 

https://community.bistudio.com/wiki/addWaypoint

The addWaypoint function takes 4 args in addition to the group, one of which is radius. You'd think normally that radius would be the distance you have to be from the wp for it to be completed, but it actually randomizes the waypoint. Instead of doing this for vehicles, we find the closest road and set radius to -1 (for exact placement).