### PR TITLE
Vehicle waypoints should always be exact

### DIFF
--- a/addons/sys_profile/fnc_profileWaypointToWaypoint.sqf
+++ b/addons/sys_profile/fnc_profileWaypointToWaypoint.sqf
@@ -49,15 +49,16 @@ private _waypointStatements = [_profileWaypoint,"statements"] call ALIVE_fnc_has
 private _waypointName = [_profileWaypoint,"name"] call ALiVE_fnc_hashGet;
 
 // If the leader is in a land vehicle, snap waypoints to nearest road within 200m - do not do this if pathfinding enabled
-if (!_pathfindingEnabled &&
+if (
     !isNull (assignedVehicle leader _group) &&
     (assignedVehicle leader _group) isKindOf "LandVehicle"
 ) then {
-    private _road = [_position, 200] call BIS_fnc_nearestRoad;
-    if !(isNull _road) then {
-        _position = (getPos _road) select [0, 2];
-	_radius = -1;
+    if (!_pathfindingEnabled) then {
+        private _road = [_position, 200] call BIS_fnc_nearestRoad;
+        if !(isNull _road) then {
+            _position = (getPos _road) select [0, 2];
     };
+    _radius = -1;
 };
 
 _position set [2,0];

--- a/addons/sys_profile/fnc_profileWaypointToWaypoint.sqf
+++ b/addons/sys_profile/fnc_profileWaypointToWaypoint.sqf
@@ -57,8 +57,9 @@ if (
         private _road = [_position, 200] call BIS_fnc_nearestRoad;
         if !(isNull _road) then {
             _position = (getPos _road) select [0, 2];
+        };
     };
-    _radius = -1;
+    _radius = 0;
 };
 
 _position set [2,0];


### PR DESCRIPTION
If vehicle waypoint radius isn't set to -1, they will be randomized and not follow the roads exactly.