### PR TITLE
used the existing ALiVE_advciv_blacklist flag as the hard opt-out for…

### DIFF
--- a/addons/amb_civ_population/fnc_addCivilianInteraction.sqf
+++ b/addons/amb_civ_population/fnc_addCivilianInteraction.sqf
@@ -21,7 +21,7 @@ params ["_unit"];
 
 // Only proceed if the global interaction handler has been initialised and
 // the unit is actually a civilian
-if (!isNil "ALiVE_civInteractHandler" && {side _unit == CIVILIAN}) then {
+if (!isNil "ALiVE_civInteractHandler" && {side _unit == CIVILIAN} && {!(_unit getVariable ["ALiVE_advciv_blacklist", false])}) then {
     private _hasAdvCiv = _unit getVariable ["ALiVE_advciv_active", false];
 
     if (!_hasAdvCiv) then {
@@ -42,7 +42,7 @@ if (!isNil "ALiVE_civInteractHandler" && {side _unit == CIVILIAN}) then {
             true,
             false,
             "",
-            format ["alive _target && _this distance _target < %1", _range],
+            format ["alive _target && !(_target getVariable ['ALiVE_advciv_blacklist', false]) && _this distance _target < %1", _range],
             _range
         ];
     };

--- a/addons/amb_civ_population/fnc_advciv_brainTick.sqf
+++ b/addons/amb_civ_population/fnc_advciv_brainTick.sqf
@@ -27,6 +27,10 @@ params [["_unit", objNull, [objNull]]];
 
 if (isNull _unit || {!alive _unit} || {isPlayer _unit}) exitWith {};
 if (!(_unit getVariable ["ALiVE_advciv_active", false])) exitWith {};
+if ((_unit getVariable ["ALiVE_advciv_blacklist", false]) || {[_unit] call ALiVE_fnc_advciv_isMissionCritical}) exitWith {
+    _unit setVariable ["ALiVE_advciv_active", false, true];
+    ALiVE_advciv_activeUnits = ALiVE_advciv_activeUnits - [_unit];
+};
 
 // If the unit's side has changed (e.g. killed and replaced), deregister it
 if (side _unit != civilian) exitWith {

--- a/addons/amb_civ_population/fnc_advciv_orderMenu.sqf
+++ b/addons/amb_civ_population/fnc_advciv_orderMenu.sqf
@@ -25,11 +25,13 @@ Peer Reviewed:
 params [["_unit", objNull, [objNull]]];
 
 if (isNull _unit || {!alive _unit}) exitWith {};
+if (_unit getVariable ["ALiVE_advciv_blacklist", false]) exitWith {};
 if (_unit getVariable ["ALiVE_advciv_orderMenuAdded", false]) exitWith {};   // Don't double-add
 
 _unit setVariable ["ALiVE_advciv_orderMenuAdded", true];
 
 private _range = ALiVE_advciv_orderMenuRange;
+private _baseCondition = format ["alive _target && !(_target getVariable ['ALiVE_advciv_blacklist', false]) && _this distance _target < %1", _range];
 
 // --- FOLLOW ME ---
 _unit addAction [
@@ -43,7 +45,7 @@ _unit addAction [
     true,
     true,
     "",
-    format ["alive _target && _this distance _target < %1", _range],
+    _baseCondition,
     _range
 ];
 
@@ -59,7 +61,7 @@ _unit addAction [
     true,
     true,
     "",
-    format ["alive _target && _this distance _target < %1", _range],
+    _baseCondition,
     _range
 ];
 
@@ -75,7 +77,7 @@ _unit addAction [
     true,
     true,
     "",
-    format ["alive _target && _this distance _target < %1", _range],
+    _baseCondition,
     _range
 ];
 
@@ -91,7 +93,7 @@ _unit addAction [
     true,
     true,
     "",
-    format ["alive _target && _this distance _target < %1", _range],
+    _baseCondition,
     _range
 ];
 
@@ -107,7 +109,7 @@ _unit addAction [
     true,
     true,
     "",
-    format ["alive _target && _this distance _target < %1", _range],
+    _baseCondition,
     _range
 ];
 
@@ -123,7 +125,7 @@ _unit addAction [
     true,
     true,
     "",
-    format ["alive _target && _this distance _target < %1", _range],
+    _baseCondition,
     _range
 ];
 
@@ -139,7 +141,7 @@ _unit addAction [
     true,
     true,
     "",
-    format ["alive _target && _this distance _target < %1", _range],
+    _baseCondition,
     _range
 ];
 
@@ -176,7 +178,7 @@ _unit addAction [
     "",
     // Condition: visible only when a qualifying vehicle is actually within range
     format [
-        "alive _target && {_this distance _target < %1} && {
+        "alive _target && {!(_target getVariable ['ALiVE_advciv_blacklist', false])} && {_this distance _target < %1} && {
             private _v = nearestObjects [_target, ['Car','Truck','Motorcycle','Helicopter','Plane','Ship'], 15];
             _v = _v select { alive _x && {canMove _x} && {locked _x < 2} && {isNull driver _x} && {speed _x < 1} && {fuel _x > 0} };
             count _v > 0
@@ -215,7 +217,7 @@ if (!isNil "ALiVE_civInteractHandler") then {
         true,
         true,
         "",
-        format ["alive _target && _this distance _target < %1", _range],
+        _baseCondition,
         _range
     ];
 };

--- a/addons/amb_civ_population/fnc_advciv_react.sqf
+++ b/addons/amb_civ_population/fnc_advciv_react.sqf
@@ -40,6 +40,7 @@ params [["_unit", objNull, [objNull]], ["_type", "GUNFIRE", [""]], ["_extraParam
 
 if (isNull _unit || {!alive _unit}) exitWith {};
 if (isPlayer _unit) exitWith {};
+if (_unit getVariable ["ALiVE_advciv_blacklist", false]) exitWith {};
 if (vehicle _unit != _unit && {_type == "HIT"}) exitWith {};   // Don't react to HIT while in a vehicle
 
 private _inVehicle = (vehicle _unit != _unit);

--- a/addons/amb_civ_population/fnc_civilianPopulationSystemInit.sqf
+++ b/addons/amb_civ_population/fnc_civilianPopulationSystemInit.sqf
@@ -148,9 +148,9 @@ if(isServer) then {
     // ----------------------------------------------------------------
     ALiVE_fnc_advciv_isMissionCritical = {
         params [["_unit", objNull]];
-        if (!ALiVE_advciv_missionCriticalCheck) exitWith { false };
         if (isNull _unit) exitWith { false };
         if (_unit getVariable ["ALiVE_advciv_blacklist", false]) exitWith { true };
+        if (!ALiVE_advciv_missionCriticalCheck) exitWith { false };
 
         private _grp = group _unit;
         // Only block civs in mixed groups (civ + military together)

--- a/addons/mil_c2istar/tasks/fnc_taskAidDelivery.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskAidDelivery.sqf
@@ -140,6 +140,7 @@ switch (_taskState) do {
         _sourceContact setCaptive true;
         _sourceContact setBehaviour "CARELESS";
         _sourceContact setDir random 360;
+        _sourceContact setVariable ["ALiVE_advciv_blacklist", true, true];
         _sourceContact setVariable ["ALiVE_advciv_active", false, true];
 
         private _destinationContactGroup = createGroup [civilian, true];
@@ -153,6 +154,7 @@ switch (_taskState) do {
         _destinationContact setCaptive true;
         _destinationContact setBehaviour "CARELESS";
         _destinationContact setDir random 360;
+        _destinationContact setVariable ["ALiVE_advciv_blacklist", true, true];
         _destinationContact setVariable ["ALiVE_advciv_active", false, true];
 
         private _aidVehicle = createVehicle ["C_Van_01_box_F", _aidVehiclePosition, [], 0, "NONE"];

--- a/addons/mil_c2istar/tasks/fnc_taskCheckpointPartnership.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskCheckpointPartnership.sqf
@@ -207,6 +207,7 @@ switch (_taskState) do {
             _vip setCaptive true;
             _vip setBehaviour "CARELESS";
             _vip setDir random 360;
+            _vip setVariable ["ALiVE_advciv_blacklist", true, true];
             _vip setVariable ["ALiVE_advciv_active", false, true];
             _vipUnits pushBack _vip;
             _cleanup pushBack _vip;
@@ -224,6 +225,7 @@ switch (_taskState) do {
             _crowdUnit setCaptive true;
             _crowdUnit setBehaviour "CARELESS";
             _crowdUnit setDir random 360;
+            _crowdUnit setVariable ["ALiVE_advciv_blacklist", true, true];
             _crowdUnit setVariable ["ALiVE_advciv_active", false, true];
             _crowdUnits pushBack _crowdUnit;
             _cleanup pushBack _crowdUnit;

--- a/addons/mil_c2istar/tasks/fnc_taskInformantExfiltration.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskInformantExfiltration.sqf
@@ -219,6 +219,7 @@ switch (_taskState) do {
         _vip setCaptive true;
         _vip setBehaviour "CARELESS";
         _vip setDir random 360;
+        _vip setVariable ["ALiVE_advciv_blacklist", true, true];
         _vip setVariable ["ALiVE_advciv_active", false, true];
 
         _vip setVariable ["ALIVE_Task_VIPPicked", false, true];

--- a/addons/mil_c2istar/tasks/fnc_taskMarketReopening.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskMarketReopening.sqf
@@ -207,6 +207,7 @@ switch (_taskState) do {
             _vip setCaptive true;
             _vip setBehaviour "CARELESS";
             _vip setDir random 360;
+            _vip setVariable ["ALiVE_advciv_blacklist", true, true];
             _vip setVariable ["ALiVE_advciv_active", false, true];
             _vipUnits pushBack _vip;
             _cleanup pushBack _vip;
@@ -224,6 +225,7 @@ switch (_taskState) do {
             _crowdUnit setCaptive true;
             _crowdUnit setBehaviour "CARELESS";
             _crowdUnit setDir random 360;
+            _crowdUnit setVariable ["ALiVE_advciv_blacklist", true, true];
             _crowdUnit setVariable ["ALiVE_advciv_active", false, true];
             _crowdUnits pushBack _crowdUnit;
             _cleanup pushBack _crowdUnit;

--- a/addons/mil_c2istar/tasks/fnc_taskMedicalOutreach.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskMedicalOutreach.sqf
@@ -90,6 +90,7 @@ switch (_taskState) do {
         _contact setCaptive true;
         _contact setBehaviour "CARELESS";
         _contact setDir random 360;
+        _contact setVariable ["ALiVE_advciv_blacklist", true, true];
         _contact setVariable ["ALiVE_advciv_active", false, true];
 
         private _aidCrate = createVehicle ["Land_WoodenCrate_01_F", _cratePosition, [], 0, "NONE"];

--- a/addons/mil_c2istar/tasks/fnc_taskMeetLocalLeader.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskMeetLocalLeader.sqf
@@ -87,6 +87,7 @@ switch (_taskState) do {
         _leader setCaptive true;
         _leader setBehaviour "CARELESS";
         _leader setDir random 360;
+        _leader setVariable ["ALiVE_advciv_blacklist", true, true];
         _leader setVariable ["ALiVE_advciv_active", false, true];
         private _completionVar = format ["ALIVE_Task_%1_LeaderMet", _taskID];
         _leader setVariable [_completionVar, false, true];

--- a/addons/mil_c2istar/tasks/fnc_taskSecureCommunityEvent.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskSecureCommunityEvent.sqf
@@ -207,6 +207,7 @@ switch (_taskState) do {
             _vip setCaptive true;
             _vip setBehaviour "CARELESS";
             _vip setDir random 360;
+            _vip setVariable ["ALiVE_advciv_blacklist", true, true];
             _vip setVariable ["ALiVE_advciv_active", false, true];
             _vipUnits pushBack _vip;
             _cleanup pushBack _vip;
@@ -224,6 +225,7 @@ switch (_taskState) do {
             _crowdUnit setCaptive true;
             _crowdUnit setBehaviour "CARELESS";
             _crowdUnit setDir random 360;
+            _crowdUnit setVariable ["ALiVE_advciv_blacklist", true, true];
             _crowdUnit setVariable ["ALiVE_advciv_active", false, true];
             _crowdUnits pushBack _crowdUnit;
             _cleanup pushBack _crowdUnit;

--- a/addons/mil_c2istar/tasks/fnc_taskSupplyConvoy.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskSupplyConvoy.sqf
@@ -153,6 +153,7 @@ switch (_taskState) do {
         _sourceContact setCaptive true;
         _sourceContact setBehaviour "CARELESS";
         _sourceContact setDir random 360;
+        _sourceContact setVariable ["ALiVE_advciv_blacklist", true, true];
         _sourceContact setVariable ["ALiVE_advciv_active", false, true];
 
         private _destinationContactGroup = createGroup [civilian, true];
@@ -166,6 +167,7 @@ switch (_taskState) do {
         _destinationContact setCaptive true;
         _destinationContact setBehaviour "CARELESS";
         _destinationContact setDir random 360;
+        _destinationContact setVariable ["ALiVE_advciv_blacklist", true, true];
         _destinationContact setVariable ["ALiVE_advciv_active", false, true];
 
         private _convoyVehicle = createVehicle ["C_Van_01_box_F", _convoyPosition, [], 0, "NONE"];

--- a/addons/mil_c2istar/tasks/fnc_taskVIPEscort.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskVIPEscort.sqf
@@ -221,6 +221,7 @@ switch (_taskState) do {
         _vip setCaptive true;
         _vip setBehaviour "CARELESS";
         _vip setDir random 360;
+        _vip setVariable ["ALiVE_advciv_blacklist", true, true];
         _vip setVariable ["ALiVE_advciv_active", false, true];
 
         _vip setVariable ["ALIVE_Task_VIPPicked", false, true];


### PR DESCRIPTION
… C2ISTAR civic task agents.

I applied the same protection to the civic task civilians: VIP Escort,  informant, aid/convoy contacts, local leader, medical contact, and community-event crowds.

I also tightened AdvCiv so blacklisted units do not get or respond to player order actions. The blacklist now works even if the AdvCiv mission-critical check setting is disabled.