### PR TITLE
Shuffle CQB start spawn positions.

### DIFF
--- a/addons/mil_cqb/fnc_CQB.sqf
+++ b/addons/mil_cqb/fnc_CQB.sqf
@@ -1273,7 +1273,7 @@ switch(_operation) do {
             };
 
             // position AI
-            _positions = [_house] call ALiVE_fnc_getBuildingPositions;
+            _positions = [[_house] call ALiVE_fnc_getBuildingPositions, 2] call CBA_fnc_shuffle;
 
             if (count _positions == 0) exitwith {_args = _grp};
 


### PR DESCRIPTION
Currently, when units are spawned in by CQB, the game picks the first positions listed in a given building's `buildingPositions` every time. This has significant effects on gameplay because some buildings (CUP's middle eastern village buildings specifically prompted this) have their first positions situated on e.g. the roof of the building, resulting in a bias towards CQB enemies spawning in plain view shooting at players from rooftops.

All this does is shuffle the spawn positions that CQB chooses. I have tested this through overwriting `ALIVE_fnc_CQB` in a mission file and verified it works.