### PR TITLE
[mil_ATO] Fix infinite resupply - Remove from resupplyList

### DIFF
--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -3045,7 +3045,7 @@ switch(_operation) do {
 
                         // Order 1 asset each go around, first in first out!
                         private _resupplyList = [_logic,"resupplyList"] call MAINCLASS;
-                        private _asset = _resupplyList select 0;
+                        private _asset = _resupplyList deleteAt 0;
 
                         private _implemented = false; // remove once LOGCOM integration done
 


### PR DESCRIPTION
Without the deleteAt, the resupplyList queue never actually shrinks and it will repeatedly stack replacement aircraft at the same spot.

(Will cause a full crash when a spawn source gets close enough and it tries to spawn 100+ aircraft at the same location)

Sidenote: Would you guys prefer separate PRs for unrelated bugfixes, or should I do all ~6 in one go?