### PR TITLE
attach waypoint to object for slingloading

### DIFF
--- a/addons/sup_combatsupport/scripts/NEO_radio/fsms/transport.fsm
+++ b/addons/sup_combatsupport/scripts/NEO_radio/fsms/transport.fsm
@@ -2172,7 +2172,7 @@ class FSM
                                          "private ""_wp"";" \n
                                          "_wp = group _chopper addWaypoint [_pos, 0]; " \n
                                          "_wp setWaypointType ""HOOK""; " \n
-                                         "_wp waypointAttachObject (nearestObject _pos select 0);"/*%FSM</ACTION""">*/;
+                                         "_wp waypointAttachObject (nearestObject _pos);"/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/
                         };

--- a/addons/sup_combatsupport/scripts/NEO_radio/fsms/transport.fsm
+++ b/addons/sup_combatsupport/scripts/NEO_radio/fsms/transport.fsm
@@ -2171,7 +2171,8 @@ class FSM
                                          "" \n
                                          "private ""_wp"";" \n
                                          "_wp = group _chopper addWaypoint [_pos, 0]; " \n
-                                         "_wp setWaypointType ""HOOK""; "/*%FSM</ACTION""">*/;
+                                         "_wp setWaypointType ""HOOK""; " \n
+                                         "_wp waypointAttachObject (nearestObject _pos select 0);"/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/
                         };


### PR DESCRIPTION
Had a weird issue with SOG DLC this past week. One day slingloading in [Player CS Transport] wasn't working anymore. Presumably after the latest update. Put together a basic test mission with no other mods: One DLC helo with editor placed waypoints and a bunch of CS TRANSPORT spawned helos. Some were DLC and some vanilla Arma 3. The editor placed waypoints for the DLC worked fine. The vanilla helos in CS TRANSPORT worked fine. The DLC one's did not. They just hovered above the object. Just threw this one line of code to attach HOOK waypoint to nearestObject on position and now all are working correctly. Not sure why but, this fix is for a 'some cases only' situation. I guess since vanilla were working fine it's not critical. If there's a more elegant solution, feel free to suggest alternative.

Thank you.