### PR TITLE
Add objective "freezing" functionality to OPCOMs

### DIFF
--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -2663,6 +2663,7 @@ switch(_operation) do {
 
             private _module = [_logic,"module"] call ALiVE_fnc_HashGet;
             private _objectives = [_logic, "objectives", []] call AliVE_fnc_HashGet;
+            private _frozenObjs = [_logic, "frozenObjs", []] call AliVE_fnc_HashGet;
             private _OPCOM_FSM = [_logic,"OPCOM_FSM",-1] call ALiVE_fnc_HashGet;
             private _OPCOM_SKIP_OBJECTIVES = _OPCOM_FSM getFSMvariable ["_OPCOM_SKIP_OBJECTIVES", []];
 
@@ -2673,6 +2674,7 @@ switch(_operation) do {
                 private _objectiveState = [_x, "opcom_state"] call AliVE_fnc_HashGet;
 
                 !(_objectiveID in _OPCOM_SKIP_OBJECTIVES) &&
+		!(_objectiveID in _frozenObjs) &&
                 _objectiveState == _state &&
                 { _allSyncedTriggersActivated || { !(_objectiveState in ["attack","unassigned"]) } }
             };
@@ -2690,6 +2692,25 @@ switch(_operation) do {
                 [_targetObjective,"opcom_orders", _nextOrders] call AliVE_fnc_HashSet;
                 _result = ["execute", _targetObjective];
             };
+        };
+
+        case "FreezeObjective": {
+            ["Freeze Objective Called"] call ALiVE_fnc_DumpR;
+            _frozenObjs = [_logic, "frozenObjs",[]] call ALiVE_fnc_hashGet;
+            _frozenObjs pushBackUnique _args;
+            [_logic, "frozenObjs",_frozenObjs] call ALiVE_fnc_hashSet;
+        };
+
+        case "UnfreezeObjective": {
+            ["Unfreeze Objective Called"] call ALiVE_fnc_DumpR;
+            _frozenObjs = [_logic, "frozenObjs",[]] call ALiVE_fnc_hashGet;
+            _frozenObjs = _frozenObjs - _args;
+            [_logic, "frozenObjs",_frozenObjs] call ALiVE_fnc_hashSet;
+        };
+
+        case "UnfreezeAllObjectives": {
+            ["Unfreeze All Objectives Called"] call ALiVE_fnc_DumpR;
+            [_logic, "frozenObjs",[]] call ALiVE_fnc_hashSet;
         };
 
         case "sectionsamount_attack": {

--- a/addons/mil_opcom/opcom.fsm
+++ b/addons/mil_opcom/opcom.fsm
@@ -330,9 +330,10 @@ class FSM
                          "            _active = 0;" \n
                          "" \n
                          "            {" \n
+                         "		  private _frozenObjs = [_OPCOM_HANDLER, ""frozenObjs"", []] call AliVE_fnc_HashGet;" \n
                          "                private _objectiveID = [_x, ""objectiveID""] call AliVE_fnc_HashGet;" \n
                          "" \n
-                         "                if !(_objectiveID in _OPCOM_SKIP_OBJECTIVES) then {" \n
+                         "                if (!(_objectiveID in _OPCOM_SKIP_OBJECTIVES) && !(_objectiveID in _frozenObjs)) then {" \n
                          "                    private [""_state""];" \n
                          "" \n
                          "                    _state = _x select 2 select 5;" \n


### PR DESCRIPTION
Adds the ability for external scripting to tell OPCOM commanders to ignore/"freeze" certain objectives.

Currently, there is no way to tell the OPCOM commanders to ignore certain objectives without deleting and re-adding the objective later, which breaks the objectives nodes and stops the objective from being a possible location for C2ISTAR tasks.

The system just copies the already built in objective skipping functionality, with some extra functions/cases to add/remove the objectives from the list of objectives to be "frozen"

(This is my first time doing a pull request, so lmk if I did something wrong) 