### PR TITLE
[mil_command] Fix fnc_ambush typo causing premature timeout

### DIFF
--- a/addons/mil_command/fnc_ambush.sqf
+++ b/addons/mil_command/fnc_ambush.sqf
@@ -131,7 +131,7 @@ if (_type == "entity") then {
             //["Enabling bombs!"] call AliVE_fnc_DumpH;
             {_x enableSimulationGlobal true} foreach (_this select 0);
             
-            waituntil {sleep 10; time - _timeout > 1800};
+            waituntil {sleep 10; time - _time > _timeout};
 
             //["Cleaning up whats left"] call AliVE_fnc_DumpH;
             {deletevehicle _x} foreach (_this select 0);


### PR DESCRIPTION
Rather than waiting until 1800 seconds had passed since the code started, it would wait until 3600 seconds had passed since mission start. Any executions after 3600 seconds (an hour) would finish the timeout after a single "sleep 10" call, essentially immediately deleting the bombs.

New code ensures that the timeout period is `_timeout` (1800) since ambush start instead.