### PR TITLE
added a task-owned profile cleanup helper

### DIFF
--- a/addons/mil_c2istar/CfgFunctions.hpp
+++ b/addons/mil_c2istar/CfgFunctions.hpp
@@ -216,6 +216,11 @@ class CfgFunctions {
                 file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetStateOfEntityProfiles.sqf";
                 RECOMPILE;
             };
+            class taskDestroyEntityProfiles {
+                description = "Utility destroy task-owned entity profiles";
+                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskDestroyEntityProfiles.sqf";
+                RECOMPILE;
+            };
             class taskGetStateOfObjects {
                 description = "Utility have all the entity profiles been destroyed";
                 file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetStateOfObjects.sqf";

--- a/addons/mil_c2istar/tasks/fnc_taskCheckpointPartnership.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskCheckpointPartnership.sqf
@@ -306,6 +306,7 @@ switch (_taskState) do {
         [_taskParams, "lastState", ""] call ALIVE_fnc_hashSet;
         [_taskParams, "siteActive", false] call ALIVE_fnc_hashSet;
         [_taskParams, "holdUntil", 0] call ALIVE_fnc_hashSet;
+        [_taskParams, "forceCompleteAt", 0] call ALIVE_fnc_hashSet;
         [_taskParams, "currentWave", 1] call ALIVE_fnc_hashSet;
         [_taskParams, "lastWave", 0] call ALIVE_fnc_hashSet;
         [_taskParams, "totalWaves", 2 + floor (random 2)] call ALIVE_fnc_hashSet;
@@ -370,6 +371,7 @@ switch (_taskState) do {
                 [_params] call _activateAttendees;
                 [_params, "siteActive", true] call ALIVE_fnc_hashSet;
                 [_params, "holdUntil", serverTime + 540] call ALIVE_fnc_hashSet;
+                [_params, "forceCompleteAt", serverTime + 1140] call ALIVE_fnc_hashSet;
                 [_params, "nextWaveAt", serverTime + 30] call ALIVE_fnc_hashSet;
                 [_params, "nextTask", ([_params, "taskIDs"] call ALIVE_fnc_hashGet) select 2] call ALIVE_fnc_hashSet;
 
@@ -399,6 +401,7 @@ switch (_taskState) do {
         private _taskDialog = [_params, "dialog"] call ALIVE_fnc_hashGet;
         private _currentTaskDialog = [_taskDialog, "Secure"] call ALIVE_fnc_hashGet;
         private _holdUntil = [_params, "holdUntil", 0] call ALIVE_fnc_hashGet;
+        private _forceCompleteAt = [_params, "forceCompleteAt", 0] call ALIVE_fnc_hashGet;
         private _currentWave = [_params, "currentWave", 1] call ALIVE_fnc_hashGet;
         private _lastWave = [_params, "lastWave", 0] call ALIVE_fnc_hashGet;
         private _totalWaves = [_params, "totalWaves", 2] call ALIVE_fnc_hashGet;
@@ -475,7 +478,30 @@ switch (_taskState) do {
             _currentWave = [_params, "currentWave", _currentWave] call ALIVE_fnc_hashGet;
             _entityProfileIDs = [_params, "entityProfileIDs", []] call ALIVE_fnc_hashGet;
 
-            if (_currentWave > _totalWaves && {_entityProfileIDs isEqualTo []} && {serverTime >= _holdUntil} && {[_taskPosition, _taskPlayers, _taskSide, 250] call ALIVE_fnc_taskIsAreaClearOfEnemies}) then {
+            if (_forceCompleteAt <= 0 && {_holdUntil > 0}) then {
+                _forceCompleteAt = _holdUntil + 600;
+                [_params, "forceCompleteAt", _forceCompleteAt] call ALIVE_fnc_hashSet;
+            };
+
+            private _areaClear = [_taskPosition, _taskPlayers, _taskSide, 250] call ALIVE_fnc_taskIsAreaClearOfEnemies;
+            private _staleWave = !(_entityProfileIDs isEqualTo []) && {serverTime >= _holdUntil} && {_forceCompleteAt > 0} && {serverTime >= _forceCompleteAt};
+
+            if (_staleWave) then {
+                private _playersNear = [_taskPosition, _taskPlayers, 1000] call ALIVE_fnc_taskHavePlayersReachedDestination;
+                private _realAreaClear = _playersNear && {!([_taskPosition, _taskSide, 250, false] call ALIVE_fnc_isEnemyNear)};
+
+                if (_areaClear || {_realAreaClear}) then {
+                    [_entityProfileIDs] call ALIVE_fnc_taskDestroyEntityProfiles;
+                    [_params, "entityProfileIDs", []] call ALIVE_fnc_hashSet;
+                    [_params, "currentWave", _totalWaves + 1] call ALIVE_fnc_hashSet;
+                    [_params, "nextWaveAt", 0] call ALIVE_fnc_hashSet;
+                    _currentWave = _totalWaves + 1;
+                    _entityProfileIDs = [];
+                    _areaClear = [_taskPosition, _taskPlayers, _taskSide, 250] call ALIVE_fnc_taskIsAreaClearOfEnemies;
+                };
+            };
+
+            if (_currentWave > _totalWaves && {_entityProfileIDs isEqualTo []} && {serverTime >= _holdUntil} && {_areaClear}) then {
                 [_params, "nextTask", ""] call ALIVE_fnc_hashSet;
 
                 _task set [8, "Succeeded"];

--- a/addons/mil_c2istar/tasks/fnc_taskMarketReopening.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskMarketReopening.sqf
@@ -306,6 +306,7 @@ switch (_taskState) do {
         [_taskParams, "lastState", ""] call ALIVE_fnc_hashSet;
         [_taskParams, "siteActive", false] call ALIVE_fnc_hashSet;
         [_taskParams, "holdUntil", 0] call ALIVE_fnc_hashSet;
+        [_taskParams, "forceCompleteAt", 0] call ALIVE_fnc_hashSet;
         [_taskParams, "currentWave", 1] call ALIVE_fnc_hashSet;
         [_taskParams, "lastWave", 0] call ALIVE_fnc_hashSet;
         [_taskParams, "totalWaves", 2 + floor (random 2)] call ALIVE_fnc_hashSet;
@@ -370,6 +371,7 @@ switch (_taskState) do {
                 [_params] call _activateAttendees;
                 [_params, "siteActive", true] call ALIVE_fnc_hashSet;
                 [_params, "holdUntil", serverTime + 540] call ALIVE_fnc_hashSet;
+                [_params, "forceCompleteAt", serverTime + 1140] call ALIVE_fnc_hashSet;
                 [_params, "nextWaveAt", serverTime + 30] call ALIVE_fnc_hashSet;
                 [_params, "nextTask", ([_params, "taskIDs"] call ALIVE_fnc_hashGet) select 2] call ALIVE_fnc_hashSet;
 
@@ -399,6 +401,7 @@ switch (_taskState) do {
         private _taskDialog = [_params, "dialog"] call ALIVE_fnc_hashGet;
         private _currentTaskDialog = [_taskDialog, "Secure"] call ALIVE_fnc_hashGet;
         private _holdUntil = [_params, "holdUntil", 0] call ALIVE_fnc_hashGet;
+        private _forceCompleteAt = [_params, "forceCompleteAt", 0] call ALIVE_fnc_hashGet;
         private _currentWave = [_params, "currentWave", 1] call ALIVE_fnc_hashGet;
         private _lastWave = [_params, "lastWave", 0] call ALIVE_fnc_hashGet;
         private _totalWaves = [_params, "totalWaves", 2] call ALIVE_fnc_hashGet;
@@ -475,7 +478,30 @@ switch (_taskState) do {
             _currentWave = [_params, "currentWave", _currentWave] call ALIVE_fnc_hashGet;
             _entityProfileIDs = [_params, "entityProfileIDs", []] call ALIVE_fnc_hashGet;
 
-            if (_currentWave > _totalWaves && {_entityProfileIDs isEqualTo []} && {serverTime >= _holdUntil} && {[_taskPosition, _taskPlayers, _taskSide, 250] call ALIVE_fnc_taskIsAreaClearOfEnemies}) then {
+            if (_forceCompleteAt <= 0 && {_holdUntil > 0}) then {
+                _forceCompleteAt = _holdUntil + 600;
+                [_params, "forceCompleteAt", _forceCompleteAt] call ALIVE_fnc_hashSet;
+            };
+
+            private _areaClear = [_taskPosition, _taskPlayers, _taskSide, 250] call ALIVE_fnc_taskIsAreaClearOfEnemies;
+            private _staleWave = !(_entityProfileIDs isEqualTo []) && {serverTime >= _holdUntil} && {_forceCompleteAt > 0} && {serverTime >= _forceCompleteAt};
+
+            if (_staleWave) then {
+                private _playersNear = [_taskPosition, _taskPlayers, 1000] call ALIVE_fnc_taskHavePlayersReachedDestination;
+                private _realAreaClear = _playersNear && {!([_taskPosition, _taskSide, 250, false] call ALIVE_fnc_isEnemyNear)};
+
+                if (_areaClear || {_realAreaClear}) then {
+                    [_entityProfileIDs] call ALIVE_fnc_taskDestroyEntityProfiles;
+                    [_params, "entityProfileIDs", []] call ALIVE_fnc_hashSet;
+                    [_params, "currentWave", _totalWaves + 1] call ALIVE_fnc_hashSet;
+                    [_params, "nextWaveAt", 0] call ALIVE_fnc_hashSet;
+                    _currentWave = _totalWaves + 1;
+                    _entityProfileIDs = [];
+                    _areaClear = [_taskPosition, _taskPlayers, _taskSide, 250] call ALIVE_fnc_taskIsAreaClearOfEnemies;
+                };
+            };
+
+            if (_currentWave > _totalWaves && {_entityProfileIDs isEqualTo []} && {serverTime >= _holdUntil} && {_areaClear}) then {
                 [_params, "nextTask", ""] call ALIVE_fnc_hashSet;
 
                 _task set [8, "Succeeded"];

--- a/addons/mil_c2istar/tasks/fnc_taskSecureCommunityEvent.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskSecureCommunityEvent.sqf
@@ -306,6 +306,7 @@ switch (_taskState) do {
         [_taskParams, "lastState", ""] call ALIVE_fnc_hashSet;
         [_taskParams, "siteActive", false] call ALIVE_fnc_hashSet;
         [_taskParams, "holdUntil", 0] call ALIVE_fnc_hashSet;
+        [_taskParams, "forceCompleteAt", 0] call ALIVE_fnc_hashSet;
         [_taskParams, "currentWave", 1] call ALIVE_fnc_hashSet;
         [_taskParams, "lastWave", 0] call ALIVE_fnc_hashSet;
         [_taskParams, "totalWaves", 2 + floor (random 2)] call ALIVE_fnc_hashSet;
@@ -370,6 +371,7 @@ switch (_taskState) do {
                 [_params] call _activateAttendees;
                 [_params, "siteActive", true] call ALIVE_fnc_hashSet;
                 [_params, "holdUntil", serverTime + 540] call ALIVE_fnc_hashSet;
+                [_params, "forceCompleteAt", serverTime + 1140] call ALIVE_fnc_hashSet;
                 [_params, "nextWaveAt", serverTime + 30] call ALIVE_fnc_hashSet;
                 [_params, "nextTask", ([_params, "taskIDs"] call ALIVE_fnc_hashGet) select 2] call ALIVE_fnc_hashSet;
 
@@ -399,6 +401,7 @@ switch (_taskState) do {
         private _taskDialog = [_params, "dialog"] call ALIVE_fnc_hashGet;
         private _currentTaskDialog = [_taskDialog, "Secure"] call ALIVE_fnc_hashGet;
         private _holdUntil = [_params, "holdUntil", 0] call ALIVE_fnc_hashGet;
+        private _forceCompleteAt = [_params, "forceCompleteAt", 0] call ALIVE_fnc_hashGet;
         private _currentWave = [_params, "currentWave", 1] call ALIVE_fnc_hashGet;
         private _lastWave = [_params, "lastWave", 0] call ALIVE_fnc_hashGet;
         private _totalWaves = [_params, "totalWaves", 2] call ALIVE_fnc_hashGet;
@@ -475,7 +478,30 @@ switch (_taskState) do {
             _currentWave = [_params, "currentWave", _currentWave] call ALIVE_fnc_hashGet;
             _entityProfileIDs = [_params, "entityProfileIDs", []] call ALIVE_fnc_hashGet;
 
-            if (_currentWave > _totalWaves && {_entityProfileIDs isEqualTo []} && {serverTime >= _holdUntil} && {[_taskPosition, _taskPlayers, _taskSide, 250] call ALIVE_fnc_taskIsAreaClearOfEnemies}) then {
+            if (_forceCompleteAt <= 0 && {_holdUntil > 0}) then {
+                _forceCompleteAt = _holdUntil + 600;
+                [_params, "forceCompleteAt", _forceCompleteAt] call ALIVE_fnc_hashSet;
+            };
+
+            private _areaClear = [_taskPosition, _taskPlayers, _taskSide, 250] call ALIVE_fnc_taskIsAreaClearOfEnemies;
+            private _staleWave = !(_entityProfileIDs isEqualTo []) && {serverTime >= _holdUntil} && {_forceCompleteAt > 0} && {serverTime >= _forceCompleteAt};
+
+            if (_staleWave) then {
+                private _playersNear = [_taskPosition, _taskPlayers, 1000] call ALIVE_fnc_taskHavePlayersReachedDestination;
+                private _realAreaClear = _playersNear && {!([_taskPosition, _taskSide, 250, false] call ALIVE_fnc_isEnemyNear)};
+
+                if (_areaClear || {_realAreaClear}) then {
+                    [_entityProfileIDs] call ALIVE_fnc_taskDestroyEntityProfiles;
+                    [_params, "entityProfileIDs", []] call ALIVE_fnc_hashSet;
+                    [_params, "currentWave", _totalWaves + 1] call ALIVE_fnc_hashSet;
+                    [_params, "nextWaveAt", 0] call ALIVE_fnc_hashSet;
+                    _currentWave = _totalWaves + 1;
+                    _entityProfileIDs = [];
+                    _areaClear = [_taskPosition, _taskPlayers, _taskSide, 250] call ALIVE_fnc_taskIsAreaClearOfEnemies;
+                };
+            };
+
+            if (_currentWave > _totalWaves && {_entityProfileIDs isEqualTo []} && {serverTime >= _holdUntil} && {_areaClear}) then {
                 [_params, "nextTask", ""] call ALIVE_fnc_hashSet;
 
                 _task set [8, "Succeeded"];

--- a/addons/mil_c2istar/utils/fnc_taskDestroyEntityProfiles.sqf
+++ b/addons/mil_c2istar/utils/fnc_taskDestroyEntityProfiles.sqf
@@ -1,0 +1,58 @@
+#include "\x\alive\addons\mil_C2ISTAR\script_component.hpp"
+SCRIPT(taskDestroyEntityProfiles);
+
+/* ----------------------------------------------------------------------------
+Function: ALIVE_fnc_taskDestroyEntityProfiles
+
+Description:
+Destroy task-owned entity profiles and any linked vehicle profiles.
+
+Parameters:
+Array - Profile IDs
+
+Returns:
+Array - Destroyed profile IDs
+
+Author:
+Javen
+Jman
+---------------------------------------------------------------------------- */
+
+params [
+    ["_profileIDs", [], [[]]]
+];
+
+private _profilesToDestroy = [];
+
+{
+    private _profile = [ALIVE_profileHandler, "getProfile", _x] call ALIVE_fnc_profileHandler;
+
+    if !(isNil "_profile") then {
+        _profilesToDestroy pushBackUnique (_profile select 2 select 4);
+
+        if ((_profile select 2 select 5) == "entity") then {
+            {
+                if (_x isEqualType "") then {
+                    _profilesToDestroy pushBackUnique _x;
+                };
+            } forEach ((_profile select 2 select 8) + (_profile select 2 select 9));
+        };
+    };
+} forEach _profileIDs;
+
+{
+    private _profile = [ALIVE_profileHandler, "getProfile", _x] call ALIVE_fnc_profileHandler;
+
+    if !(isNil "_profile") then {
+        switch (_profile select 2 select 5) do {
+            case "entity": {
+                [_profile, "destroy"] call ALIVE_fnc_profileEntity;
+            };
+            case "vehicle": {
+                [_profile, "destroy"] call ALIVE_fnc_profileVehicle;
+            };
+        };
+    };
+} forEach _profilesToDestroy;
+
+_profilesToDestroy


### PR DESCRIPTION
and registered it

Then I wired a stale-wave fallback into the shared hold logic 

Behavior now: normal completion is unchanged, but after the 9-minute hold plus a 10-minute grace period, if a task-owned wave profile is still blocking and the real objective area is clear with a task player nearby, the task destroys those task-owned profiles, rechecks the normal area-clear condition, and completes instead of hanging forever.