### PR TITLE
[CIV_PLACEMENT] Implemented a roadblock fix across both civ placement paths

### DIFF
--- a/addons/civ_placement/fnc_CP.sqf
+++ b/addons/civ_placement/fnc_CP.sqf
@@ -611,21 +611,25 @@ switch(_operation) do {
                     if (parsenumber([_logic, "roadBlocks"] call MAINCLASS) > 0) then {
                         [_logic] spawn {
 
-                            private ["_logic","_roadBlocks","_debug"];
+                            private ["_logic","_roadBlocks","_debug","_maxRoadblockSpawnAttempts","_lastRoadblockDebug"];
 
                             _logic = _this select 0;
 
                             _roadBlocks = parsenumber([_logic, "roadBlocks"] call MAINCLASS);
                             _debug = [_logic, "debug"] call MAINCLASS;
+                            _maxRoadblockSpawnAttempts = 10;
+                            _lastRoadblockDebug = -30;
 
                             if (_debug) then { ["TOTAL VAR(ROADBLOCK_LOCATIONS): %1, count: %2", GVAR(ROADBLOCK_LOCATIONS), count GVAR(ROADBLOCK_LOCATIONS)] call ALiVE_fnc_dump };
 											  
                             while {count GVAR(ROADBLOCK_LOCATIONS) > 0} do {
-                                private ["_timer"];
+                                private ["_timer","_spawnChecks"];
 
                                 _timer = time;
+                                _spawnChecks = 0;
+
                                 {
-                                    private ["_position","_size","_spawn"];
+                                    private ["_position","_size","_spawn","_attempts","_thisroadblockResult"];
 
                                     if (!isnil "_x") then {
 
@@ -644,11 +648,22 @@ switch(_operation) do {
                                             };
 
                                             if (_spawn) then {
-                                                _thisroadblockResult = [_position, _size + 150, ceil(_roadblocks / 30), _debug] call ALiVE_fnc_createRoadblock;
+                                                _spawnChecks = _spawnChecks + 1;
+                                                _thisroadblockResult = [_position, _size + 150, ceil(_roadBlocks / 30), _debug] call ALiVE_fnc_createRoadblock;
                                                 if (_debug) then { ["_thisroadblockResult: %1, count: %2", _thisroadblockResult, count _thisroadblockResult] call ALiVE_fnc_dump };
                                                  if (count _thisroadblockResult > 0)  then {
                                                    GVAR(ROADBLOCK_LOCATIONS) set [_foreachIndex, -1];
-                                                 };
+                                                 } else {
+                                                   _attempts = if (count _x > 2) then {_x select 2} else {0};
+                                                   _attempts = _attempts + 1;
+
+                                                   if (_attempts >= _maxRoadblockSpawnAttempts) then {
+                                                       GVAR(ROADBLOCK_LOCATIONS) set [_foreachIndex, -1];
+                                                       if (_debug) then { ["Roadblock at %1 failed to spawn after %2 attempts; removing from queue", _position, _attempts] call ALiVE_fnc_dump };
+                                                   } else {
+                                                       GVAR(ROADBLOCK_LOCATIONS) set [_foreachIndex, [_position, _size, _attempts]];
+                                                   };
+                                                };
                                                 if (_debug) then { ["VAR(ROADBLOCK_LOCATIONS): %1, count: %2", GVAR(ROADBLOCK_LOCATIONS), count GVAR(ROADBLOCK_LOCATIONS)] call ALiVE_fnc_dump };
                                             };
                                         };
@@ -657,7 +672,10 @@ switch(_operation) do {
 
                                 GVAR(ROADBLOCK_LOCATIONS) = GVAR(ROADBLOCK_LOCATIONS) - [-1];
 
-                                if (_debug) then {["Roadblock iteration time: %1 secs for %2 entries...", time - _timer, count GVAR(ROADBLOCK_LOCATIONS)] call ALiVE_fnc_dump};
+                                if (_debug && {(_spawnChecks > 0) || {time - _lastRoadblockDebug > 30}}) then {
+                                    ["Roadblock iteration time: %1 secs for %2 entries...", time - _timer, count GVAR(ROADBLOCK_LOCATIONS)] call ALiVE_fnc_dump;
+                                    _lastRoadblockDebug = time;
+                                };
 
                                 sleep 1;
                             };

--- a/addons/civ_placement/fnc_createRoadblock.sqf
+++ b/addons/civ_placement/fnc_createRoadblock.sqf
@@ -41,6 +41,7 @@ params [
 ];
 
 private _result = [];
+_vehicle = objNull;
 
 if (isnil QGVAR(ROADBLOCKS)) then {GVAR(ROADBLOCKS) = []};
 
@@ -85,6 +86,7 @@ for "_i" from 1 to _num do {
 for "_j" from 1 to (count _roadpoints) do {
 
     _roadpos = _roadpoints select (_j - 1);
+    _vehicle = objNull;
 
     if ({_roadpos distance _x < 100} count GVAR(ROADBLOCKS) > 0) exitWith {["Roadblock %1 to close to another! Not created...",_roadpos] call ALiVE_fnc_dump};
 
@@ -136,7 +138,7 @@ for "_j" from 1 to (count _roadpoints) do {
     };
 
     if (!isNil "ALiVE_compositions_roadblocks") then {
-        _checkpoint = [(selectRandom ALiVE_compositions_roadblocks), _CompType] call ALiVE_fnc_findComposition;
+        _checkpoint = [(selectRandom ALiVE_compositions_roadblocks), _compType] call ALiVE_fnc_findComposition;
     } else {
         private ["_cat","_size"];
         _cat = ["CheckpointsBarricades"];
@@ -180,30 +182,32 @@ for "_j" from 1 to (count _roadpoints) do {
     private _vehicleTypes = [1, _fac, "Car"] call ALiVE_fnc_findVehicleType;
     _vehicleTypes = _vehicleTypes - ALiVE_PLACEMENT_VEHICLEBLACKLIST;
 
-    _vehtype = selectRandom _vehicleTypes;
-   
-    // randomise 50/50 spawn...
-    private _randomVehicleDice = round(random 99);
-    if (_randomVehicleDice % 2 == 0) then {   
-      if (!isNil "_vehtype") then {
-     	 private _parkingPosition = [_vehtype, _roadpos, _compClassnames, false] call ALIVE_fnc_getParkingPosition; 	   
-     	 if (count _parkingPosition > 0) then {
-     	  	private _parkPosition = _parkingPosition select 0;
-     	  	private _parkDirection = _parkingPosition select 1; 
-         if !(isnil "ALiVE_ProfileHandler") then {
-            _vehicle = [_vehtype, [_fac call ALiVE_fnc_factionSide] call ALiVE_fnc_sideToSideText, _fac, _parkPosition, _parkDirection, true, _fac, [], true] call ALiVE_fnc_createProfileVehicle;
-         } else {
-             _vehicle = createVehicle [_vehtype, _parkPosition, [], 0, "NONE"];
-             _vehicle setDir _parkDirection;
-             _vehicle setposATL (getposATL _vehicle);
-         };
-         // DEBUG -------------------------------------------------------------------------------------
-         if(_debug) then {
-           ["ALIVE_fnc_createRoadBlock _vehicleClass: %1, _parkPosition: %2, _parkDirection: %3", _vehtype, _parkPosition, _parkDirection] call ALiVE_fnc_dump;
-         };        
-         // DEBUG -------------------------------------------------------------------------------------
-       };
-      };
+    if (count _vehicleTypes > 0) then {
+        _vehtype = selectRandom _vehicleTypes;
+
+        // randomise 50/50 spawn...
+        private _randomVehicleDice = round(random 99);
+        if (_randomVehicleDice % 2 == 0) then {
+            if (!isNil "_vehtype") then {
+                private _parkingPosition = [_vehtype, _roadpos, _compClassnames, false] call ALIVE_fnc_getParkingPosition;
+                if (count _parkingPosition > 0) then {
+                    private _parkPosition = _parkingPosition select 0;
+                    private _parkDirection = _parkingPosition select 1;
+                    if !(isnil "ALiVE_ProfileHandler") then {
+                        _vehicle = [_vehtype, [_fac call ALiVE_fnc_factionSide] call ALiVE_fnc_sideToSideText, _fac, _parkPosition, _parkDirection, true, _fac, [], true] call ALiVE_fnc_createProfileVehicle;
+                    } else {
+                        _vehicle = createVehicle [_vehtype, _parkPosition, [], 0, "NONE"];
+                        _vehicle setDir _parkDirection;
+                        _vehicle setposATL (getposATL _vehicle);
+                    };
+                    // DEBUG -------------------------------------------------------------------------------------
+                    if(_debug) then {
+                        ["ALIVE_fnc_createRoadBlock _vehicleClass: %1, _parkPosition: %2, _parkDirection: %3", _vehtype, _parkPosition, _parkDirection] call ALiVE_fnc_dump;
+                    };
+                    // DEBUG -------------------------------------------------------------------------------------
+                };
+            };
+        };
     };
 
     // Spawn static virtual group if Profile System is loaded and get them to defend
@@ -237,7 +241,7 @@ for "_j" from 1 to (count _roadpoints) do {
 
             // Spawn group and get them to defend
             _blockers = [getpos _roadpos, _side, "Infantry", _fac] call ALiVE_fnc_randomGroupByType;
-            if (isNil "_vehicle") then {
+            if !(isNull _vehicle) then {
                 _blockers addVehicle _vehicle;
             };
 

--- a/addons/civ_placement_custom/fnc_CPC.sqf
+++ b/addons/civ_placement_custom/fnc_CPC.sqf
@@ -286,9 +286,12 @@ switch (_operation) do {
 
                         private _roadBlocks = parseNumber([_logic, "roadBlocks"] call MAINCLASS);
                         private _debug = [_logic, "debug"] call MAINCLASS;
+                        private _maxRoadblockSpawnAttempts = 10;
+                        private _lastRoadblockDebug = -30;
 
                         while {count GVAR(ROADBLOCK_LOCATIONS) > 0} do {
                             private _timer = time;
+                            private _spawnChecks = 0;
 
                             {
                                 if (_x isEqualType []) then {
@@ -305,12 +308,31 @@ switch (_operation) do {
                                     };
 
                                     if (_spawn) then {
+                                        _spawnChecks = _spawnChecks + 1;
+
                                         private _roadblockResult = [_position, _size + 150, ceil(_roadBlocks / 30), _debug] call ALiVE_fnc_createRoadblock;
+                                        private _roadblockLocation = [_position, _size];
+
                                         if (count _roadblockResult > 0) then {
-                                            private _roadblockLocation = [_position, _size];
                                             GVAR(ROADBLOCK_LOCATIONS) set [_forEachIndex, -1];
                                             if !(isNil "ALIVE_CIV_PLACEMENT_ROADBLOCK_LOCATIONS") then {
                                                 ALIVE_CIV_PLACEMENT_ROADBLOCK_LOCATIONS = ALIVE_CIV_PLACEMENT_ROADBLOCK_LOCATIONS select {!(_x isEqualTo _roadblockLocation)};
+                                            };
+                                        } else {
+                                            private _attempts = if (count _x > 2) then {_x select 2} else {0};
+                                            _attempts = _attempts + 1;
+
+                                            if (_attempts >= _maxRoadblockSpawnAttempts) then {
+                                                GVAR(ROADBLOCK_LOCATIONS) set [_forEachIndex, -1];
+                                                if !(isNil "ALIVE_CIV_PLACEMENT_ROADBLOCK_LOCATIONS") then {
+                                                    ALIVE_CIV_PLACEMENT_ROADBLOCK_LOCATIONS = ALIVE_CIV_PLACEMENT_ROADBLOCK_LOCATIONS select {!(_x isEqualTo _roadblockLocation)};
+                                                };
+
+                                                if (_debug) then {
+                                                    ["Roadblock at %1 failed to spawn after %2 attempts; removing from queue", _position, _attempts] call ALiVE_fnc_dump;
+                                                };
+                                            } else {
+                                                GVAR(ROADBLOCK_LOCATIONS) set [_forEachIndex, [_position, _size, _attempts]];
                                             };
                                         };
                                     };
@@ -319,8 +341,9 @@ switch (_operation) do {
 
                             GVAR(ROADBLOCK_LOCATIONS) = GVAR(ROADBLOCK_LOCATIONS) - [-1];
 
-                            if (_debug) then {
+                            if (_debug && {(_spawnChecks > 0) || {time - _lastRoadblockDebug > 30}}) then {
                                 ["Roadblock iteration time: %1 secs for %2 entries...", time - _timer, count GVAR(ROADBLOCK_LOCATIONS)] call ALiVE_fnc_dump;
+                                _lastRoadblockDebug = time;
                             };
 
                             sleep 1;


### PR DESCRIPTION
Changed:

Now tracks failed roadblock spawn attempts, removes a queued/persistent roadblock after 10 real spawn failures, and throttles the Roadblock iteration time debug heartbeat.
Mirrors the same retry limit/debug throttling for the stock civ placement module, and fixes the _roadBlocks reference in that spawn call.
Initializes/resets _vehicle, avoids selectRandom on an empty vehicle list, fixes _compType casing, and corrects the inverted nil guard so addVehicle is only called with a real vehicle.