### PR TITLE
Artillery fixes

### DIFF
--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -3803,7 +3803,7 @@ switch(_operation) do {
                                     _eventPosition = position (_eventTargets select 0);
                                 } else {
                                     private _targetProfile = [ALiVE_profileHandler, "getProfile", (_eventTargets select 0)] call ALiVE_fnc_ProfileHandler;
-                                    _eventPosition = [_targetProfile,"position"] call ALiVE_fnc_hashGet;
+                                    if !(isNil "_targetProfile") then {_eventPosition = [_targetProfile,"position"] call ALiVE_fnc_hashGet;};
                                 };
                             };
 

--- a/addons/sup_combatsupport/fnc_combatSupport.sqf
+++ b/addons/sup_combatsupport/fnc_combatSupport.sqf
@@ -693,11 +693,16 @@ switch(_operation) do {
                                     };
                                 };
                             } else {
-                                _units pushback _veh;
-                                _veh lock true;
+                                {
+                                    private _v = vehicle _x;
+                                    if !(_v in _units) then {
+                                        _units pushback _v;
+                                        _v lock true;
 
-                                // set ownership flag for other modules
-                                _veh setVariable ["ALIVE_CombatSupport", true];
+                                        // set ownership flag for other modules
+                                        _v setVariable ["ALIVE_CombatSupport", true];
+                                    };
+                                } foreach units _grp;
                             };
 
                             { _x setVariable ["NEO_radioArtyModule", [leader _grp, _callsign], true] } forEach _units;

--- a/addons/sup_combatsupport/fnc_combatSupport.sqf
+++ b/addons/sup_combatsupport/fnc_combatSupport.sqf
@@ -703,6 +703,7 @@ switch(_operation) do {
                                         _v setVariable ["ALIVE_CombatSupport", true];
                                     };
                                 } foreach units _grp;
+                                _grp setVariable ["supportWeaponCount",count _units];
                             };
 
                             { _x setVariable ["NEO_radioArtyModule", [leader _grp, _callsign], true] } forEach _units;

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_ExecuteMission.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_ExecuteMission.sqf
@@ -54,16 +54,30 @@ if(_missionRoundCount == 1) then {
     _battery DOArtilleryFire [_targetPos, _ordnance, _missionRoundCount];
 
 } else {
-    {
+    private _roundsOut = _missionRoundCount;
+    private _numUnits = (group _battery) getVariable ["supportWeaponCount",3];
+    private _roundsOutEach = [];
+    _roundsOutEach resize [_numUnits,0];
+    private _i = 0;
+    while {_roundsOut > 0} do {
+        _roundsOutEach set [_i,(_roundsOutEach select _i) + 1];
+        _roundsOut = _roundsOut - 1;
+        _i = _i + 1;
+        if (_i == _numUnits) then {_i = 0;};
+    };
+
+    for "_u" from 0 to (_numUnits -1) do { 
         private "_pos";
         if (_dispersion > 50) then {
             _pos = (_targetPos getPos [(_dispersion - 50), (round (random 360))]);
         } else {
             _pos = _targetPos;
         };
-        _x DOArtilleryFire [_pos, _ordnance, _missionRoundCount/((group _battery) getVariable ["supportWeaponCount",3])];
-        sleep _rateOfFire;
-    } foreach _units;
+        if (_roundsOutEach select _u > 0) then {
+            (_units select _u) DOArtilleryFire [_pos, _ordnance, _roundsOutEach select _u];
+            sleep _rateOfFire;
+        };
+    };
 };
 
 _battery setVariable ["ARTY_COMPLETE", true, true];

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_supportAdd.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_supportAdd.sqf
@@ -321,6 +321,8 @@ switch (_support) do
         private _roundsAvailable = _rounds select { (_x select 0) in _roundsUnit };
 
         leader _grp setVariable ["NEO_radioArtyBatteryRounds", _roundsAvailable, true];
+        
+        private _audio = NEO_radioLogic getvariable ["combatsupport_audio",true];
 
         //FSM
         private _fsmHandle = [_units, _grp, _callsign, _pos, _roundsAvailable, _canMove, _class, leader _grp, _code, _audio, _side] execFSM "\x\alive\addons\sup_combatSupport\scripts\NEO_radio\fsms\alivearty.fsm";


### PR DESCRIPTION
Added the ability to sync groups of artillery units rather than single. Also, groups of more or less than 3 use proper number of rounds. 

To use properly: 
Create an artillery group of (e.g. 4 units)
In one of the units INIT (preferably the leader)- add proper code for CS_TYPE and CS_CALLSIGN (optionally)
Sync that unit (again preferably the leader) directly to Player CS Module
Should only show as single line entry in player UI as Callsign or GroupID
Any requests will use up to entire group to expend the correct number of rounds selected.

Also added quick fix for Issue #780 while I was meddling in this area.
