### PR TITLE
[mil_OPCOM] Multiple bug fixes

### DIFF
--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -791,11 +791,6 @@ switch(_operation) do {
                     };
                 };
 
-                if (count _profiles == 0) then {
-                	{
-                		if (count _x > 0) exitwith {_profiles = _x};
-                	} foreach [_armored,_mechanized,_motorized,_infantry];
-                };
 
                 if (!isnil "_rtb" && {["ALiVE_mil_ATO"] call ALiVE_fnc_IsModuleAvailable}) exitwith {
 
@@ -818,6 +813,15 @@ switch(_operation) do {
 
                     _attackedE pushback [_target,_pos,_section,time];
                     [_logic,"attackedentities",_attackedE] call ALiVE_fnc_HashSet;
+                };
+
+                if (count _profiles == 0) then {
+                	{
+                		if (count _x > 0) exitwith {
+                            _profiles = _x;
+                            _rtb = nil;
+                        };
+                	} foreach [_armored,_mechanized,_motorized,_infantry];
                 };
 
                 if (count _profiles > 0) then {

--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -751,7 +751,7 @@ switch(_operation) do {
 
             	private _infantry = [_logic,"infantry",[]] call ALiVE_fnc_HashGet;
             	private _motorized = [_logic,"motorized",[]] call ALiVE_fnc_HashGet;
-            	private _mechanized = [_logic,"mechandized",[]] call ALiVE_fnc_HashGet;
+            	private _mechanized = [_logic,"mechanized",[]] call ALiVE_fnc_HashGet;
             	private _armored = [_logic,"armored",[]] call ALiVE_fnc_HashGet;
             	private _artillery = [_logic,"artillery",[]] call ALiVE_fnc_HashGet;
             	private _AAA = [_logic,"AAA",[]] call ALiVE_fnc_HashGet;
@@ -766,7 +766,7 @@ switch(_operation) do {
                         _profiles = _motorized;
                         _dist = 3000;
                     };
-                    case ("mechandized") : {
+                    case ("mechanized") : {
                         _profiles = _mechanized;
                     };
                     case ("armored") : {


### PR DESCRIPTION
### 1. Fix typo from "mechandized" to "mechanized".
- "Mechandized" only appears in these two instances, in all of the ALiVE code

### 2. Reset "_rtb" to nil if no air profiles are available
- Move the check down below the `if (rtb and ATO available) exitWith ...` block to avoid interfering with that
- This way it won't end up creating a LAND waypoint for say, an armored profile


### 3. Fix the synchronizeorders function so that it is possible for it to return true
_See annotated (old) code below:_
```
private _ordersToRemove = [];
{
    _x params ["_pos","_profileID","_objectiveID","_time"];

    private _dead = isnil { [ALiVE_profileHandler,"getProfile", _profileID] call ALiVE_fnc_profileHandler };
    private _timeout = (time - _time) > 3600;

    if (_dead || { _timeout } || { _ProfileID == _ProfileIDInput }) then {
        _ordersToRemove pushback _foreachindex;


        //  ***************HERE***************
        // It checks to see if there are any more orders for this objective, 
        // but this one (in_x variable) hasn't been deleted yet, 
        // so this will always find and return the index of the current value.
        //  **********************************

        private _objectiveFound = _pendingOrders findIf { _objectiveID == (_x select 2) };
        if (_objectiveFound == -1) then {
            _synchronized = true; 
        };
    };
} foreach _pendingOrders;

[_pendingOrders, _ordersToRemove] call ALiVE_fnc_deleteAtMany;
```

The check needed to occur after the ALiVE_fnc_deleteAtMany call for this to work.

While writing this PR, I noticed something else. Is "synchronizeorders" supposed to return true even if a _different_ objective is synchronized due to the `_dead || { _timeout }` condition? Even if the objective of the profileId specified as an argument still has pending orders? 

If this **is** a mistake, I can further optimize this code to only check a single objective after deletion, rather than looping through an array of objective ids.