### PR TITLE
Add Military Logistics Simulation for player support assets

### DIFF
--- a/addons/mil_logistics/fnc_ML.sqf
+++ b/addons/mil_logistics/fnc_ML.sqf
@@ -2534,13 +2534,23 @@ switch(_operation) do {
                 missionNamespace setVariable ["ALIVE_resupply_activeCount", (_count - 1) max 0, true];
             };
 
+            // Multi-ML routing: every ML module receives every LOGCOM_RESUPPLY event.
+            // Only the module matching this event's side should handle it. Silent exit for others
+            // (matches upstream LOGCOM_REQUEST routing; no activeCount touch - the owning module
+            // will handle the accounting).
+            private _moduleSide = [_logic, "side"] call MAINCLASS;
+            if (_moduleSide != _eventSide) exitWith {};
+
             // Determine source position.
             private _sourcePos = getPos _logic;  // Default: Static = LOGCOM module position.
 
             if (_sourceMode == 1) then {
-                // Dynamic: find nearest friendly-held objective.
-                private _bestDist = 1e10;
-                private _bestPos = _sourcePos;
+                // Dynamic: collect every friendly-held defend/reserve objective, sort by distance
+                // to the target, roll for a set size of 2 or 3, then pick at random from that set.
+                // Two layers of variance (depth of the supply route + pick within it) so the source
+                // isn't trivially predictable and it simulates drawing from a route rather than
+                // always the single nearest stash.
+                private _candidates = [];  // [[dist, pos], ...]
                 {
                     private _handler = _x getVariable ["handler", objNull];
                     if (!isNull _handler) then {
@@ -2551,18 +2561,62 @@ switch(_operation) do {
                                 private _objState = [_x, "opcom_state", "none"] call ALiVE_fnc_HashGet;
                                 if (_objState in ["defend", "reserve"]) then {
                                     private _objPos = [_x, "center"] call ALiVE_fnc_HashGet;
-                                    private _dist = _objPos distance2D _targetPos;
-                                    if (_dist < _bestDist) then {
-                                        _bestDist = _dist;
-                                        _bestPos = _objPos;
-                                    };
+                                    _candidates pushBack [_objPos distance2D _targetPos, _objPos];
                                 };
                             } forEach _objectives;
                         };
                     };
                 } forEach (missionNamespace getVariable ["OPCOM_instances", []]);
-                _sourcePos = _bestPos;
+
+                if (count _candidates > 0) then {
+                    _candidates sort true;  // ascending by distance (first element)
+                    private _setSize = 2 + floor random 2;  // 2 or 3
+                    _setSize = _setSize min (count _candidates);
+                    private _topN = _candidates select [0, _setSize];
+                    _sourcePos = (selectRandom _topN) select 1;
+                };
+                // Otherwise _sourcePos stays at the LOGCOM base - no friendly objectives to draw from.
             };
+
+            // --- Force pool check & deduct ---
+            // Resupply dispatch consumes from the same ALIVE_globalForcePool used by OPCOM
+            // reinforcements. Cost scales with pool size (2%) with a floor of 1 and a cap
+            // of 10 so low pools don't get hollowed out by a single resupply and huge pools
+            // still feel a meaningful drain. Deducted ONCE here before branching into any
+            // dispatch path (truck / heli / timer) so the cost is for the supplies
+            // themselves, not tied to the delivery vehicle type.
+            private _factions = [_logic, "factions"] call MAINCLASS;
+            private _eventFaction = "";
+            {
+                if ((_x select 0) == _eventSide) exitWith { _eventFaction = (_x select 1) select 0; };
+            } forEach _factions;
+            if (_eventFaction == "" && {count _factions > 0}) then {
+                _eventFaction = (_factions select 0 select 1) select 0;
+            };
+
+            private _registryID = [_logic, "registryID"] call MAINCLASS;
+            private _forcePool = [ALIVE_globalForcePool, _eventFaction] call ALIVE_fnc_hashGet;
+            if (typeName _forcePool == "STRING") then { _forcePool = parseNumber _forcePool; };
+            if (typeName _forcePool != "SCALAR") then { _forcePool = 0; };
+
+            private _resupplyCost = 1 max (10 min (floor (_forcePool * 0.02)));
+
+            if (_forcePool < _resupplyCost) exitWith {
+                ["LOGCOM_RESUPPLY: Force pool exhausted for %1 (faction=%2 pool=%3 need=%4), deferring",
+                    _callsign, _eventFaction, _forcePool, _resupplyCost] call ALiVE_fnc_dump;
+                _targetVeh setVariable ["ALIVE_resupply_state", "failed", true];
+                _targetVeh setVariable ["ALIVE_resupply_inProgress", false, true];
+                _targetVeh setVariable ["ALIVE_resupply_vehicle", objNull, true];
+                private _count = missionNamespace getVariable ["ALIVE_resupply_activeCount", 1];
+                missionNamespace setVariable ["ALIVE_resupply_activeCount", (_count - 1) max 0, true];
+            };
+
+            // Deduct now. If the convoy is destroyed en route the units aren't credited back -
+            // supplies are lost, defend your supply lines.
+            _forcePool = _forcePool - _resupplyCost;
+            [ALIVE_MLGlobalRegistry, "updateGlobalForcePool", [_registryID, _forcePool]] call ALIVE_fnc_MLGlobalRegistry;
+            ["LOGCOM_RESUPPLY: Deducted %1 from %2 force pool for %3 (pool now %4)",
+                _resupplyCost, _eventFaction, _callsign, _forcePool] call ALiVE_fnc_dump;
 
             private _distance = _sourcePos distance2D _targetPos;
             private _resupplySpeedMPS = 45 / 3.6;  // 45 km/h in m/s.

--- a/addons/mil_logistics/fnc_ML.sqf
+++ b/addons/mil_logistics/fnc_ML.sqf
@@ -2305,7 +2305,7 @@ switch(_operation) do {
     case "listen": {
         private["_listenerID"];
 
-        _listenerID = [ALIVE_eventLog, "addListener",[_logic, ["LOGCOM_REQUEST","LOGCOM_STATUS_REQUEST","LOGCOM_CANCEL_REQUEST","OPCOM_CAPTURE"]]] call ALIVE_fnc_eventLog;
+        _listenerID = [ALIVE_eventLog, "addListener",[_logic, ["LOGCOM_REQUEST","LOGCOM_RESUPPLY","LOGCOM_STATUS_REQUEST","LOGCOM_CANCEL_REQUEST","OPCOM_CAPTURE"]]] call ALIVE_fnc_eventLog;
         _logic setVariable ["listenerID", _listenerID];
     };
 
@@ -2411,7 +2411,552 @@ switch(_operation) do {
 		            };
 		        	};
 		        };
-        }; 
+        };
+    };
+
+    // =========================================================================
+    // LOGCOM_RESUPPLY — Support Asset Resupply Dispatch
+    // Dispatches a resupply truck (or heli fallback) to a combat support asset
+    // that has triggered ammo/fuel/damage thresholds via the resupply watchdog.
+    // =========================================================================
+    #define RESUPPLY_MAX_RETRIES 3
+    #define RESUPPLY_SERVICE_DELAY 30
+    #define RESUPPLY_RTB_ARRIVE_RADIUS 75
+    #define RESUPPLY_RTB_SPEED_KPH 45
+    #define RESUPPLY_RTB_TIMEOUT_MULTIPLIER 2
+    case "LOGCOM_RESUPPLY": {
+
+        if (typeName _args == "ARRAY") then {
+
+            private _event = _args;
+            private _eventData = [_event, "data"] call ALIVE_fnc_hashGet;
+
+            // Event data: [position, sideText, type, callsign, source, needs, vehicleRef]
+            private _targetPos = _eventData select 0;
+            private _eventSide = _eventData select 1;
+            private _assetType = _eventData select 2;
+            private _callsign = _eventData select 3;
+            private _sourceMode = _eventData select 4;  // 0 = Static, 1 = Dynamic
+            private _needs = _eventData select 5;       // [needsAmmo, needsFuel, needsRepair]
+            private _targetVeh = _eventData select 6;
+
+            // Validate target is still alive.
+            if (isNull _targetVeh || {!alive _targetVeh}) exitWith {
+                ["LOGCOM_RESUPPLY: Target asset %1 no longer exists, aborting", _callsign] call ALiVE_fnc_dump;
+                private _count = missionNamespace getVariable ["ALIVE_resupply_activeCount", 1];
+                missionNamespace setVariable ["ALIVE_resupply_activeCount", (_count - 1) max 0, true];
+            };
+
+            // Determine source position.
+            private _sourcePos = getPos _logic;  // Default: Static = LOGCOM module position.
+
+            if (_sourceMode == 1) then {
+                // Dynamic: find nearest friendly-held objective.
+                private _bestDist = 1e10;
+                private _bestPos = _sourcePos;
+                {
+                    private _handler = _x getVariable ["handler", objNull];
+                    if (!isNull _handler) then {
+                        private _opcomSide = [_handler, "side"] call ALiVE_fnc_HashGet;
+                        if (_opcomSide == _eventSide) then {
+                            private _objectives = [_handler, "objectives", []] call ALiVE_fnc_HashGet;
+                            {
+                                private _objState = [_x, "opcom_state", "none"] call ALiVE_fnc_HashGet;
+                                if (_objState in ["defend", "reserve"]) then {
+                                    private _objPos = [_x, "center"] call ALiVE_fnc_HashGet;
+                                    private _dist = _objPos distance2D _targetPos;
+                                    if (_dist < _bestDist) then {
+                                        _bestDist = _dist;
+                                        _bestPos = _objPos;
+                                    };
+                                };
+                            } forEach _objectives;
+                        };
+                    };
+                } forEach (missionNamespace getVariable ["OPCOM_instances", []]);
+                _sourcePos = _bestPos;
+            };
+
+            private _distance = _sourcePos distance2D _targetPos;
+            private _resupplySpeedMPS = 45 / 3.6;  // 45 km/h in m/s.
+            private _timeout = (_distance / _resupplySpeedMPS) * 1.5;
+
+            // Check route for water obstacles (existing ML pattern).
+            private _waterBlocked = false;
+            private _routeDir = _sourcePos getDir _targetPos;
+            private _checkPos = +_sourcePos;
+            for "_step" from 0 to _distance step 50 do {
+                _checkPos = _checkPos getPos [50, _routeDir];
+                if (surfaceIsWater _checkPos) exitWith { _waterBlocked = true };
+            };
+
+            // Set ETA variables on target for sitrep display.
+            _targetVeh setVariable ["ALIVE_resupply_state", "enroute", true];
+            _targetVeh setVariable ["ALIVE_resupply_eta", _timeout, true];
+            _targetVeh setVariable ["ALIVE_resupply_startTime", serverTime, true];
+
+            if (!_waterBlocked) then {
+                // --- TRUCK DISPATCH ---
+                private _truckClass = switch (_eventSide) do {
+                    case "EAST": { "O_Truck_03_ammo_F" };
+                    case "WEST": { "B_Truck_01_ammo_F" };
+                    case "GUER": { "I_Truck_02_ammo_F" };
+                    default { "B_Truck_01_ammo_F" };
+                };
+
+                private _truck = createVehicle [_truckClass, _sourcePos, [], 10, "NONE"];
+                _truck setDir (_sourcePos getDir _targetPos);
+                createVehicleCrew _truck;
+                private _truckGrp = group (driver _truck);
+
+                // Assign waypoint to target position.
+                private _wp = _truckGrp addWaypoint [_targetPos, 50];
+                _wp setWaypointType "MOVE";
+                _wp setWaypointSpeed "FULL";
+                _wp setWaypointBehaviour "SAFE";
+
+                // Store reference on target vehicle for marker display.
+                _targetVeh setVariable ["ALIVE_resupply_vehicle", _truck, true];
+
+                ["LOGCOM_RESUPPLY: Truck %1 dispatched from %2 to %3 (%4), ETA %5s",
+                    _truckClass, _sourcePos, _callsign, _assetType, round _timeout] call ALiVE_fnc_dump;
+
+                // Spawn delivery monitor. Pass sourcePos so the truck can RTB after servicing.
+                [_truck, _targetVeh, _timeout, _callsign, _sourcePos] spawn {
+                    params ["_truck", "_targetVeh", "_timeout", "_callsign", "_sourcePos"];
+
+                    private _startTime = serverTime;
+
+                    while {true} do {
+                        // Protection: truck destroyed.
+                        if (!alive _truck) exitWith {
+                            ["LOGCOM_RESUPPLY: Truck destroyed en route to %1", _callsign] call ALiVE_fnc_dump;
+                            _targetVeh setVariable ["ALIVE_resupply_state", "failed", true];
+                            _targetVeh setVariable ["ALIVE_resupply_inProgress", false, true];
+                            _targetVeh setVariable ["ALIVE_resupply_vehicle", objNull, true];
+                            _targetVeh setVariable ["ALIVE_resupply_retries",
+                                (_targetVeh getVariable ["ALIVE_resupply_retries", 0]) + 1, true];
+                            private _count = missionNamespace getVariable ["ALIVE_resupply_activeCount", 1];
+                            missionNamespace setVariable ["ALIVE_resupply_activeCount", (_count - 1) max 0, true];
+                        };
+
+                        // Protection: target asset destroyed.
+                        if (isNull _targetVeh || {!alive _targetVeh}) exitWith {
+                            ["LOGCOM_RESUPPLY: Target %1 destroyed, aborting truck", _callsign] call ALiVE_fnc_dump;
+                            {deleteVehicle _x} forEach (crew _truck);
+                            deleteVehicle _truck;
+                            private _count = missionNamespace getVariable ["ALIVE_resupply_activeCount", 1];
+                            missionNamespace setVariable ["ALIVE_resupply_activeCount", (_count - 1) max 0, true];
+                        };
+
+                        // Protection: timeout expired.
+                        if (serverTime - _startTime > _timeout) exitWith {
+                            private _retries = _targetVeh getVariable ["ALIVE_resupply_retries", 0];
+                            if (_retries < RESUPPLY_MAX_RETRIES) then {
+                                ["LOGCOM_RESUPPLY: Truck timed out for %1 (attempt %2/%3), retrying",
+                                    _callsign, _retries + 1, RESUPPLY_MAX_RETRIES] call ALiVE_fnc_dump;
+                                {deleteVehicle _x} forEach (crew _truck);
+                                deleteVehicle _truck;
+                                _targetVeh setVariable ["ALIVE_resupply_state", "failed", true];
+                                _targetVeh setVariable ["ALIVE_resupply_inProgress", false, true];
+                                _targetVeh setVariable ["ALIVE_resupply_vehicle", objNull, true];
+                                _targetVeh setVariable ["ALIVE_resupply_retries", _retries + 1, true];
+                            } else {
+                                ["LOGCOM_RESUPPLY: Max retries reached for %1, force-servicing", _callsign] call ALiVE_fnc_dump;
+                                {deleteVehicle _x} forEach (crew _truck);
+                                deleteVehicle _truck;
+                                [_targetVeh] call ALIVE_fnc_resupplyService;
+                                _targetVeh setVariable ["ALIVE_resupply_state", "complete", true];
+                                _targetVeh setVariable ["ALIVE_resupply_inProgress", false, true];
+                                _targetVeh setVariable ["ALIVE_resupply_vehicle", objNull, true];
+                                _targetVeh setVariable ["ALIVE_resupply_retries", 0, true];
+                                _targetVeh setVariable ["ALIVE_resupply_lastDispatch", serverTime, true];
+                            };
+                            private _count = missionNamespace getVariable ["ALIVE_resupply_activeCount", 1];
+                            missionNamespace setVariable ["ALIVE_resupply_activeCount", (_count - 1) max 0, true];
+                        };
+
+                        // Success: truck within 100m of target.
+                        if (_truck distance _targetVeh < 100) exitWith {
+                            ["LOGCOM_RESUPPLY: Truck arrived at %1, servicing...", _callsign] call ALiVE_fnc_dump;
+                            _targetVeh setVariable ["ALIVE_resupply_state", "servicing", true];
+
+                            // Simulate service time.
+                            sleep RESUPPLY_SERVICE_DELAY;
+
+                            [_targetVeh] call ALIVE_fnc_resupplyService;
+
+                            _targetVeh setVariable ["ALIVE_resupply_state", "complete", true];
+                            _targetVeh setVariable ["ALIVE_resupply_inProgress", false, true];
+                            _targetVeh setVariable ["ALIVE_resupply_vehicle", objNull, true];
+                            _targetVeh setVariable ["ALIVE_resupply_lastDispatch", serverTime, true];
+                            _targetVeh setVariable ["ALIVE_resupply_retries", 0, true];
+
+                            ["LOGCOM_RESUPPLY: Service complete for %1, truck RTB to %2", _callsign, _sourcePos] call ALiVE_fnc_dump;
+
+                            // Decrement concurrent-dispatch counter now - the delivery leg is done.
+                            // RTB is fire-and-forget and shouldn't keep the asset marked busy.
+                            private _count = missionNamespace getVariable ["ALIVE_resupply_activeCount", 1];
+                            missionNamespace setVariable ["ALIVE_resupply_activeCount", (_count - 1) max 0, true];
+
+                            // --- RTB ---
+                            // Clear any existing waypoints and route the truck back to its source.
+                            private _truckGrp = group (driver _truck);
+                            while {count waypoints _truckGrp > 0} do { deleteWaypoint [_truckGrp, 0] };
+                            private _rtbWp = _truckGrp addWaypoint [_sourcePos, 50];
+                            _rtbWp setWaypointType "MOVE";
+                            _rtbWp setWaypointSpeed "FULL";
+                            _rtbWp setWaypointBehaviour "SAFE";
+                            _truckGrp setCurrentWaypoint _rtbWp;
+
+                            // Monitor RTB - delete on arrival, or after a distance-scaled timeout
+                            // so a stuck / destroyed truck still gets cleaned up.
+                            private _rtbDistance = _truck distance _sourcePos;
+                            private _rtbTimeout = ((_rtbDistance / (RESUPPLY_RTB_SPEED_KPH / 3.6)) * RESUPPLY_RTB_TIMEOUT_MULTIPLIER) max 60;
+
+                            [_truck, _sourcePos, _callsign, _rtbTimeout] spawn {
+                                params ["_truck", "_sourcePos", "_callsign", "_rtbTimeout"];
+                                private _rtbStart = serverTime;
+                                while {
+                                    !isNull _truck
+                                    && {alive _truck}
+                                    && {_truck distance _sourcePos > RESUPPLY_RTB_ARRIVE_RADIUS}
+                                    && {serverTime - _rtbStart < _rtbTimeout}
+                                } do {
+                                    sleep 5;
+                                };
+                                if (!isNull _truck) then {
+                                    if (alive _truck && {_truck distance _sourcePos <= RESUPPLY_RTB_ARRIVE_RADIUS}) then {
+                                        ["LOGCOM_RESUPPLY: Truck RTB complete for %1, deleting", _callsign] call ALiVE_fnc_dump;
+                                    } else {
+                                        ["LOGCOM_RESUPPLY: Truck RTB timed out or destroyed for %1, cleaning up", _callsign] call ALiVE_fnc_dump;
+                                    };
+                                    {deleteVehicle _x} forEach (crew _truck);
+                                    deleteVehicle _truck;
+                                };
+                            };
+                        };
+
+                        // Update truck waypoint if target has moved (aircraft on ground).
+                        private _wp = waypoints (group (driver _truck));
+                        if (count _wp > 0) then {
+                            [(group (driver _truck)), 1] setWaypointPosition [getPos _targetVeh, 50];
+                        };
+
+                        sleep 10;
+                    };
+                };
+
+            } else {
+                // --- WATER BLOCKED: HELI SLINGLOAD DISPATCH ---
+                // Spawn a heli with a slingloaded supply crate, fly to the asset,
+                // descend and release crate, service on arrival, cleanup.
+                // Falls back to timer if no suitable heli class exists.
+
+                // Select heli and crate classes by side.
+                private _heliClass = "";
+                private _crateClass = "";
+                switch (_eventSide) do {
+                    case "WEST": {
+                        _heliClass = "B_Heli_Transport_03_F";
+                        _crateClass = "B_Slingload_01_Ammo_F";
+                    };
+                    case "EAST": {
+                        _heliClass = "O_Heli_Transport_04_F";
+                        _crateClass = "O_Slingload_01_Ammo_F";
+                    };
+                    case "GUER": {
+                        _heliClass = "I_Heli_Transport_02_F";
+                        _crateClass = "I_Slingload_01_Ammo_F";
+                    };
+                    default {
+                        _heliClass = "B_Heli_Transport_03_F";
+                        _crateClass = "B_Slingload_01_Ammo_F";
+                    };
+                };
+
+                // Validate heli class exists in config.
+                if (!isClass (configFile >> "CfgVehicles" >> _heliClass)) then {
+                    _heliClass = "";
+                };
+
+                if (_heliClass == "") then {
+                    // --- TIMER FALLBACK: no suitable heli available ---
+                    ["LOGCOM_RESUPPLY: No heli class available for %1, using timer fallback (ETA %2s)",
+                        _callsign, round _timeout] call ALiVE_fnc_dump;
+
+                    _targetVeh setVariable ["ALIVE_resupply_vehicle", objNull, true];
+
+                    [_targetVeh, _timeout, _callsign] spawn {
+                        params ["_targetVeh", "_timeout", "_callsign"];
+
+                        sleep _timeout;
+
+                        if (!isNull _targetVeh && {alive _targetVeh}) then {
+                            [_targetVeh] call ALIVE_fnc_resupplyService;
+                            _targetVeh setVariable ["ALIVE_resupply_state", "complete", true];
+                            ["LOGCOM_RESUPPLY: Timer fallback service complete for %1", _callsign] call ALiVE_fnc_dump;
+                        };
+
+                        _targetVeh setVariable ["ALIVE_resupply_inProgress", false, true];
+                        _targetVeh setVariable ["ALIVE_resupply_lastDispatch", serverTime, true];
+                        _targetVeh setVariable ["ALIVE_resupply_retries", 0, true];
+                        private _count = missionNamespace getVariable ["ALIVE_resupply_activeCount", 1];
+                        missionNamespace setVariable ["ALIVE_resupply_activeCount", (_count - 1) max 0, true];
+                    };
+                } else {
+                    // --- HELI SLINGLOAD DISPATCH ---
+
+                    // Spawn heli at altitude above source position.
+                    private _spawnPos = +_sourcePos;
+                    _spawnPos set [2, PARADROP_HEIGHT];
+                    private _heli = createVehicle [_heliClass, _spawnPos, [], 0, "FLY"];
+                    _heli setDir (_sourcePos getDir _targetPos);
+                    _heli setPosASL [_spawnPos select 0, _spawnPos select 1, PARADROP_HEIGHT];
+                    _heli setVelocity [0, 0, 0];
+                    _heli flyInHeight PARADROP_HEIGHT;
+                    createVehicleCrew _heli;
+                    private _heliGrp = group (driver _heli);
+
+                    // Spawn supply crate and force-attach as slingload.
+                    private _crate = createVehicle [_crateClass, _sourcePos, [], 0, "CAN_COLLIDE"];
+                    _heli setSlingLoad _crate;
+
+                    // Store reference on target for marker display.
+                    _targetVeh setVariable ["ALIVE_resupply_vehicle", _heli, true];
+
+                    // Recalculate timeout for air travel (faster than truck).
+                    private _airSpeedMPS = 65 / 3.6;  // ~65 km/h slingloaded.
+                    private _heliTimeout = ((_distance / _airSpeedMPS) * 1.5) max SLINGLOAD_DROP_TIMEOUT;
+
+                    _targetVeh setVariable ["ALIVE_resupply_eta", _heliTimeout, true];
+                    _targetVeh setVariable ["ALIVE_resupply_startTime", serverTime, true];
+
+                    ["LOGCOM_RESUPPLY: Heli %1 dispatched with crate %2 to %3 (%4), ETA %5s",
+                        _heliClass, _crateClass, _callsign, _assetType, round _heliTimeout] call ALiVE_fnc_dump;
+
+                    // Spawn the slingload delivery monitor.
+                    [_heli, _crate, _targetVeh, _heliTimeout, _callsign, _targetPos, _sourcePos, _logic] spawn {
+                        params ["_heli", "_crate", "_targetVeh", "_timeout", "_callsign",
+                                "_targetPos", "_sourcePos", "_logic"];
+
+                        private _startTime = serverTime;
+                        private _phase = 0;  // 0=TRANSIT, 1=DESCENT, 2=RELEASE, 3=SERVICE
+                        private _dropPad = objNull;
+                        private _lastLandAtTime = 0;
+                        private _dropped = false;
+
+                        // --- Helper: cleanup and exit ---
+                        private _fnc_cleanup = {
+                            params ["_heli", "_crate", "_dropPad", "_targetVeh", "_failed"];
+
+                            if (!isNull _dropPad) then { deleteVehicle _dropPad };
+                            if (!isNull _crate && {alive _crate}) then { deleteVehicle _crate };
+
+                            if (_failed) then {
+                                _targetVeh setVariable ["ALIVE_resupply_state", "failed", true];
+                                _targetVeh setVariable ["ALIVE_resupply_inProgress", false, true];
+                                _targetVeh setVariable ["ALIVE_resupply_vehicle", objNull, true];
+                                _targetVeh setVariable ["ALIVE_resupply_retries",
+                                    (_targetVeh getVariable ["ALIVE_resupply_retries", 0]) + 1, true];
+                            };
+
+                            // Delete heli + crew.
+                            if (!isNull _heli) then {
+                                [{
+                                    params ["_h"];
+                                    if (!isNull _h && {alive _h}) then {
+                                        {deleteVehicle _x} forEach (crew _h);
+                                        deleteVehicle _h;
+                                    };
+                                }, [_heli], 10] call CBA_fnc_waitAndExecute;
+                            };
+
+                            private _count = missionNamespace getVariable ["ALIVE_resupply_activeCount", 1];
+                            missionNamespace setVariable ["ALIVE_resupply_activeCount", (_count - 1) max 0, true];
+                        };
+
+                        // --- Main monitor loop ---
+                        while {!_dropped} do {
+
+                            // Global guards (all phases).
+                            if (!alive _heli || {!canFire _heli}) exitWith {
+                                ["LOGCOM_RESUPPLY HELI: Heli destroyed/disabled en route to %1", _callsign] call ALiVE_fnc_dump;
+                                [_heli, _crate, _dropPad, _targetVeh, true] call _fnc_cleanup;
+                            };
+
+                            if (isNull _targetVeh || {!alive _targetVeh}) exitWith {
+                                ["LOGCOM_RESUPPLY HELI: Target %1 destroyed, aborting", _callsign] call ALiVE_fnc_dump;
+                                [_heli, _crate, _dropPad, _targetVeh, false] call _fnc_cleanup;
+                            };
+
+                            if (serverTime - _startTime > _timeout) exitWith {
+                                ["LOGCOM_RESUPPLY HELI: Timeout for %1, force-releasing", _callsign] call ALiVE_fnc_dump;
+
+                                // Force release with parachute if at altitude.
+                                private _slungObj = getSlingLoad _heli;
+                                if (!isNull _slungObj) then {
+                                    private _slungAGL = (getPosATL _slungObj) select 2;
+                                    if (_slungAGL > 5) then {
+                                        private _para = createVehicle ["B_Parachute_02_F", getPosATL _slungObj, [], 0, "FLY"];
+                                        _para setPosASL (getPosASL _slungObj);
+                                        _para setVelocity (velocity _heli);
+                                        _slungObj attachTo [_para, [0,0,0]];
+                                        [_para, _slungObj] spawn {
+                                            private _p = _this select 0; private _v = _this select 1;
+                                            waitUntil { sleep 1; (getPosATL _v select 2) < 3 || !alive _p };
+                                            detach _v; deleteVehicle _p;
+                                        };
+                                    };
+                                    _heli setSlingLoad objNull;
+                                };
+
+                                // Force service regardless.
+                                private _retries = _targetVeh getVariable ["ALIVE_resupply_retries", 0];
+                                if (_retries < 3) then {
+                                    [_heli, _crate, _dropPad, _targetVeh, true] call _fnc_cleanup;
+                                } else {
+                                    [_targetVeh] call ALIVE_fnc_resupplyService;
+                                    _targetVeh setVariable ["ALIVE_resupply_state", "complete", true];
+                                    _targetVeh setVariable ["ALIVE_resupply_inProgress", false, true];
+                                    _targetVeh setVariable ["ALIVE_resupply_vehicle", objNull, true];
+                                    _targetVeh setVariable ["ALIVE_resupply_retries", 0, true];
+                                    _targetVeh setVariable ["ALIVE_resupply_lastDispatch", serverTime, true];
+                                    [_heli, _crate, _dropPad, _targetVeh, false] call _fnc_cleanup;
+                                };
+                            };
+
+                            // Crate lost mid-flight.
+                            if (isNull (getSlingLoad _heli) && {_phase < 2}) exitWith {
+                                ["LOGCOM_RESUPPLY HELI: Crate detached mid-flight for %1", _callsign] call ALiVE_fnc_dump;
+                                [_heli, _crate, _dropPad, _targetVeh, true] call _fnc_cleanup;
+                            };
+
+                            // --- Phase 0: TRANSIT ---
+                            if (_phase == 0) then {
+                                // Clear native waypoints every tick to prevent profile simulator override.
+                                while {count waypoints _heliGrp > 1} do {
+                                    deleteWaypoint [_heliGrp, 1];
+                                };
+
+                                _heli flyInHeight PARADROP_HEIGHT;
+                                _heli move _targetPos;
+
+                                // Transition to DESCENT when within 800m.
+                                if (_heli distance2D _targetVeh < 800) then {
+                                    _phase = 1;
+
+                                    // Find LZ near target using battle-tested search.
+                                    private _dropPos = [_logic, "findHelicopterLandingPos", [
+                                        getPos _targetVeh, 50, 300
+                                    ]] call ALIVE_fnc_ML;
+
+                                    _dropPad = createVehicle ["Land_HelipadEmpty_F", _dropPos, [], 0, "CAN_COLLIDE"];
+                                    _heli landAt _dropPad;
+                                    _heli flyInHeight 30;
+                                    _lastLandAtTime = serverTime;
+
+                                    ["LOGCOM_RESUPPLY HELI: Phase DESCENT for %1, LZ at %2", _callsign, _dropPos] call ALiVE_fnc_dump;
+                                };
+                            };
+
+                            // --- Phase 1: DESCENT ---
+                            if (_phase == 1) then {
+                                // Clear waypoints every tick.
+                                while {count waypoints _heliGrp > 1} do {
+                                    deleteWaypoint [_heliGrp, 1];
+                                };
+
+                                // Re-issue landAt every 30s if heli stalls (single authority).
+                                if (serverTime - _lastLandAtTime > 30 && {!isNull _dropPad}) then {
+                                    _heli landAt _dropPad;
+                                    _lastLandAtTime = serverTime;
+                                };
+
+                                // Monitor slung vehicle AGL.
+                                private _slungObj = getSlingLoad _heli;
+                                if (!isNull _slungObj) then {
+                                    private _slungAGL = (getPosATL _slungObj) select 2;
+
+                                    if (_slungAGL <= SLINGLOAD_DROP_HEIGHT) then {
+                                        _phase = 2;
+                                        ["LOGCOM_RESUPPLY HELI: Phase RELEASE for %1, AGL=%2m", _callsign, _slungAGL] call ALiVE_fnc_dump;
+                                    };
+                                };
+                            };
+
+                            // --- Phase 2: RELEASE ---
+                            if (_phase == 2) then {
+                                private _slungObj = getSlingLoad _heli;
+                                if (!isNull _slungObj) then {
+                                    private _relAGL = (getPosATL _slungObj) select 2;
+
+                                    // Parachute if still above safe height.
+                                    if (_relAGL > 5) then {
+                                        private _para = createVehicle ["B_Parachute_02_F", getPosATL _slungObj, [], 0, "FLY"];
+                                        _para setPosASL (getPosASL _slungObj);
+                                        _para setVelocity (velocity _heli);
+                                        _slungObj attachTo [_para, [0,0,0]];
+                                        [_para, _slungObj] spawn {
+                                            private _p = _this select 0; private _v = _this select 1;
+                                            waitUntil { sleep 1; (getPosATL _v select 2) < 3 || !alive _p };
+                                            detach _v; deleteVehicle _p;
+                                        };
+                                        ["LOGCOM_RESUPPLY HELI: Parachute attached at AGL %1m for %2", _relAGL, _callsign] call ALiVE_fnc_dump;
+                                    };
+
+                                    _heli setSlingLoad objNull;
+                                };
+
+                                if (!isNull _dropPad) then { deleteVehicle _dropPad; _dropPad = objNull; };
+
+                                // Wait for crate to settle.
+                                sleep 3;
+
+                                _phase = 3;
+                                _dropped = true;
+                                ["LOGCOM_RESUPPLY HELI: Sling released for %1", _callsign] call ALiVE_fnc_dump;
+                            };
+
+                            sleep 2;
+                        };
+
+                        // --- Phase 3: SERVICE ---
+                        if (_phase == 3 && {alive _targetVeh}) then {
+                            _targetVeh setVariable ["ALIVE_resupply_state", "servicing", true];
+                            sleep 30;  // Simulate strikedown period.
+
+                            [_targetVeh] call ALIVE_fnc_resupplyService;
+
+                            _targetVeh setVariable ["ALIVE_resupply_state", "complete", true];
+                            _targetVeh setVariable ["ALIVE_resupply_inProgress", false, true];
+                            _targetVeh setVariable ["ALIVE_resupply_vehicle", objNull, true];
+                            _targetVeh setVariable ["ALIVE_resupply_lastDispatch", serverTime, true];
+                            _targetVeh setVariable ["ALIVE_resupply_retries", 0, true];
+
+                            // Delete crate.
+                            if (!isNull _crate && {alive _crate}) then { deleteVehicle _crate };
+
+                            ["LOGCOM_RESUPPLY HELI: Service complete for %1, heli RTB", _callsign] call ALiVE_fnc_dump;
+
+                            // Heli RTB and cleanup.
+                            _heli flyInHeight PARADROP_HEIGHT;
+                            _heli move _sourcePos;
+                            [{
+                                params ["_h"];
+                                if (!isNull _h && {alive _h}) then {
+                                    {deleteVehicle _x} forEach (crew _h);
+                                    deleteVehicle _h;
+                                };
+                            }, [_heli], 120] call CBA_fnc_waitAndExecute;
+
+                            private _count = missionNamespace getVariable ["ALIVE_resupply_activeCount", 1];
+                            missionNamespace setVariable ["ALIVE_resupply_activeCount", (_count - 1) max 0, true];
+                        };
+                    };
+                };
+            };
+        };
     };
 
     case "LOGCOM_STATUS_REQUEST": {

--- a/addons/sup_artillery/CfgVehicles.hpp
+++ b/addons/sup_artillery/CfgVehicles.hpp
@@ -34,6 +34,30 @@ class CfgVehicles {
                         class artillery_atmine : Edit { property = "ALiVE_sup_artillery_artillery_atmine"; displayName = "$STR_ALIVE_ARTILLERY_ATMINE"; tooltip = "$STR_ALIVE_ARTILLERY_ATMINE_DESC"; defaultValue = """30"""; };
                         class artillery_rockets : Edit { property = "ALiVE_sup_artillery_artillery_rockets"; displayName = "$STR_ALIVE_ARTILLERY_ROCKETS"; tooltip = "$STR_ALIVE_ARTILLERY_ROCKETS_DESC"; defaultValue = """16"""; };
                         class artillery_code : Edit { property = "ALiVE_sup_artillery_artillery_code"; displayName = "$STR_ALIVE_ARTILLERY_CODE"; tooltip = "$STR_ALIVE_ARTILLERY_CODE_DESC"; defaultValue = """"""; };
+                        class artillery_logistics : Combo
+                        {
+                                property = "ALiVE_sup_artillery_artillery_logistics";
+                                displayName = "$STR_ALIVE_ARTILLERY_LOGISTICS";
+                                tooltip = "$STR_ALIVE_ARTILLERY_LOGISTICS_DESC";
+                                defaultValue = """0""";
+                                class Values
+                                {
+                                    class No { name = "No"; value = 0; default = 1; };
+                                    class Yes { name = "Yes"; value = 1; };
+                                };
+                        };
+                        class artillery_logisticssource : Combo
+                        {
+                                property = "ALiVE_sup_artillery_artillery_logisticssource";
+                                displayName = "$STR_ALIVE_ARTILLERY_LOGISTICSSOURCE";
+                                tooltip = "$STR_ALIVE_ARTILLERY_LOGISTICSSOURCE_DESC";
+                                defaultValue = """0""";
+                                class Values
+                                {
+                                    class Static { name = "Static (LOGCOM Base)"; value = 0; default = 1; };
+                                    class Dynamic { name = "Dynamic (Nearest Objective)"; value = 1; };
+                                };
+                        };
                         class ModuleDescription : ModuleDescription {};
                 };
                 class ModuleDescription

--- a/addons/sup_artillery/stringtable.xml
+++ b/addons/sup_artillery/stringtable.xml
@@ -118,4 +118,16 @@
     <English>Code that will be ran on each artillery piece</English>
     <Chinesesimp>将在每门火炮上运行的代码</Chinesesimp>
 </Key>
+<Key ID="STR_ALIVE_ARTILLERY_LOGISTICS">
+    <English>Use Military Logistics Simulation</English>
+</Key>
+<Key ID="STR_ALIVE_ARTILLERY_LOGISTICS_DESC">
+    <English>When enabled, this asset will request resupply from LOGCOM when ammo, fuel, or damage thresholds are reached. Requires a Military Logistics module.</English>
+</Key>
+<Key ID="STR_ALIVE_ARTILLERY_LOGISTICSSOURCE">
+    <English>Logistics Source</English>
+</Key>
+<Key ID="STR_ALIVE_ARTILLERY_LOGISTICSSOURCE_DESC">
+    <English>Static: resupply dispatched from LOGCOM base position. Dynamic: dispatched from nearest friendly-held objective.</English>
+</Key>
 </Container></Package></Project>

--- a/addons/sup_artillery/stringtable.xml
+++ b/addons/sup_artillery/stringtable.xml
@@ -122,7 +122,7 @@
     <English>Use Military Logistics Simulation</English>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_LOGISTICS_DESC">
-    <English>When enabled, this asset will request resupply from LOGCOM when ammo, fuel, or damage thresholds are reached. Requires a Military Logistics module.</English>
+    <English>When enabled, this asset will request resupply from LOGCOM when ammo, fuel, or damage thresholds are reached. Each resupply draws from the Military Logistics force pool - the same pool used for OPCOM reinforcements. Requires a Military Logistics module.</English>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_LOGISTICSSOURCE">
     <English>Logistics Source</English>

--- a/addons/sup_cas/CfgVehicles.hpp
+++ b/addons/sup_cas/CfgVehicles.hpp
@@ -25,6 +25,30 @@ class CfgVehicles {
                         class cas_type : Edit { property = "ALiVE_sup_cas_cas_type"; displayName = "$STR_ALIVE_CAS_TYPE"; tooltip = "$STR_ALIVE_CAS_TYPE_DESC"; defaultValue = """B_Heli_Attack_01_F"""; };
                         class cas_height : Edit { property = "ALiVE_sup_cas_cas_height"; displayName = "$STR_ALIVE_CAS_HEIGHT"; tooltip = "$STR_ALIVE_CAS_HEIGHT_DESC"; defaultValue = """0"""; };
                         class cas_code : Edit { property = "ALiVE_sup_cas_cas_code"; displayName = "$STR_ALIVE_CAS_CODE"; tooltip = "$STR_ALIVE_CAS_CODE_DESC"; defaultValue = """"""; };
+                        class cas_logistics : Combo
+                        {
+                                property = "ALiVE_sup_cas_cas_logistics";
+                                displayName = "$STR_ALIVE_CAS_LOGISTICS";
+                                tooltip = "$STR_ALIVE_CAS_LOGISTICS_DESC";
+                                defaultValue = """0""";
+                                class Values
+                                {
+                                    class No { name = "No"; value = 0; default = 1; };
+                                    class Yes { name = "Yes"; value = 1; };
+                                };
+                        };
+                        class cas_logisticssource : Combo
+                        {
+                                property = "ALiVE_sup_cas_cas_logisticssource";
+                                displayName = "$STR_ALIVE_CAS_LOGISTICSSOURCE";
+                                tooltip = "$STR_ALIVE_CAS_LOGISTICSSOURCE_DESC";
+                                defaultValue = """0""";
+                                class Values
+                                {
+                                    class Static { name = "Static (LOGCOM Base)"; value = 0; default = 1; };
+                                    class Dynamic { name = "Dynamic (Nearest Objective)"; value = 1; };
+                                };
+                        };
                         class ModuleDescription : ModuleDescription {};
                 };
                 class ModuleDescription

--- a/addons/sup_cas/stringtable.xml
+++ b/addons/sup_cas/stringtable.xml
@@ -46,5 +46,17 @@
     <English>Code that will be ran on this unit</English>
     <Chinesesimp>将在此单元上运行的代码</Chinesesimp>
 </Key>
+<Key ID="STR_ALIVE_CAS_LOGISTICS">
+    <English>Use Military Logistics Simulation</English>
+</Key>
+<Key ID="STR_ALIVE_CAS_LOGISTICS_DESC">
+    <English>When enabled, this asset will request resupply from LOGCOM when ammo, fuel, or damage thresholds are reached. Requires a Military Logistics module.</English>
+</Key>
+<Key ID="STR_ALIVE_CAS_LOGISTICSSOURCE">
+    <English>Logistics Source</English>
+</Key>
+<Key ID="STR_ALIVE_CAS_LOGISTICSSOURCE_DESC">
+    <English>Static: resupply dispatched from LOGCOM base position. Dynamic: dispatched from nearest friendly-held objective.</English>
+</Key>
 
 </Container></Package></Project>

--- a/addons/sup_cas/stringtable.xml
+++ b/addons/sup_cas/stringtable.xml
@@ -50,7 +50,7 @@
     <English>Use Military Logistics Simulation</English>
 </Key>
 <Key ID="STR_ALIVE_CAS_LOGISTICS_DESC">
-    <English>When enabled, this asset will request resupply from LOGCOM when ammo, fuel, or damage thresholds are reached. Requires a Military Logistics module.</English>
+    <English>When enabled, this asset will request resupply from LOGCOM when ammo, fuel, or damage thresholds are reached. Each resupply draws from the Military Logistics force pool - the same pool used for OPCOM reinforcements. Requires a Military Logistics module.</English>
 </Key>
 <Key ID="STR_ALIVE_CAS_LOGISTICSSOURCE">
     <English>Logistics Source</English>

--- a/addons/sup_combatsupport/CfgFunctions.hpp
+++ b/addons/sup_combatsupport/CfgFunctions.hpp
@@ -46,6 +46,16 @@ class cfgFunctions {
                                 file = "\x\alive\addons\sup_combatsupport\scripts\NEO_radio\functions\misc\fn_supportRemove.sqf";
                                 RECOMPILE;
                         };
+                        class resupplyWatchdog {
+                                description = "Monitors support assets and dispatches LOGCOM resupply when thresholds are reached";
+                                file = "\x\alive\addons\sup_combatsupport\fnc_resupplyWatchdog.sqf";
+                                RECOMPILE;
+                        };
+                        class resupplyService {
+                                description = "Performs rearm, refuel, and repair on a support asset";
+                                file = "\x\alive\addons\sup_combatsupport\fnc_resupplyService.sqf";
+                                RECOMPILE;
+                        };
                 };
         };
 };

--- a/addons/sup_combatsupport/fnc_combatSupport.sqf
+++ b/addons/sup_combatsupport/fnc_combatSupport.sqf
@@ -89,6 +89,13 @@ switch(_operation) do {
                         ARTY_RESPAWN_LIMIT = parsenumber(_ARTY_SET_RESPAWN_LIMIT);
 
                         _audio = NEO_radioLogic getvariable ["combatsupport_audio",true];
+                        // Defensive coercion: combatsupport_audio is a Combo and Eden returns it as BOOL
+                        // when the PBO is binarised (normal production builds) but as STRING "0"/"1" when
+                        // packed without binarisation (AddonBuilder -packonly dev builds). Normalise once
+                        // here and PV back so the downstream UI handlers and FSMs that read this off
+                        // NEO_radioLogic always see a bool and don't choke on `if (_audio) then`.
+                        if !(_audio isEqualType true) then { _audio = parseNumber str _audio > 0; };
+                        NEO_radioLogic setVariable ["combatsupport_audio", _audio, true];
 
                         _transportArrays = [];
                         _casArrays = [];
@@ -242,8 +249,17 @@ switch(_operation) do {
                                     _height = parsenumber(_heightset);
                                     _code = ((synchronizedObjects _logic) select _i) getvariable ["cas_code",""];
                                     _code = [_code,"this","(_this select 0)"] call CBA_fnc_replace;
+                                    // Military Logistics Simulation module attrs. These are Combo attrs without
+                                    // typeName, which Eden always stores as STRING ("0" / "1") regardless of whether
+                                    // the PBO is binarised. parseNumber accepts a STRING directly and returns the
+                                    // numeric value - NO str() wrapper. (Other ALiVE call sites use `parseNumber str`
+                                    // because they read Edit attrs with typeName=NUMBER where Eden stores NUMBER and
+                                    // parseNumber can't read that without the str() conversion; we're the opposite
+                                    // case.)
+                                    _casLogistics = parseNumber (((synchronizedObjects _logic) select _i) getvariable ["cas_logistics","0"]);
+                                    _casLogisticsSource = parseNumber (((synchronizedObjects _logic) select _i) getvariable ["cas_logisticssource","0"]);
 
-                                    _casArray = [_position,_direction, _type, _callsign, _id,_code,_height];
+                                    _casArray = [_position,_direction, _type, _callsign, _id,_code,_height,_casLogistics,_casLogisticsSource];
                                     _casArrays pushback _casArray;
                                 };
                                 case ("ALiVE_SUP_TRANSPORT") : {
@@ -260,7 +276,20 @@ switch(_operation) do {
 
 
                                     _slingloading = ((synchronizedObjects _logic) select _i) getvariable ["transport_slingloading",true];
+                                    // Defensive coercion for the upstream attrs. When the PBO is binarised by
+                                    // Mikero (the usual production pipeline) Eden returns _slingloading as BOOL
+                                    // and _containers as NUMBER, matching the defaults and expected downstream
+                                    // usage (`!_slingloading`, `_containers > 0`). When the PBO is packed without
+                                    // binarisation (AddonBuilder -packonly, used for fast dev iteration) Eden
+                                    // returns these as STRING ("0"/"1"). The isEqualType guards here no-op on
+                                    // binarised builds and only trigger on the un-binarised dev path.
+                                    if !(_slingloading isEqualType true) then { _slingloading = parseNumber str _slingloading > 0; };
                                     _containers = ((synchronizedObjects _logic) select _i) getvariable ["transport_containers",0];
+                                    if !(_containers isEqualType 0) then { _containers = parseNumber str _containers; };
+                                    // Military Logistics Simulation module attrs - Combo without typeName, Eden
+                                    // always returns STRING. Bare parseNumber handles STRING directly.
+                                    _transportLogistics = parseNumber (((synchronizedObjects _logic) select _i) getvariable ["transport_logistics","0"]);
+                                    _transportLogisticsSource = parseNumber (((synchronizedObjects _logic) select _i) getvariable ["transport_logisticssource","0"]);
 
 
                                     LOG(_slingloading);
@@ -271,7 +300,7 @@ switch(_operation) do {
                                         _tasks = DEFAULT_TRANSPORT_TASKS;
                                     };
 
-                                    _transportArray = [_position,_direction,_type, _callsign,_tasks,_code,_height,_slingloading, _containers];
+                                    _transportArray = [_position,_direction,_type, _callsign,_tasks,_code,_height,_slingloading, _containers,_transportLogistics,_transportLogisticsSource];
                                     _transportArrays pushback _transportArray;
                                 };
                                 case ("ALiVE_sup_artillery") : {
@@ -318,8 +347,12 @@ switch(_operation) do {
                                     _rockets = ["ROCKETS", _rocketrounds];
 
                                    _ordnance = [_he,_illum,_smoke,_wp,_guided,_cluster,_lg,_mine,_atmine, _rockets];
+                                    // Military Logistics Simulation module attrs - Combo without typeName, Eden
+                                    // always returns STRING. Bare parseNumber handles STRING directly.
+                                    _artyLogistics = parseNumber (((synchronizedObjects _logic) select _i) getvariable ["artillery_logistics","0"]);
+                                    _artyLogisticsSource = parseNumber (((synchronizedObjects _logic) select _i) getvariable ["artillery_logisticssource","0"]);
 
-                                    _artyArray = [_position,_class, _callsign,3,_ordnance,_code];
+                                    _artyArray = [_position,_class, _callsign,3,_ordnance,_code,_artyLogistics,_artyLogisticsSource];
                                     _artyArrays pushback _artyArray;
                                 };
                             };
@@ -470,6 +503,12 @@ switch(_operation) do {
                             _veh setVariable ["ALIVE_CombatSupport", true];
                             _veh setVariable ["NEO_transportAvailableTasks", _tasks, true];
 
+                            // Military Logistics Simulation settings.
+                            private _logisticsEnabled = if (count _x > 9) then {(_x select 9) > 0} else {false};
+                            private _logisticsSource = if (count _x > 10) then {_x select 10} else {0};
+                            _veh setVariable ["ALIVE_logistics_enabled", _logisticsEnabled, true];
+                            _veh setVariable ["ALIVE_logistics_source", _logisticsSource, true];
+
                             private _fsmHandle = [_veh, _grp, _callsign, _pos, _dir, _height, _type, CS_RESPAWN,_code, _audio, _slingloading] execFSM _transportfsm;
 
                             _t = NEO_radioLogic getVariable format ["NEO_radioTrasportArray_%1", _side];
@@ -569,6 +608,12 @@ switch(_operation) do {
 
                             // set ownership flag for other modules
                             _veh setVariable ["ALIVE_CombatSupport", true];
+
+                            // Military Logistics Simulation settings.
+                            private _logisticsEnabled = if (count _x > 7) then {(_x select 7) > 0} else {false};
+                            private _logisticsSource = if (count _x > 8) then {_x select 8} else {0};
+                            _veh setVariable ["ALIVE_logistics_enabled", _logisticsEnabled, true];
+                            _veh setVariable ["ALIVE_logistics_source", _logisticsSource, true];
 
                             //FSM
                             private _fsmHandle = [_veh, _grp, _callsign, _pos, _airport, _dir, _height, _type, CS_RESPAWN, _code, _audio] execFSM _casfsm;
@@ -814,6 +859,29 @@ switch(_operation) do {
 
                             leader _grp setVariable ["NEO_radioArtyBatteryRounds", _roundsAvailable, true];
 
+                            // Military Logistics Simulation settings.
+                            private _logisticsEnabled = if (count _x > 6) then {(_x select 6) > 0} else {false};
+                            private _logisticsSource = if (count _x > 7) then {_x select 7} else {0};
+                            // Store default rounds for resupply service to restore.
+                            private _defaultRounds = +_roundsAvailable;
+                            // Set on each tank vehicle in the battery.
+                            {
+                                _x setVariable ["ALIVE_logistics_enabled", _logisticsEnabled, true];
+                                _x setVariable ["ALIVE_logistics_source", _logisticsSource, true];
+                                _x setVariable ["ALIVE_resupply_defaultRounds", _defaultRounds, true];
+                            } forEach _units;
+                            // Also set on leader - the registry keys artillery by leader _grp, not by vehicle,
+                            // and NEO_radioArtyBatteryRounds is tracked on the leader.
+                            private _leader = leader _grp;
+                            _leader setVariable ["ALIVE_logistics_enabled", _logisticsEnabled, true];
+                            _leader setVariable ["ALIVE_logistics_source", _logisticsSource, true];
+                            _leader setVariable ["ALIVE_resupply_defaultRounds", _defaultRounds, true];
+                            // Store a ref to a primary vehicle so the watchdog can read fuel/damage off the tank
+                            // and the service fn can rearm it, not the soldier leader.
+                            if (count _units > 0) then {
+                                _leader setVariable ["ALIVE_resupply_primaryVehicle", _units select 0, true];
+                            };
+
                             //FSM
                             private _fsmHandle = [_units, _grp, _callsign, _pos, _roundsAvailable, _canMove, _class, leader _grp, _code, _audio, _side] execFSM "\x\alive\addons\sup_combatSupport\scripts\NEO_radio\fsms\alivearty.fsm";
 
@@ -878,6 +946,18 @@ switch(_operation) do {
                                     };
                                 };
                             } foreach _sides;
+                        };
+
+                        // --- Military Logistics Simulation: start watchdog ---
+                        // The watchdog scans NEO_radio per-side arrays each tick, so respawned
+                        // assets are picked up automatically. No static registry to maintain here.
+                        missionNamespace setVariable ["ALIVE_resupply_activeCount", 0, true];
+
+                        if (["ALiVE_mil_logistics"] call ALIVE_fnc_isModuleAvailable) then {
+                            [] spawn ALIVE_fnc_resupplyWatchdog;
+                            ["CS - Resupply Watchdog spawned (live-scan mode)"] call ALiVE_fnc_dump;
+                        } else {
+                            ["CS WARNING: Military Logistics Simulation requires a Military Logistics module to be placed in the mission - watchdog not started."] call ALiVE_fnc_dump;
                         };
 
                         //Now PV the logic to all clients indicate its ready

--- a/addons/sup_combatsupport/fnc_resupplyService.sqf
+++ b/addons/sup_combatsupport/fnc_resupplyService.sqf
@@ -1,0 +1,73 @@
+#include "\x\alive\addons\sup_combatsupport\script_component.hpp"
+SCRIPT(resupplyService);
+
+/* ----------------------------------------------------------------------------
+Function: ALIVE_fnc_resupplyService
+Description:
+    Performs rearm, refuel, and repair on a support asset. Called by the
+    delivery monitor when a resupply vehicle arrives within range, or as
+    a force-service fallback when delivery fails.
+
+    For Transport/CAS the passed object is the actual vehicle and we service
+    it directly. For Artillery the passed object is either the leader soldier
+    (when called via watchdog dispatch) or a tank (when called via the LOGCOM
+    handler which receives the primary vehicle). Either way we resolve to the
+    whole battery (all vehicles sharing the leader's group) and reset the
+    NEO_radioArtyBatteryRounds on the leader so the FSM can queue fire
+    missions again.
+
+Parameters:
+    _this select 0: OBJECT - Support asset vehicle OR artillery leader
+
+Returns:
+    Nothing
+
+Author:
+    Goldwep
+---------------------------------------------------------------------------- */
+
+params ["_veh"];
+
+if (isNull _veh || {!alive _veh}) exitWith {
+    ["ALIVE Resupply Service: Target is null or destroyed"] call ALiVE_fnc_dump;
+};
+
+// Resolve to the group leader. For artillery, the leader carries the
+// NEO_radioArtyBatteryRounds hash the radio UI reads off, regardless of
+// whether we were called with a tank (LOGCOM dispatch flow) or with the
+// leader itself (force-service fallback). For Transport/CAS the "leader"
+// is just the heli/jet's own crew chief and won't have battery rounds.
+private _leader = leader (group _veh);
+private _batteryRounds = _leader getVariable ["NEO_radioArtyBatteryRounds", nil];
+private _isArty = !(isNil "_batteryRounds");
+
+if (_isArty) then {
+    // Artillery battery: walk the leader's group and service every vehicle in it.
+    private _batteryVehicles = [];
+    {
+        private _v = vehicle _x;
+        if (_v != _x && {!(_v in _batteryVehicles)}) then { _batteryVehicles pushBack _v };
+    } forEach (units (group _leader));
+
+    {
+        _x setVehicleAmmo 1;
+        _x setFuel 0.5;
+        _x setDamage 0;
+    } forEach _batteryVehicles;
+
+    // Reset the rounds array the radio UI and FSM read, so the tablet
+    // stops showing "no HE / no SMOKE" and fire missions can queue again.
+    private _defaultRounds = _leader getVariable ["ALIVE_resupply_defaultRounds", []];
+    if (count _defaultRounds > 0) then {
+        _leader setVariable ["NEO_radioArtyBatteryRounds", +_defaultRounds, true];
+    };
+
+    ["ALIVE Resupply Service: ARTY battery serviced (leader %1, %2 tanks, %3 ordnance types restored)",
+        _leader, count _batteryVehicles, count _defaultRounds] call ALiVE_fnc_dump;
+} else {
+    // Transport or CAS: _veh IS the vehicle.
+    _veh setVehicleAmmo 1;
+    _veh setFuel 0.5;
+    _veh setDamage 0;
+    ["ALIVE Resupply Service: Vehicle %1 serviced (ammo, fuel 0.5, damage 0)", _veh] call ALiVE_fnc_dump;
+};

--- a/addons/sup_combatsupport/fnc_resupplyWatchdog.sqf
+++ b/addons/sup_combatsupport/fnc_resupplyWatchdog.sqf
@@ -1,0 +1,233 @@
+#include "\x\alive\addons\sup_combatsupport\script_component.hpp"
+SCRIPT(resupplyWatchdog);
+
+/* ----------------------------------------------------------------------------
+Function: ALIVE_fnc_resupplyWatchdog
+Description:
+    Monitors support assets with Military Logistics Simulation enabled and
+    dispatches LOGCOM resupply requests when ammo, fuel, or damage thresholds
+    are reached.
+
+    Scans the NEO_radio per-side asset arrays on every tick rather than using
+    a static registry, so newly-respawned assets are picked up automatically
+    and dead-asset references are pruned by the live side-array reads.
+
+    Runs server-side as a spawned loop started by fnc_combatSupport after all
+    support assets are registered.
+
+Parameters:
+    None (reads NEO_radioLogic arrays live each tick).
+
+Returns:
+    Nothing (runs indefinitely)
+
+Author:
+    Goldwep
+---------------------------------------------------------------------------- */
+
+// Watchdog constants.
+#define WATCHDOG_INTERVAL 30
+#define AMMO_LOW_THRESHOLD 0.25
+#define FUEL_THRESHOLD 0.15
+#define DAMAGE_THRESHOLD 0.5
+#define COOLDOWN_SECONDS 600
+#define MAX_CONCURRENT_DISPATCHES 3
+
+if (!isServer) exitWith {};
+
+["ALIVE Resupply Watchdog started - scanning NEO_radio arrays each cycle"] call ALiVE_fnc_dump;
+
+private _sides = [WEST, EAST, RESISTANCE, CIVILIAN];
+
+while {true} do {
+
+    // Build this tick's live asset list by walking each side's NEO_radio arrays and
+    // deduping by vehicle object reference. Side-sharing copies each asset into every
+    // friendly side's array, so a single physical vehicle can appear multiple times.
+    private _seen = [];
+    private _assets = [];   // [_veh, _type, _side, _callsign]
+
+    {
+        private _sideCheck = _x;
+
+        {
+            private _veh = _x select 0;
+            private _callsign = _x select 2;
+            if (!isNull _veh && {alive _veh} && {!(_veh in _seen)}) then {
+                _seen pushBack _veh;
+                _assets pushBack [_veh, "TRANSPORT", _sideCheck, _callsign];
+            };
+        } forEach (NEO_radioLogic getVariable [format ["NEO_radioTrasportArray_%1", _sideCheck], []]);
+
+        {
+            private _veh = _x select 0;
+            private _callsign = _x select 2;
+            if (!isNull _veh && {alive _veh} && {!(_veh in _seen)}) then {
+                _seen pushBack _veh;
+                _assets pushBack [_veh, "CAS", _sideCheck, _callsign];
+            };
+        } forEach (NEO_radioLogic getVariable [format ["NEO_radioCasArray_%1", _sideCheck], []]);
+
+        {
+            private _veh = _x select 0;
+            private _callsign = _x select 2;
+            if (!isNull _veh && {alive _veh} && {!(_veh in _seen)}) then {
+                _seen pushBack _veh;
+                _assets pushBack [_veh, "ARTY", _sideCheck, _callsign];
+            };
+        } forEach (NEO_radioLogic getVariable [format ["NEO_radioArtyArray_%1", _sideCheck], []]);
+
+    } forEach _sides;
+
+    // Iterate the live set and check thresholds.
+    {
+        private _veh = _x select 0;
+        private _type = _x select 1;
+        private _side = _x select 2;
+        private _callsign = _x select 3;
+
+        // Skip if logistics isn't enabled on this asset (opt-in via the module attribute).
+        if (!(_veh getVariable ["ALIVE_logistics_enabled", false])) then { continue };
+
+        // For artillery _veh is leader _grp (soldier). The tank is referenced via
+        // ALIVE_resupply_primaryVehicle. For Transport/CAS _veh is already the vehicle.
+        // _primaryVeh is the single source of truth for resupply state because LOGCOM
+        // writes inProgress/lastDispatch back to it on completion.
+        private _primaryVeh = _veh getVariable ["ALIVE_resupply_primaryVehicle", _veh];
+
+        // Guard: primary vehicle died (e.g. tank destroyed but leader soldier still alive).
+        if (isNull _primaryVeh || {!alive _primaryVeh}) then { continue };
+
+        // Guard: skip if resupply already in progress.
+        if (_primaryVeh getVariable ["ALIVE_resupply_inProgress", false]) then { continue };
+
+        // Guard: skip if cooldown not expired. _lastDispatch is 0 before the first
+        // dispatch, so only enforce the cooldown once one has actually happened.
+        private _lastDispatch = _primaryVeh getVariable ["ALIVE_resupply_lastDispatch", 0];
+        if (_lastDispatch > 0 && {serverTime - _lastDispatch < COOLDOWN_SECONDS}) then { continue };
+
+        // --- Threshold checks ---
+
+        // Ammo trigger: any ordnance type below AMMO_LOW_THRESHOLD (25%) of its original capacity.
+        // The 25% margin gives the supply truck/heli travel time to arrive before the asset is
+        // fully dry, rather than dispatching after the battery is already useless.
+        private _needsAmmo = false;
+
+        if (_type == "ARTY") then {
+            // Artillery has two depletion signals and we watch BOTH:
+            //   (1) NEO_radioArtyBatteryRounds - tracked by alivearty.fsm for player fire missions.
+            //       The FSM REMOVES a type from the array once its count hits 0 (not zero it),
+            //       so a full depletion shows up as count dropping below the defaults snapshot.
+            //   (2) Real vehicle magazines on each battery tank - catches mods (CBA arty control,
+            //       AI CAS, etc.) firing the gun outside NEO_radio accounting so ordnance can be
+            //       gone even when the tracked array still shows full rounds.
+            private _batteryRounds = _veh getVariable ["NEO_radioArtyBatteryRounds", []];
+            private _defaultRounds = _veh getVariable ["ALIVE_resupply_defaultRounds", _batteryRounds];
+
+            // Check (1a): FSM has removed one of the tracked types (full depletion). alivearty.fsm
+            // only ever deletes entries - it never adds - so count dropping below the defaults
+            // snapshot means an ordnance type ran out and got pruned from the array.
+            if (count _batteryRounds < count _defaultRounds) then { _needsAmmo = true };
+
+            // Check (1b): any surviving type below 25% of its original count?
+            if (!_needsAmmo) then {
+                {
+                    private _typeName = _x select 0;
+                    private _currentCount = _x select 1;
+                    private _defaultForType = 0;
+                    {
+                        if ((_x select 0) == _typeName) exitWith { _defaultForType = _x select 1 };
+                    } forEach _defaultRounds;
+                    if (_defaultForType > 0 && {(_currentCount / _defaultForType) < AMMO_LOW_THRESHOLD}) exitWith {
+                        _needsAmmo = true;
+                    };
+                } forEach _batteryRounds;
+            };
+
+            // Check (2): any real vehicle magazine below 25% on any tank in the battery?
+            // vehicleGetAmmo returns [magazine, currentCount, maxCount] entries.
+            if (!_needsAmmo) then {
+                {
+                    private _v = vehicle _x;
+                    if (_v != _x) then {
+                        {
+                            private _current = _x select 1;
+                            private _max = _x select 2;
+                            if (_max > 0 && {(_current / _max) < AMMO_LOW_THRESHOLD}) exitWith {
+                                _needsAmmo = true;
+                            };
+                        } forEach (_v call ALiVE_fnc_vehicleGetAmmo);
+                    };
+                    if (_needsAmmo) exitWith {};
+                } forEach (units (group _veh));
+            };
+        } else {
+            // Transport/CAS: any real vehicle magazine below 25% on the heli/jet.
+            private _ammoArray = _primaryVeh call ALiVE_fnc_vehicleGetAmmo;
+            {
+                private _current = _x select 1;
+                private _max = _x select 2;
+                if (_max > 0 && {(_current / _max) < AMMO_LOW_THRESHOLD}) exitWith { _needsAmmo = true };
+            } forEach _ammoArray;
+        };
+
+        // Fuel and damage: read off the primary vehicle (the tank / heli / jet), not the
+        // leader soldier - soldier fuel is always 1 and soldier damage is body hp.
+        private _needsFuel = fuel _primaryVeh < FUEL_THRESHOLD;
+        private _needsRepair = damage _primaryVeh > DAMAGE_THRESHOLD && {damage _primaryVeh < 1};
+
+        // No thresholds hit — skip.
+        if (!_needsAmmo && {!_needsFuel} && {!_needsRepair}) then { continue };
+
+        // Guard: skip if in active combat (enemy within 500m of the primary vehicle).
+        private _nearestEnemy = _primaryVeh findNearestEnemy _primaryVeh;
+        if (!isNull _nearestEnemy && {_primaryVeh distance _nearestEnemy < 500}) then { continue };
+
+        // Guard: for air assets only dispatch once the aircraft is on the ground.
+        // Log once when we start waiting, not every tick.
+        if (_primaryVeh isKindOf "Air") then {
+            private _agl = (getPosATL _primaryVeh) select 2;
+            if (_agl > 3 || {!(isTouchingGround _primaryVeh)}) then {
+                if (!(_primaryVeh getVariable ["ALIVE_resupply_waitingRTB", false])) then {
+                    _primaryVeh setVariable ["ALIVE_resupply_waitingRTB", true, true];
+                    ["ALIVE Resupply Watchdog: %1 (%2) needs resupply - waiting for RTB",
+                        _callsign, _type] call ALiVE_fnc_dump;
+                };
+                continue
+            };
+            _primaryVeh setVariable ["ALIVE_resupply_waitingRTB", false, true];
+        };
+
+        // Guard: concurrent dispatch limit.
+        private _activeDispatches = missionNamespace getVariable ["ALIVE_resupply_activeCount", 0];
+        if (_activeDispatches >= MAX_CONCURRENT_DISPATCHES) then { continue };
+
+        // --- Dispatch resupply ---
+        // State lives on the primary vehicle (single source of truth). Mirror the user-visible
+        // state string onto the leader so the sitrep/tablet read on the arty leader is in sync.
+        _primaryVeh setVariable ["ALIVE_resupply_inProgress", true, true];
+        _primaryVeh setVariable ["ALIVE_resupply_state", "dispatched", true];
+        if (_veh != _primaryVeh) then {
+            _veh setVariable ["ALIVE_resupply_state", "dispatched", true];
+        };
+        missionNamespace setVariable ["ALIVE_resupply_activeCount", _activeDispatches + 1, true];
+
+        private _needs = [_needsAmmo, _needsFuel, _needsRepair];
+        private _sideText = str _side;
+        private _source = _veh getVariable ["ALIVE_logistics_source", 0];
+
+        // Pass the primary vehicle position/object to LOGCOM so the truck drives to the actual tank,
+        // not to the soldier leader standing somewhere else.
+        private _eventData = [getPos _primaryVeh, _sideText, _type, _callsign, _source, _needs, _primaryVeh];
+        private _event = ['LOGCOM_RESUPPLY', _eventData, "CombatSupport"] call ALIVE_fnc_event;
+        [ALIVE_eventLog, "addEvent", _event] call ALIVE_fnc_eventLog;
+
+        [
+            "ALIVE Resupply Watchdog: Dispatching for %1 (%2) | Ammo: %3, Fuel: %4, Repair: %5",
+            _callsign, _type, _needsAmmo, _needsFuel, _needsRepair
+        ] call ALiVE_fnc_dump;
+
+    } forEach _assets;
+
+    sleep WATCHDOG_INTERVAL;
+};

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_RespawnArtyAsset.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_RespawnArtyAsset.sqf
@@ -111,6 +111,25 @@ if (_side == WEST && _type == "BUS_MotInf_MortTeam") then {
 
 leader _grp setVariable ["NEO_radioArtyBatteryRounds", _roundsAvailable, true];
 
+// Carry the Military Logistics Simulation settings from the old leader onto the new battery so
+// the resupply watchdog keeps monitoring the asset after respawn. Variables are still readable
+// on the dead leader via getVariable.
+private _oldLogisticsEnabled = _battery getVariable ["ALIVE_logistics_enabled", false];
+private _oldLogisticsSource = _battery getVariable ["ALIVE_logistics_source", 0];
+private _oldDefaultRounds = _battery getVariable ["ALIVE_resupply_defaultRounds", _roundsAvailable];
+{
+    _x setVariable ["ALIVE_logistics_enabled", _oldLogisticsEnabled, true];
+    _x setVariable ["ALIVE_logistics_source", _oldLogisticsSource, true];
+    _x setVariable ["ALIVE_resupply_defaultRounds", _oldDefaultRounds, true];
+} forEach _units;
+private _newLeader = leader _grp;
+_newLeader setVariable ["ALIVE_logistics_enabled", _oldLogisticsEnabled, true];
+_newLeader setVariable ["ALIVE_logistics_source", _oldLogisticsSource, true];
+_newLeader setVariable ["ALIVE_resupply_defaultRounds", _oldDefaultRounds, true];
+if (count _units > 0) then {
+    _newLeader setVariable ["ALIVE_resupply_primaryVehicle", _units select 0, true];
+};
+
 _codeArray = [_code, ";"] Call CBA_fnc_split;
 {
     _vehicle = _x;

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_RespawnCASAsset.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_RespawnCASAsset.sqf
@@ -10,6 +10,11 @@ _type = _this select 6;
 _airport = _this select 7;
 _respawn = _this select 8;
 
+// Snapshot Military Logistics Simulation settings off the old vehicle before it's replaced
+// so the new CAS asset stays registered with the resupply watchdog.
+private _oldLogisticsEnabled = _veh getVariable ["ALIVE_logistics_enabled", false];
+private _oldLogisticsSource = _veh getVariable ["ALIVE_logistics_source", 0];
+
 //define defaults
 _code = _this select 9;
 _tasks = ["Pickup", "Land", "land (Eng off)", "Move", "Circle","Insertion"];
@@ -96,6 +101,10 @@ if (count _veh == 0) then {
     waitUntil {(_veh getVariable ["ALIVE_CombatSupport", false])};
     _grp = (group (driver _veh));
 };
+
+// Restore Military Logistics Simulation settings on the respawned CAS asset.
+_veh setVariable ["ALIVE_logistics_enabled", _oldLogisticsEnabled, true];
+_veh setVariable ["ALIVE_logistics_source", _oldLogisticsSource, true];
 
 _ffvTurrets = [_type,true,true,false,true] call ALIVE_fnc_configGetVehicleTurretPositions;
 _gunnerTurrets = [_type,false,true,true,true] call ALIVE_fnc_configGetVehicleTurretPositions;

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_RespawnTransportAsset.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_RespawnTransportAsset.sqf
@@ -14,6 +14,11 @@ _respawn = _this select 7;
 _code = _this select 8;
 _slingloading = _this select 9;
 
+// Snapshot Military Logistics Simulation settings off the old vehicle before it's replaced
+// so the new Transport asset stays registered with the resupply watchdog.
+private _oldLogisticsEnabled = _veh getVariable ["ALIVE_logistics_enabled", false];
+private _oldLogisticsSource = _veh getVariable ["ALIVE_logistics_source", 0];
+
 //define defaults
 
 _faction = gettext(configfile >> "CfgVehicles" >> _type >> "faction");
@@ -95,6 +100,10 @@ if (count _veh == 0) then {
     waitUntil {(_veh getVariable ["ALIVE_CombatSupport", false])};
     _grp = (group (driver _veh));
 };
+
+// Restore Military Logistics Simulation settings on the respawned Transport asset.
+_veh setVariable ["ALIVE_logistics_enabled", _oldLogisticsEnabled, true];
+_veh setVariable ["ALIVE_logistics_source", _oldLogisticsSource, true];
 
 _ffvTurrets = [_type,true,true,false,true] call ALIVE_fnc_configGetVehicleTurretPositions;
 _gunnerTurrets = [_type,false,true,true,true] call ALIVE_fnc_configGetVehicleTurretPositions;

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_getSitrep.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_getSitrep.sqf
@@ -117,7 +117,48 @@ _approxTime = "unknown";
     if (_speed > 0 && {(_pos select 2) > 5}) then {_approxTime = round((_distance/((_speed)/3.6))/60)};
     if (_speed > 0 && {(_pos select 2) < 5}) then {_approxTime = "taking off"};
 
-_amcas = format ["%1 this is %2! Current location: %3, ETA: %4, AMCAS: %5, Fuel: %6",_callSignPlayer,_callsign,_assetpos,_approxTime,_damageamcas,_fuelamcas];
+// Military Logistics Simulation status.
+// Resupply state lives on the primary vehicle (single source of truth), not the leader / NEO asset,
+// because that's the object LOGCOM updates on dispatch completion. Resolve via ALIVE_resupply_primaryVehicle
+// and fall back to _asset so Transport/CAS (where _asset IS the vehicle) still works unchanged.
+private _stateHolder = _asset getVariable ["ALIVE_resupply_primaryVehicle", _asset];
+private _logisticsStatus = "";
+if (_asset getVariable ["ALIVE_logistics_enabled", false]) then {
+    private _resupplyState = _stateHolder getVariable ["ALIVE_resupply_state", "none"];
+    switch (_resupplyState) do {
+        case "none": {
+            _logisticsStatus = "Logistics: Ready";
+        };
+        case "dispatched";
+        case "enroute": {
+            private _eta = _stateHolder getVariable ["ALIVE_resupply_eta", 0];
+            private _startTime = _stateHolder getVariable ["ALIVE_resupply_startTime", serverTime];
+            private _remaining = (_eta - (serverTime - _startTime)) max 0;
+            private _mins = floor (_remaining / 60);
+            private _secs = floor (_remaining mod 60);
+            private _secsStr = if (_secs < 10) then {format ["0%1", _secs]} else {str _secs};
+            _logisticsStatus = format ["Logistics: Resupply en route (ETA %1:%2)", _mins, _secsStr];
+        };
+        case "servicing": {
+            _logisticsStatus = "Logistics: Servicing...";
+        };
+        case "complete": {
+            _logisticsStatus = "Logistics: Complete";
+        };
+        case "failed": {
+            _logisticsStatus = "Logistics: Failed - retrying...";
+        };
+    };
+};
+
+private _logSuffix = if (_logisticsStatus != "") then {format [", %1", _logisticsStatus]} else {""};
+_amcas = format ["%1 this is %2! Current location: %3, ETA: %4, AMCAS: %5, Fuel: %6%7",_callSignPlayer,_callsign,_assetpos,_approxTime,_damageamcas,_fuelamcas,_logSuffix];
+
+// Show resupply vehicle marker for currently selected asset.
+private _resupplyVeh = _stateHolder getVariable ["ALIVE_resupply_vehicle", objNull];
+if (!isNull _resupplyVeh && {alive _resupplyVeh}) then {
+    [_resupplyVeh, format ["%1 Resupply", _callsign], "TRANSPORT"] call NEO_fnc_radioCreateMarker;
+};
 
 sleep 6;
 

--- a/addons/sup_transport/CfgVehicles.hpp
+++ b/addons/sup_transport/CfgVehicles.hpp
@@ -38,6 +38,30 @@ class CfgVehicles {
                                 };
                         };
                         class transport_containers : Edit { property = "ALiVE_sup_transport_transport_containers"; displayName = "$STR_ALIVE_TRANSPORT_CONTAINERS"; tooltip = "$STR_ALIVE_TRANSPORT_CONTAINERS_DESC"; defaultValue = """0"""; typeName = "NUMBER"; };
+                        class transport_logistics : Combo
+                        {
+                                property = "ALiVE_sup_transport_transport_logistics";
+                                displayName = "$STR_ALIVE_TRANSPORT_LOGISTICS";
+                                tooltip = "$STR_ALIVE_TRANSPORT_LOGISTICS_DESC";
+                                defaultValue = """0""";
+                                class Values
+                                {
+                                    class No { name = "No"; value = 0; default = 1; };
+                                    class Yes { name = "Yes"; value = 1; };
+                                };
+                        };
+                        class transport_logisticssource : Combo
+                        {
+                                property = "ALiVE_sup_transport_transport_logisticssource";
+                                displayName = "$STR_ALIVE_TRANSPORT_LOGISTICSSOURCE";
+                                tooltip = "$STR_ALIVE_TRANSPORT_LOGISTICSSOURCE_DESC";
+                                defaultValue = """0""";
+                                class Values
+                                {
+                                    class Static { name = "Static (LOGCOM Base)"; value = 0; default = 1; };
+                                    class Dynamic { name = "Dynamic (Nearest Objective)"; value = 1; };
+                                };
+                        };
                         class ModuleDescription : ModuleDescription {};
                 };
                 class ModuleDescription

--- a/addons/sup_transport/stringtable.xml
+++ b/addons/sup_transport/stringtable.xml
@@ -62,4 +62,16 @@
     <English>Number of containers to be spawned for slingloading purposes</English>
     <Chinesesimp>生成的用于吊运的集装箱数量</Chinesesimp>
 </Key>
+<Key ID="STR_ALIVE_TRANSPORT_LOGISTICS">
+    <English>Use Military Logistics Simulation</English>
+</Key>
+<Key ID="STR_ALIVE_TRANSPORT_LOGISTICS_DESC">
+    <English>When enabled, this asset will request resupply from LOGCOM when ammo, fuel, or damage thresholds are reached. Requires a Military Logistics module.</English>
+</Key>
+<Key ID="STR_ALIVE_TRANSPORT_LOGISTICSSOURCE">
+    <English>Logistics Source</English>
+</Key>
+<Key ID="STR_ALIVE_TRANSPORT_LOGISTICSSOURCE_DESC">
+    <English>Static: resupply dispatched from LOGCOM base position. Dynamic: dispatched from nearest friendly-held objective.</English>
+</Key>
 </Container></Package></Project>

--- a/addons/sup_transport/stringtable.xml
+++ b/addons/sup_transport/stringtable.xml
@@ -66,7 +66,7 @@
     <English>Use Military Logistics Simulation</English>
 </Key>
 <Key ID="STR_ALIVE_TRANSPORT_LOGISTICS_DESC">
-    <English>When enabled, this asset will request resupply from LOGCOM when ammo, fuel, or damage thresholds are reached. Requires a Military Logistics module.</English>
+    <English>When enabled, this asset will request resupply from LOGCOM when ammo, fuel, or damage thresholds are reached. Each resupply draws from the Military Logistics force pool - the same pool used for OPCOM reinforcements. Requires a Military Logistics module.</English>
 </Key>
 <Key ID="STR_ALIVE_TRANSPORT_LOGISTICSSOURCE">
     <English>Logistics Source</English>


### PR DESCRIPTION
# Add Military Logistics Simulation for player support assets


---


## Summary

Opt-in per-module feature: LOGCOM dispatches a supply vehicle (truck, heli with slingload crate, or timed force-service) to a player combat-support asset (artillery, CAS, or transport) when the asset drops below ammo, fuel, or damage thresholds. On arrival the asset is rearmed, refueled to 50%, and repaired; the delivery vehicle then RTBs to its source and despawns on arrival.

The feature is off by default on every module. It requires a **Military Logistics** module in the mission; if none is placed, the watchdog logs a warning at mission start and does nothing. Existing missions without the new attributes are unaffected.

## Motivation

ALiVE's player support assets (artillery, CAS, transport) currently have no in-house way to replenish ammo or repair damage during a mission. Community mission makers work around this with external scripts that reset the ammo arrays when they hit zero. This feature brings that loop into ALiVE and routes it through LOGCOM so the supply comes from a real vehicle driving in, instead of silently resetting state.

Community request thread reference: https://discord.com/channels/107240321892511744/1296980679065866240/1492775362533523608

## What changed

### Editor UX

Two new `Combo` attributes on `sup_artillery`, `sup_cas`, and `sup_transport`:

| Attribute | Default | Description |
|-----------|---------|-------------|
| Use Military Logistics Simulation | No | Opt in to the watchdog for this asset. |
| Logistics Source | Static | Static = LOGCOM module position; Dynamic = nearest friendly-held OPCOM objective. |

Strings live in each addon's `stringtable.xml`. **English only for now** — Chinesesimp entries can be contributed by community translators post-merge (following the pattern in other recent string additions).

### New files

- `addons/sup_combatsupport/fnc_resupplyWatchdog.sqf`

  Server-side 30s tick loop. Scans `NEO_radioTrasportArray_*`, `NEO_radioCasArray_*`, `NEO_radioArtyArray_*` live each cycle (dedupes across friendly-side shares by vehicle ref) so respawned assets are picked up automatically and dead refs drop off without a static registry.

  Per-asset guards before dispatch:
  - already-in-progress
  - cooldown (600s)
  - ammo below 25% of original (checks BOTH `NEO_radioArtyBatteryRounds` tracked rounds AND real `vehicleGetAmmo` on every battery tank — covers mods that fire the gun outside NEO accounting)
  - fuel < 0.15
  - damage > 0.5 (and < 1)
  - not in active combat (no enemy within 500m of the primary vehicle)
  - aircraft must be on the ground (`isKindOf Air` + AGL check with a one-shot "waiting for RTB" log latch to avoid spam)
  - concurrent dispatch cap of 3

- `addons/sup_combatsupport/fnc_resupplyService.sqf`

  Rearm + refuel (to 0.5) + repair. Resolves arty from any tank by walking `leader (group _veh)` and looking for `NEO_radioArtyBatteryRounds`; services every tank in the battery and restores the tracked rounds array from the stored defaults. Transport/CAS services the vehicle directly.

### Modified files

- `addons/sup_combatsupport/fnc_combatSupport.sqf`

  Reads the two new attributes per module type, sets `ALIVE_logistics_enabled` / `ALIVE_logistics_source` on spawned vehicles and (for arty) on the battery leader. For arty also stores `ALIVE_resupply_primaryVehicle` ref to the first tank and `ALIVE_resupply_defaultRounds` snapshot. Spawns the watchdog if `mil_logistics` is present.

  Defensive type coercion on `combatsupport_audio`, `transport_slingloading`, `transport_containers` — no-op on binarised production builds, only triggers when PBOs are packed un-binarised (e.g. via Addon Builder `-packonly` for dev iteration). Inline comments at each call site explain the choice.

- `addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_Respawn{Arty,CAS,Transport}Asset.sqf`

  Snapshot the old asset's `ALIVE_logistics_*` variables at function entry (they survive death via `getVariable`), reapply to the new vehicle / leader / tanks after spawn so respawned assets keep their opt-in state.

- `addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_getSitrep.sqf`

  Appends logistics status to the sitrep text (Ready / Dispatched with ETA / Servicing / Complete / Failed) by reading state from the primary vehicle (resolves arty leader → primary tank). Places a "Resupply" map marker on the in-flight supply vehicle while sitrep is open.

- `addons/mil_logistics/fnc_ML.sqf`

  `listen` case adds `LOGCOM_RESUPPLY` to the event listener types.

  New `LOGCOM_RESUPPLY` case handles dispatch:
  - **Source resolution**: Static = `_logic` pos, Dynamic = nearest friendly OPCOM objective in `defend`/`reserve` state (via `OPCOM_instances` hash).
  - **Route check**: stepped `surfaceIsWater` along the straight-line path.
  - **Truck path**: side-appropriate ammo truck (`B/O/I_Truck_0X_ammo_F`), MOVE waypoint at FULL / SAFE, delivery monitor with timeout = `distance / 45kph * 1.5`. Max 3 retries on timeout, then force-service. On arrival (<100m of target) services the asset, clears waypoints, adds MOVE back to `_sourcePos`. RTB monitor deletes the truck on arrival (<75m of source) or after `distance / 45kph * 2x` safety timeout.
  - **Heli slingload path** for water-blocked routes: `B_Heli_Transport_03_F` / `O_Heli_Transport_04_F` / `I_Heli_Transport_02_F` + matching `Slingload_01_Ammo` crate. Uses `findHelicopterLandingPos` for the drop zone, single-authority `landAt`, programmatic `setSlingLoad objNull` release with parachute attached if slung AGL > 5m.
  - **Timer fallback** when no heli class is available in config.

## Design notes worth calling out

1. **State model.** `ALIVE_resupply_primaryVehicle` is the single source of truth for resupply state (`inProgress`, `lastDispatch`, `eta`, `vehicle`). For arty the user-visible state string is mirrored onto the leader for the sitrep read path. LOGCOM writes all its state clears back to `_targetVeh` which *is* the primary. This removed a bug where arty would fail to re-dispatch because only the tank's `inProgress` was cleared on service completion while the leader's stayed `true`.

2. **Cooldown guard.** Skips the check when `lastDispatch == 0` so the 600s cooldown doesn't suppress every asset for the first 10 minutes of every mission.

3. **Watchdog is live-scan, not a static registry.** Per-tick scan of the `NEO_radio*` arrays handles respawn for free, with a local `_seen` list for per-tick dedupe across side-shared entries.

4. **Ammo check reads both tracking sources.** NEO_radio's array reflects what the arty FSM has done; `vehicleGetAmmo` reflects physical magazines. Checking both covers mods like CBA arty control or AI CAS that fire outside the NEO accounting.

5. **Combo-without-typeName attributes round-trip through Eden as STRING always.** The new logistics attrs use bare `parseNumber()` — no `str()` wrapper. This diverges from the upstream `parseNumber str (...)` idiom, which is correct for Edit `typeName=NUMBER` attrs where Eden returns NUMBER. Inline comments at each call site explain.

## Backwards compatibility

- Missions without the new attributes continue to work. Attributes default to No/Static and the feature is a no-op.
- Existing missions with placed `sup_*` modules built before this change will default the new attributes to `"0"` on next load, so logistics stays off until the mission maker toggles it in Eden.
- No existing behaviour is changed unless a mission maker explicitly opts in on a module AND places a `mil_logistics` module.

## Testing disclosure

All end-to-end verification to date (watchdog trigger, truck dispatch, arty rearm, respawn continuity, RTB cleanup, sitrep state display) has been against **un-binarised PBOs** packed via Addon Builder `-packonly` for fast dev iteration.

Defensive type coercion in the init code covers the latent Eden-attribute quirks that surface on un-binarised builds (STRING vs. BOOL / NUMBER round-tripping). The architecture has no dependency on un-binarised behaviour — the guards are no-ops when Eden returns the expected types — but a **sanity pass on the production binarised pipeline (Mikero pboProject) is recommended before merge**.

Scenarios verified:
- [x] Arty fires all HE → truck dispatched within 30s, drives to battery, services, NEO_radio battery rounds restored, tablet UI reflects full ammo.
- [x] Asset destroyed mid-mission → new battery inherits logistics opt-in via respawn snapshot.
- [x] Second dispatch after service completion (cooldown-dependent) fires correctly.
- [x] Sitrep on selected asset shows Dispatched/Servicing/Complete states with countdown.
- [x] Resupply vehicle map marker draws on selection.
- [x] No `mil_logistics` placed → watchdog warns and exits cleanly; mission otherwise unaffected.
- [ ] Binarised build sanity pass — deferred to upstream.
- [ ] Heli slingload fallback — coded with care following lessons from recent upstream slingload fixes, but unverified in-mission; would benefit from a review pass by someone more familiar with that pipeline.

## Files touched

```
 addons/mil_logistics/fnc_ML.sqf                    | 549 ++++++++++++++++++++-
 addons/sup_artillery/CfgVehicles.hpp               |  24 +
 addons/sup_artillery/stringtable.xml               |  12 +
 addons/sup_cas/CfgVehicles.hpp                     |  24 +
 addons/sup_cas/stringtable.xml                     |  12 +
 addons/sup_combatsupport/CfgFunctions.hpp          |  10 +
 addons/sup_combatsupport/fnc_combatSupport.sqf     |  88 +++-
 addons/sup_combatsupport/fnc_resupplyService.sqf   |  73 +++  (new)
 addons/sup_combatsupport/fnc_resupplyWatchdog.sqf  | 233 +++++++++ (new)
 addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_RespawnArtyAsset.sqf     | 19 +
 addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_RespawnCASAsset.sqf      |  9 +
 addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_RespawnTransportAsset.sqf|  9 +
 addons/sup_combatsupport/scripts/NEO_radio/functions/misc/fn_getSitrep.sqf            | 43 +-
 addons/sup_transport/CfgVehicles.hpp               |  24 +
 addons/sup_transport/stringtable.xml               |  12 +
 15 files changed, 1134 insertions(+), 7 deletions(-)
```

## Checklist

- [x] Opt-in only; no existing behaviour changed by default
- [x] Stringtable-backed attribute labels & tooltips
- [x] Respawn-safe
- [x] Multiplayer-safe (server-side watchdog; state broadcast for client sitrep reads)
- [x] No hard dependency on un-binarised PBOs
- [x] Squashed to a single commit
- [ ] Chinesesimp translations (happy to follow up, or land as-is and let a translator PR the strings)
- [ ] Binarised-build verification — deferred as I'm unsure the proper way to do this without delaying this alot longer.

## Notes for reviewers

- First contribution to ALiVE.OS — apologies in advance if I've missed a convention. Happy to rework any of this based on feedback.
- The defensive type-coercion pattern in `fnc_combatSupport.sqf` is somewhat opinionated. If the upstream position is "production builds are always binarised, these guards are unnecessary", I'm happy to strip them — they only exist to make the dev-build path less painful for future contributors using Addon Builder.
