### PR TITLE
[sup_CS] add waypointAttachVehicle for sling loading

### DIFF
--- a/addons/sup_combatsupport/scripts/NEO_radio/fsms/transport.fsm
+++ b/addons/sup_combatsupport/scripts/NEO_radio/fsms/transport.fsm
@@ -2171,7 +2171,8 @@ class FSM
                                          "" \n
                                          "private ""_wp"";" \n
                                          "_wp = group _chopper addWaypoint [_pos, 0]; " \n
-                                         "_wp setWaypointType ""HOOK""; "/*%FSM</ACTION""">*/;
+                                         "_wp setWaypointType ""HOOK""; " \n
+                                         "_wp waypointAttachVehicle ((_pos nearObjects 0.5) select 0);"/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/
                         };


### PR DESCRIPTION
This is a minor fix for some helicopters. Mostly the SOG PF ones. Did multiple tests using a control KingBee with waypoints for slingloading, a vanilla Ghosthawk using CS, and a test KingBee using CS. Control Kingbee worked 100% of the time, Ghosthawk worked with CS module 100% of the time, the KingBee in CS worked only occasionally (almost 0%) and I couldn't figure out exactly why. Worked maybe 1 out of 10 loads of the test mission. Changed it out for several UH1s and still same problem. They also never worked at all in actual missions I made. They would just drop and then climb and hang without picking up the cargo. Saw this fix online and gave it a try. Now it works 100% in my tests. The code change is only to reduce the problem with certain aircraft as it seems vanilla helis are fine without it. They still may act a little wild trying to pick up the cargo but, at least they don't immediately give up.

Note:  Tested using master branch and STEAM current release with CBA only. 