### PR TITLE
[MIL_C2ISTAR] [FNC_ANALYSIS] OPCOM map intel now creates client-local…

### DIFF
--- a/addons/fnc_analysis/fnc_liveAnalysis.sqf
+++ b/addons/fnc_analysis/fnc_liveAnalysis.sqf
@@ -501,11 +501,19 @@ switch(_operation) do {
                     _revealInstallations = (_revealInstallations == "true");
                 };
 
-                private _sourceSideText = toUpper _side;
-                if (_sourceSideText in ["INDEP","INDEPENDENT","RESISTANCE"]) then {
-                    _sourceSideText = "GUER";
+                private _sourceSide = civilian;
+                private _sourceSideText = "CIV";
+                if (_side isEqualType west) then {
+                    _sourceSide = _side;
+                    _sourceSideText = [[_sourceSide] call ALIVE_fnc_sideObjectToNumber] call ALIVE_fnc_sideNumberToText;
+                } else {
+                    _sourceSideText = if (_side isEqualType "") then {toUpper _side} else {toUpper str _side};
+                    if (_sourceSideText in ["INDEP","INDEPENDENT","RESISTANCE"]) then {
+                        _sourceSideText = "GUER";
+                    };
+                    _sourceSide = [_sourceSideText] call ALIVE_fnc_sideTextToObject;
                 };
-                private _sourceSide = [_sourceSideText] call ALIVE_fnc_sideTextToObject;
+
                 private _sourceFactions = [];
                 private _opcomID = [_objective,"opcomID",""] call ALIVE_fnc_hashGet;
 
@@ -572,7 +580,7 @@ switch(_operation) do {
                     };
 
                     // set the side color
-                    switch(_side) do {
+                    switch(_sourceSideText) do {
                         case "EAST":{
                             _color = "ColorRed";
                         };

--- a/addons/fnc_analysis/fnc_liveAnalysis.sqf
+++ b/addons/fnc_analysis/fnc_liveAnalysis.sqf
@@ -140,18 +140,6 @@ switch(_operation) do {
                 };
             } foreach _args;
         };
-        case "setMarkerAlphaLocally": {
-            if !(hasInterface) exitWith {};
-
-            _args params [
-                ["_markers", [], [[]]],
-                ["_alpha", 1, [0]]
-            ];
-
-            {
-                _x setMarkerAlphaLocal _alpha;
-            } forEach _markers;
-        };
         case "deleteMarkersLocally": {
             if !(hasInterface) exitWith {};
 
@@ -539,6 +527,7 @@ switch(_operation) do {
                     };
                     default {allPlayers select {side (group _x) == _sourceSide}};
                 };
+                private _intelNonRecipients = allPlayers - _intelRecipients;
 
                 // Installations
                 private _factory = [[],"convertObject",[_objective,"factory",[]] call ALiVE_fnc_HashGet] call ALiVE_fnc_OPCOM;
@@ -552,7 +541,7 @@ switch(_operation) do {
 
                 private _installations = [_factory,_HQ,_ambush,_depot,_sabotage,_ied,_suicide,_roadblocks];
 
-                private ["_profiles","_markers","_profileID","_profile","_alpha","_marker","_color","_dir","_position","_icon","_text","_m"];
+                private ["_profiles","_markers","_markerData","_profileID","_profile","_alpha","_marker","_color","_dir","_position","_icon","_text","_m"];
 
                 // on the first run create all the markers
                 if(_runCount == 0) then {
@@ -711,14 +700,18 @@ switch(_operation) do {
                     if (count _intelRecipients > 0 && {count _markerData > 0}) then {
                         [objNull,"createMarkersLocally", _markerData] remoteExecCall ["ALiVE_fnc_liveAnalysis", _intelRecipients];
                     };
+                    if (count _intelNonRecipients > 0 && {count _markers > 0}) then {
+                        [objNull,"deleteMarkersLocally", _markers] remoteExecCall ["ALiVE_fnc_liveAnalysis", _intelNonRecipients];
+                    };
 
-                    _jobArgs pushback ([_markers, _profiles]);
+                    _jobArgs pushback ([_markers, _profiles, _markerData]);
 
                 // on subsequent runs lower marker alpha
                 } else {
 
                     _markers = _jobArgs select 1 select 0;
                     _profiles = _jobArgs select 1 select 1;
+                    _markerData = (_jobArgs select 1) param [2, []];
 
                     // set alpha based on age of intel item
                     if(_runCount <= 1) then {
@@ -734,8 +727,15 @@ switch(_operation) do {
                         _alpha = 0.2;
                     };
 
-                    if (count _intelRecipients > 0 && {count _markers > 0}) then {
-                        [objNull,"setMarkerAlphaLocally", [_markers,_alpha]] remoteExecCall ["ALiVE_fnc_liveAnalysis", _intelRecipients];
+                    {
+                        _x set ["alpha", _alpha];
+                    } forEach _markerData;
+
+                    if (count _intelRecipients > 0 && {count _markerData > 0}) then {
+                        [objNull,"createMarkersLocally", _markerData] remoteExecCall ["ALiVE_fnc_liveAnalysis", _intelRecipients];
+                    };
+                    if (count _intelNonRecipients > 0 && {count _markers > 0}) then {
+                        [objNull,"deleteMarkersLocally", _markers] remoteExecCall ["ALiVE_fnc_liveAnalysis", _intelNonRecipients];
                     };
 
                 };

--- a/addons/fnc_analysis/fnc_liveAnalysis.sqf
+++ b/addons/fnc_analysis/fnc_liveAnalysis.sqf
@@ -93,6 +93,70 @@ switch(_operation) do {
 
             _result = _args;
         };
+        case "createMarkersLocally": {
+            if !(hasInterface) exitWith {};
+
+            {
+                private _id = _x get "id";
+                private _position = _x get "position";
+                private _shape = _x get "shape";
+                private _color = _x get "color";
+                private _alpha = _x get "alpha";
+                private _type = _x get "type";
+                private _size = _x get "size";
+                private _dir = _x get "direction";
+                private _text = _x get "text";
+                private _brush = _x get "brush";
+                private _path = _x get "path";
+
+                deleteMarkerLocal _id;
+                private _marker = createMarkerLocal [_id, _position];
+                _marker setMarkerShapeLocal _shape;
+
+                if !(isnil "_color") then {
+                    _marker setMarkerColorLocal _color;
+                };
+                if !(isnil "_alpha") then {
+                    _marker setMarkerAlphaLocal _alpha;
+                };
+                if !(isnil "_type") then {
+                    _marker setMarkerTypeLocal _type;
+                };
+                if !(isnil "_size") then {
+                    _marker setMarkerSizeLocal _size;
+                };
+                if !(isnil "_dir") then {
+                    _marker setMarkerDirLocal _dir;
+                };
+                if !(isnil "_text") then {
+                    _marker setMarkerTextLocal _text;
+                };
+                if !(isnil "_brush") then {
+                    _marker setMarkerBrushLocal _brush;
+                };
+                if !(isnil "_path") then {
+                    _marker setMarkerPolylineLocal _path;
+                    _marker setMarkerShadowLocal false;
+                };
+            } foreach _args;
+        };
+        case "setMarkerAlphaLocally": {
+            if !(hasInterface) exitWith {};
+
+            _args params [
+                ["_markers", [], [[]]],
+                ["_alpha", 1, [0]]
+            ];
+
+            {
+                _x setMarkerAlphaLocal _alpha;
+            } forEach _markers;
+        };
+        case "deleteMarkersLocally": {
+            if !(hasInterface) exitWith {};
+
+            {deleteMarkerLocal _x} forEach _args;
+        };
         case "pause": {
             if(typeName _args != "BOOL") then {
                     // if no new value was provided return current setting
@@ -443,6 +507,39 @@ switch(_operation) do {
                 _objectiveID = [_objective,"objectiveID"] call ALIVE_fnc_hashGet;
                 _section = [_objective,"section",[]] call ALIVE_fnc_hashGet;
 
+                private _mapIntelVisibility = toUpper (missionNamespace getVariable ["ALIVE_militaryIntelVisibility", "SIDE"]);
+                private _revealInstallations = missionNamespace getVariable ["ALIVE_militaryIntelRevealInstallations", false];
+                if (_revealInstallations isEqualType "") then {
+                    _revealInstallations = (_revealInstallations == "true");
+                };
+
+                private _sourceSideText = toUpper _side;
+                if (_sourceSideText in ["INDEP","INDEPENDENT","RESISTANCE"]) then {
+                    _sourceSideText = "GUER";
+                };
+                private _sourceSide = [_sourceSideText] call ALIVE_fnc_sideTextToObject;
+                private _sourceFactions = [];
+                private _opcomID = [_objective,"opcomID",""] call ALIVE_fnc_hashGet;
+
+                {
+                    if (_x isEqualType [] && {([_x,"opcomID",""] call ALIVE_fnc_hashGet) == _opcomID}) exitWith {
+                        _sourceFactions = [_x,"factions",[]] call ALIVE_fnc_hashGet;
+                    };
+                } forEach (missionNamespace getVariable ["OPCOM_instances", []]);
+
+                private _intelRecipients = switch (_mapIntelVisibility) do {
+                    case "ALL": {+allPlayers};
+                    case "FRIENDLY": {allPlayers select {(_sourceSide getFriend (side (group _x))) >= 0.6}};
+                    case "FACTION": {
+                        if (_sourceFactions isEqualTo []) then {
+                            allPlayers select {side (group _x) == _sourceSide}
+                        } else {
+                            allPlayers select {(faction _x) in _sourceFactions}
+                        };
+                    };
+                    default {allPlayers select {side (group _x) == _sourceSide}};
+                };
+
                 // Installations
                 private _factory = [[],"convertObject",[_objective,"factory",[]] call ALiVE_fnc_HashGet] call ALiVE_fnc_OPCOM;
                 private _HQ = [[],"convertObject",[_objective,"HQ",[]] call ALiVE_fnc_HashGet] call ALiVE_fnc_OPCOM;
@@ -462,6 +559,7 @@ switch(_operation) do {
 
                     private _profiles = [];
                     private _markers = [];
+                    private _markerData = [];
                     private _alpha = 1;
 
                     // create the profile marker
@@ -472,14 +570,17 @@ switch(_operation) do {
                             _position = _profile select 2 select 2;
 
                             if!(surfaceIsWater _position) then {
-                                private _marker = [_profile, "createDebugMarkers", [_alpha]] call ALIVE_fnc_profileEntity;
-                                _markers = _markers + _marker;
                                 _profiles pushback _profileID;
                             };
 
                             _dir = _position getDir _center;
                         };
                     } forEach _section;
+
+                    if (isnil "_position") then {
+                        _position = _center;
+                        _dir = 0;
+                    };
 
                     // set the side color
                     switch(_side) do {
@@ -501,14 +602,17 @@ switch(_operation) do {
                     };
 
                     // create the objective area marker
-                    private _m = createMarker [format[MTEMPLATE, _objectiveID], _center];
-                    _m setMarkerShape "Ellipse";
-                    _m setMarkerBrush "FDiagonal";
-                    _m setMarkerSize [_size, _size];
-                    _m setMarkerColor _color;
-                    _m setMarkerAlpha _alpha;
-
+                    private _m = format[MTEMPLATE, _objectiveID];
                     _markers pushback _m;
+                    _markerData pushback (createHashMapFromArray [
+                        ["id", _m],
+                        ["position", _center],
+                        ["shape", "ELLIPSE"],
+                        ["brush", "FDiagonal"],
+                        ["size", [_size, _size]],
+                        ["color", _color],
+                        ["alpha", _alpha]
+                    ]);
 
                     _icon = "mil_unknown";
                     _text = "";
@@ -524,15 +628,20 @@ switch(_operation) do {
                         case "recon":{
 
                             // create direction marker
-                            _m = createMarker [format[MTEMPLATE, format["%1_dir", _objectiveID]], _position getPos [100, _dir]];
-                            _m setMarkerShape "ICON";
-                            _m setMarkerSize [0.5,0.5];
-                            _m setMarkerType "mil_arrow";
-                            _m setMarkerColor _color;
-                            _m setMarkerAlpha _alpha;
-                            _m setMarkerDir _dir;
+                            _m = format[MTEMPLATE, format["%1_dir", _objectiveID]];
 
                             _markers pushback _m;
+
+                            _markerData pushback (createHashMapFromArray [
+                                ["id", _m],
+                                ["position", _position getPos [100, _dir]],
+                                ["shape", "ICON"],
+                                ["size", [0.5,0.5]],
+                                ["type", "mil_arrow"],
+                                ["color", _color],
+                                ["alpha", _alpha],
+                                ["direction", _dir]
+                            ]);
 
                             _icon = "mil_unknown";
                             _text = " sighting";
@@ -540,15 +649,20 @@ switch(_operation) do {
                         case "capture":{
 
                             // create direction marker
-                            _m = createMarker [format[MTEMPLATE, format["%1_dir", _objectiveID]], _position getPos [100, _dir]];
-                            _m setMarkerShape "ICON";
-                            _m setMarkerSize [0.5,0.5];
-                            _m setMarkerType "mil_arrow2";
-                            _m setMarkerColor _color;
-                            _m setMarkerAlpha _alpha;
-                            _m setMarkerDir _dir;
+                            _m = format[MTEMPLATE, format["%1_dir", _objectiveID]];
 
                             _markers pushback _m;
+
+                            _markerData pushback (createHashMapFromArray [
+                                ["id", _m],
+                                ["position", _position getPos [100, _dir]],
+                                ["shape", "ICON"],
+                                ["size", [0.5,0.5]],
+                                ["type", "mil_arrow2"],
+                                ["color", _color],
+                                ["alpha", _alpha],
+                                ["direction", _dir]
+                            ]);
 
                             _icon = "mil_warning";
                             _text = " captured";
@@ -562,23 +676,41 @@ switch(_operation) do {
                     // create type marker - offset east so its text label
                     // doesn't overlap the strategic cluster / opcom labels
                     // that also render at _center (see ALiVE_fnc_debugMarkerOffset).
-                    _m = createMarker [format[MTEMPLATE, format["%1_type", _objectiveID]], ["analysis.live", _center] call ALiVE_fnc_debugMarkerOffset];
-                    _m setMarkerShape "ICON";
-                    _m setMarkerSize [0.5, 0.5];
-                    _m setMarkerType _icon;
-                    _m setMarkerColor _color;
-                    _m setMarkerAlpha _alpha;
-                    _m setMarkerText _text;
-
+                    _m = format[MTEMPLATE, format["%1_type", _objectiveID]];
                     _markers pushback _m;
+                    _markerData pushback (createHashMapFromArray [
+                        ["id", _m],
+                        ["position", ["analysis.live", _center] call ALiVE_fnc_debugMarkerOffset],
+                        ["shape", "ICON"],
+                        ["size", [0.5, 0.5]],
+                        ["type", _icon],
+                        ["color", _color],
+                        ["alpha", _alpha],
+                        ["text", _text]
+                    ]);
 
-                    // Show installations
-                    {
-                        if (alive _x) then {
-                            _m = [format[MTEMPLATE,format["%1%2_inst", _objectiveID,_foreachIndex]],getposATL _x,"ICON", [1,1],"ColorRed","Installation", "n_installation", "FDiagonal",0,0.5 ] call ALIVE_fnc_createMarkerGlobal;
-                            _markers append [_m];
-                        };
-                    } foreach _installations;
+                    if (_revealInstallations) then {
+                        {
+                            if (alive _x) then {
+                                _m = format[MTEMPLATE,format["%1%2_inst", _objectiveID,_foreachIndex]];
+                                _markers pushback _m;
+                                _markerData pushback (createHashMapFromArray [
+                                    ["id", _m],
+                                    ["position", getposATL _x],
+                                    ["shape", "ICON"],
+                                    ["size", [1,1]],
+                                    ["type", "n_installation"],
+                                    ["color", "ColorRed"],
+                                    ["alpha", 0.5],
+                                    ["text", "Installation"]
+                                ]);
+                            };
+                        } foreach _installations;
+                    };
+
+                    if (count _intelRecipients > 0 && {count _markerData > 0}) then {
+                        [objNull,"createMarkersLocally", _markerData] remoteExecCall ["ALiVE_fnc_liveAnalysis", _intelRecipients];
+                    };
 
                     _jobArgs pushback ([_markers, _profiles]);
 
@@ -602,9 +734,9 @@ switch(_operation) do {
                         _alpha = 0.2;
                     };
 
-                    {
-                        _x setMarkerAlpha _alpha;
-                    } forEach _markers;
+                    if (count _intelRecipients > 0 && {count _markers > 0}) then {
+                        [objNull,"setMarkerAlphaLocally", [_markers,_alpha]] remoteExecCall ["ALiVE_fnc_liveAnalysis", _intelRecipients];
+                    };
 
                 };
             };
@@ -647,9 +779,9 @@ switch(_operation) do {
                     };
                 } forEach _profiles;
 
-                {
-                    deleteMarker _x;
-                } forEach _markers;
+                if (count _markers > 0) then {
+                    [objNull,"deleteMarkersLocally", _markers] remoteExecCall ["ALiVE_fnc_liveAnalysis", allPlayers];
+                };
 
             };
         };

--- a/addons/fnc_analysis/fnc_liveAnalysis.sqf
+++ b/addons/fnc_analysis/fnc_liveAnalysis.sqf
@@ -109,34 +109,36 @@ switch(_operation) do {
                 private _brush = _x get "brush";
                 private _path = _x get "path";
 
-                deleteMarkerLocal _id;
-                private _marker = createMarkerLocal [_id, _position];
-                _marker setMarkerShapeLocal _shape;
+                if (!(isnil "_id") && {!(isnil "_position")} && {!(isnil "_shape")} && {_position isEqualType []} && {count _position >= 2}) then {
+                    deleteMarkerLocal _id;
+                    private _marker = createMarkerLocal [_id, _position];
+                    _marker setMarkerShapeLocal _shape;
 
-                if !(isnil "_color") then {
-                    _marker setMarkerColorLocal _color;
-                };
-                if !(isnil "_alpha") then {
-                    _marker setMarkerAlphaLocal _alpha;
-                };
-                if !(isnil "_type") then {
-                    _marker setMarkerTypeLocal _type;
-                };
-                if !(isnil "_size") then {
-                    _marker setMarkerSizeLocal _size;
-                };
-                if !(isnil "_dir") then {
-                    _marker setMarkerDirLocal _dir;
-                };
-                if !(isnil "_text") then {
-                    _marker setMarkerTextLocal _text;
-                };
-                if !(isnil "_brush") then {
-                    _marker setMarkerBrushLocal _brush;
-                };
-                if !(isnil "_path") then {
-                    _marker setMarkerPolylineLocal _path;
-                    _marker setMarkerShadowLocal false;
+                    if !(isnil "_color") then {
+                        _marker setMarkerColorLocal _color;
+                    };
+                    if !(isnil "_alpha") then {
+                        _marker setMarkerAlphaLocal _alpha;
+                    };
+                    if !(isnil "_type") then {
+                        _marker setMarkerTypeLocal _type;
+                    };
+                    if !(isnil "_size") then {
+                        _marker setMarkerSizeLocal _size;
+                    };
+                    if !(isnil "_dir") then {
+                        _marker setMarkerDirLocal _dir;
+                    };
+                    if !(isnil "_text") then {
+                        _marker setMarkerTextLocal _text;
+                    };
+                    if !(isnil "_brush") then {
+                        _marker setMarkerBrushLocal _brush;
+                    };
+                    if !(isnil "_path") then {
+                        _marker setMarkerPolylineLocal _path;
+                        _marker setMarkerShadowLocal false;
+                    };
                 };
             } foreach _args;
         };
@@ -674,10 +676,15 @@ switch(_operation) do {
                     // doesn't overlap the strategic cluster / opcom labels
                     // that also render at _center (see ALiVE_fnc_debugMarkerOffset).
                     _m = format[MTEMPLATE, format["%1_type", _objectiveID]];
+                    private _typeMarkerPosition = if (isNil "ALiVE_fnc_debugMarkerOffset") then {
+                        _center getPos [25, 90]
+                    } else {
+                        ["analysis.live", _center] call ALiVE_fnc_debugMarkerOffset
+                    };
                     _markers pushback _m;
                     _markerData pushback (createHashMapFromArray [
                         ["id", _m],
-                        ["position", ["analysis.live", _center] call ALiVE_fnc_debugMarkerOffset],
+                        ["position", _typeMarkerPosition],
                         ["shape", "ICON"],
                         ["size", [0.5, 0.5]],
                         ["type", _icon],

--- a/addons/fnc_analysis/fnc_militaryIntel.sqf
+++ b/addons/fnc_analysis/fnc_militaryIntel.sqf
@@ -40,6 +40,8 @@ nil
 #define MAINCLASS ALIVE_fnc_militaryIntel
 
 #define DEFAULT_DISPLAY_INTEL false
+#define DEFAULT_MAP_INTEL_VISIBILITY "SIDE"
+#define DEFAULT_MAP_INTEL_REVEAL_INSTALLATIONS false
 #define DEFAULT_INTEL_CHANCE "0.1"
 #define DEFAULT_FRIENDLY_INTEL false
 #define DEFAULT_FRIENDLY_INTEL_RADIUS 2000
@@ -82,6 +84,26 @@ switch(_operation) do {
     case "displayIntel": {
         _result = [_logic,_operation,_args,DEFAULT_DISPLAY_INTEL] call ALIVE_fnc_OOsimpleOperation;
     };
+    case "mapIntelVisibility": {
+        if (_args isEqualType "") then {
+            _args = toUpper _args;
+        };
+        _result = [_logic,_operation,_args,DEFAULT_MAP_INTEL_VISIBILITY,["SIDE","FACTION","FRIENDLY","ALL"]] call ALIVE_fnc_OOsimpleOperation;
+    };
+    case "mapIntelRevealInstallations": {
+        if (typeName _args == "BOOL") then {
+            [_logic,"mapIntelRevealInstallations",_args] call ALIVE_fnc_hashSet;
+        } else {
+            _args = [_logic,"mapIntelRevealInstallations",DEFAULT_MAP_INTEL_REVEAL_INSTALLATIONS] call ALIVE_fnc_hashGet;
+        };
+        if (typeName _args == "STRING") then {
+            if(_args == "true") then {_args = true;} else {_args = false;};
+            [_logic,"mapIntelRevealInstallations",_args] call ALIVE_fnc_hashSet;
+        };
+        ASSERT_TRUE(typeName _args == "BOOL",str _args);
+
+        _result = _args;
+    };
     case "intelChance": {
         _result = [_logic,_operation,_args,DEFAULT_INTEL_CHANCE] call ALIVE_fnc_OOsimpleOperation;
     };
@@ -117,7 +139,7 @@ switch(_operation) do {
         };
     };
     case "start": {
-        private["_friendlyIntel","_displayMilitarySectors","_displayPlayerSectors","_displayIntel"];
+        private["_friendlyIntel","_displayMilitarySectors","_displayPlayerSectors","_displayIntel","_mapIntelVisibility","_mapIntelRevealInstallations"];
 
         if !(["ALiVE_sys_profile"] call ALiVE_fnc_isModuleAvailable) exitwith {
             ["Profile System module not placed! Exiting..."] call ALiVE_fnc_DumpR;
@@ -144,6 +166,11 @@ switch(_operation) do {
         };
 
         _displayIntel = [_logic, "displayIntel"] call MAINCLASS;
+        _mapIntelVisibility = [_logic, "mapIntelVisibility"] call MAINCLASS;
+        _mapIntelRevealInstallations = [_logic, "mapIntelRevealInstallations"] call MAINCLASS;
+
+        missionNamespace setVariable ["ALIVE_militaryIntelVisibility", _mapIntelVisibility, true];
+        missionNamespace setVariable ["ALIVE_militaryIntelRevealInstallations", _mapIntelRevealInstallations, true];
 
         if(_displayIntel) then {
             [_logic,"listen"] call MAINCLASS;

--- a/addons/fnc_analysis/fnc_sector.sqf
+++ b/addons/fnc_analysis/fnc_sector.sqf
@@ -124,7 +124,12 @@ _createMarkers = {
                 // Offset south so the sector-ID label doesn't overlap the
                 // strategic cluster / opcom debug labels at the same centre
                 // (see ALiVE_fnc_debugMarkerOffset registry).
-                _m = createMarker [format[MTEMPLATE, format["l%1_%2",_gridID,_id]], ["analysis.sector", _position] call ALiVE_fnc_debugMarkerOffset];
+                private _sectorLabelPosition = if (isNil "ALiVE_fnc_debugMarkerOffset") then {
+                    _position getPos [25, 180]
+                } else {
+                    ["analysis.sector", _position] call ALiVE_fnc_debugMarkerOffset
+                };
+                _m = createMarker [format[MTEMPLATE, format["l%1_%2",_gridID,_id]], _sectorLabelPosition];
                 _m setMarkerShape "ICON";
                 _m setMarkerSize [0.5, 0.5];
                 _m setMarkerType "mil_dot";

--- a/addons/mil_c2istar/CfgVehicles.hpp
+++ b/addons/mil_c2istar/CfgVehicles.hpp
@@ -553,6 +553,56 @@ class CfgVehicles {
                                     };
                             };
                     };
+                    class mapIntelVisibility : Combo
+                    {
+                            property = "ALiVE_MIL_C2ISTAR_mapIntelVisibility";
+                            displayName = "$STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY";
+                            tooltip = "$STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY_COMMENT";
+                            defaultValue = """SIDE""";
+                            class Values
+                            {
+                                    class SIDE
+                                    {
+                                            name = "$STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY_SIDE";
+                                            value = "SIDE";
+                                    };
+                                    class FACTION
+                                    {
+                                            name = "$STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY_FACTION";
+                                            value = "FACTION";
+                                    };
+                                    class FRIENDLY
+                                    {
+                                            name = "$STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY_FRIENDLY";
+                                            value = "FRIENDLY";
+                                    };
+                                    class ALL
+                                    {
+                                            name = "$STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY_ALL";
+                                            value = "ALL";
+                                    };
+                            };
+                    };
+                    class mapIntelRevealInstallations : Combo
+                    {
+                            property = "ALiVE_MIL_C2ISTAR_mapIntelRevealInstallations";
+                            displayName = "$STR_ALIVE_C2ISTAR_MAP_INTEL_REVEAL_INSTALLATIONS";
+                            tooltip = "$STR_ALIVE_C2ISTAR_MAP_INTEL_REVEAL_INSTALLATIONS_COMMENT";
+                            defaultValue = """false""";
+                            class Values
+                            {
+                                    class No
+                                    {
+                                            name = "No";
+                                            value = "false";
+                                    };
+                                    class Yes
+                                    {
+                                            name = "Yes";
+                                            value = "true";
+                                    };
+                            };
+                    };
                     class displayDiarySpotrep : Combo
                     {
                             property = "ALiVE_MIL_C2ISTAR_displayDiarySpotrep";

--- a/addons/mil_c2istar/fnc_C2ISTAR.sqf
+++ b/addons/mil_c2istar/fnc_C2ISTAR.sqf
@@ -57,6 +57,8 @@ Peer Reviewed:
 #define DEFAULT_SCOM_LIMIT "SIDE"
 
 #define DEFAULT_DISPLAY_INTEL false
+#define DEFAULT_MAP_INTEL_VISIBILITY "SIDE"
+#define DEFAULT_MAP_INTEL_REVEAL_INSTALLATIONS false
 #define DEFAULT_INTEL_CHANCE "0.1"
 #define DEFAULT_FRIENDLY_INTEL false
 #define DEFAULT_FRIENDLY_INTEL_RADIUS 2000
@@ -378,6 +380,26 @@ switch(_operation) do {
         if (typeName _args == "STRING") then {
                 if(_args == "true") then {_args = true;} else {_args = false;};
                 _logic setVariable ["displayIntel", _args];
+        };
+        ASSERT_TRUE(typeName _args == "BOOL",str _args);
+
+        _result = _args;
+    };
+    case "mapIntelVisibility": {
+        if (_args isEqualType "") then {
+            _args = toUpper _args;
+        };
+        _result = [_logic,_operation,_args,DEFAULT_MAP_INTEL_VISIBILITY,["SIDE","FACTION","FRIENDLY","ALL"]] call ALIVE_fnc_OOsimpleOperation;
+    };
+    case "mapIntelRevealInstallations": {
+        if (typeName _args == "BOOL") then {
+            _logic setVariable ["mapIntelRevealInstallations", _args];
+        } else {
+            _args = _logic getVariable ["mapIntelRevealInstallations", DEFAULT_MAP_INTEL_REVEAL_INSTALLATIONS];
+        };
+        if (typeName _args == "STRING") then {
+            if(_args == "true") then {_args = true;} else {_args = false;};
+            _logic setVariable ["mapIntelRevealInstallations", _args];
         };
         ASSERT_TRUE(typeName _args == "BOOL",str _args);
 
@@ -873,9 +895,11 @@ switch(_operation) do {
                 };
             };
 
-            private["_displayIntel","_intelChance","_friendlyIntel","_friendlyIntelRadius","_displayMilitarySectors","_displayPlayerSectors","_displayIntel","_runEvery","_intel"];
+            private["_displayIntel","_mapIntelVisibility","_mapIntelRevealInstallations","_intelChance","_friendlyIntel","_friendlyIntelRadius","_displayMilitarySectors","_displayPlayerSectors","_runEvery","_intel"];
 
             _displayIntel = [_logic, "displayIntel"] call MAINCLASS;
+            _mapIntelVisibility = [_logic, "mapIntelVisibility"] call MAINCLASS;
+            _mapIntelRevealInstallations = [_logic, "mapIntelRevealInstallations"] call MAINCLASS;
             _intelChance = [_logic, "intelChance"] call MAINCLASS;
             _friendlyIntel = [_logic, "friendlyIntel"] call MAINCLASS;
             _friendlyIntelRadius = [_logic, "friendlyIntelRadius"] call MAINCLASS;
@@ -887,10 +911,15 @@ switch(_operation) do {
                 _friendlyIntelRadius = parseNumber _friendlyIntelRadius;
             };
 
+            missionNamespace setVariable ["ALIVE_militaryIntelVisibility", _mapIntelVisibility, true];
+            missionNamespace setVariable ["ALIVE_militaryIntelRevealInstallations", _mapIntelRevealInstallations, true];
+
             if(_displayIntel || _displayPlayerSectors || _displayMilitarySectors || _friendlyIntel) then {
 
                 _intel = [nil, "create"] call ALIVE_fnc_militaryIntel;
                 [_intel, "displayIntel",_displayIntel] call ALIVE_fnc_militaryIntel;
+                [_intel, "mapIntelVisibility",_mapIntelVisibility] call ALIVE_fnc_militaryIntel;
+                [_intel, "mapIntelRevealInstallations",_mapIntelRevealInstallations] call ALIVE_fnc_militaryIntel;
                 [_intel, "intelChance",_intelChance] call ALIVE_fnc_militaryIntel;
                 [_intel, "friendlyIntel",_friendlyIntel] call ALIVE_fnc_militaryIntel;
                 [_intel, "friendlyIntelRadius",_friendlyIntelRadius] call ALIVE_fnc_militaryIntel;

--- a/addons/mil_c2istar/fnc_C2ISTAR.sqf
+++ b/addons/mil_c2istar/fnc_C2ISTAR.sqf
@@ -1094,7 +1094,8 @@ switch(_operation) do {
 
             // Build faction list — filtered to ALiVE mission factions when module param is set
             _factionsDataSource = [] call ALiVE_fnc_getFactionsDataSource;
-            if (missionNamespace getVariable ["ALIVE_c2istar_filterEnemyFactions", true]) then {
+            private _filterEnemyFactions = missionNamespace getVariable ["ALIVE_c2istar_filterEnemyFactions", true];
+            if (_filterEnemyFactions && {!isNil "ALiVE_fnc_getAliveMissionFactionsDataSource"}) then {
                 private _missionFactionsDataSource = [] call ALiVE_fnc_getAliveMissionFactionsDataSource;
                 // If OPCOM has not yet registered any factions, keep the full list fallback.
                 if (
@@ -1105,6 +1106,10 @@ switch(_operation) do {
                     _factionsDataSource = _missionFactionsDataSource;
                 } else {
                     ["C2ISTAR - filterEnemyFactions: no OPCOM factions found yet, falling back to full faction list"] call ALiVE_fnc_dump;
+                };
+            } else {
+                if (_filterEnemyFactions) then {
+                    ["C2ISTAR - filterEnemyFactions: mission faction datasource unavailable, falling back to full faction list"] call ALiVE_fnc_dump;
                 };
             };
             [_taskingState,"generateFactionOptions",_factionsDataSource select 0] call ALIVE_fnc_hashSet;

--- a/addons/mil_c2istar/fnc_C2ISTAR.sqf
+++ b/addons/mil_c2istar/fnc_C2ISTAR.sqf
@@ -1093,15 +1093,19 @@ switch(_operation) do {
             [_taskingState,"generateLocationListSelectedValue",DEFAULT_SELECTED_VALUE] call ALIVE_fnc_hashSet;
 
             // Build faction list — filtered to ALiVE mission factions when module param is set
+            _factionsDataSource = [] call ALiVE_fnc_getFactionsDataSource;
             if (missionNamespace getVariable ["ALIVE_c2istar_filterEnemyFactions", true]) then {
-                _factionsDataSource = [] call ALiVE_fnc_getAliveMissionFactionsDataSource;
-                // If OPCOM has not yet registered any factions (e.g. pre-init), fall back to full list
-                if ((_factionsDataSource select 0) isEqualTo []) then {
+                private _missionFactionsDataSource = [] call ALiVE_fnc_getAliveMissionFactionsDataSource;
+                // If OPCOM has not yet registered any factions, keep the full list fallback.
+                if (
+                    _missionFactionsDataSource isEqualType [] &&
+                    {count _missionFactionsDataSource >= 2} &&
+                    {!((_missionFactionsDataSource select 0) isEqualTo [])}
+                ) then {
+                    _factionsDataSource = _missionFactionsDataSource;
+                } else {
                     ["C2ISTAR - filterEnemyFactions: no OPCOM factions found yet, falling back to full faction list"] call ALiVE_fnc_dump;
-                    _factionsDataSource = [] call ALiVE_fnc_getFactionsDataSource;
                 };
-            } else {
-                _factionsDataSource = [] call ALiVE_fnc_getFactionsDataSource;
             };
             [_taskingState,"generateFactionOptions",_factionsDataSource select 0] call ALIVE_fnc_hashSet;
             [_taskingState,"generateFactionValues",_factionsDataSource select 1] call ALIVE_fnc_hashSet;

--- a/addons/mil_c2istar/stringtable.xml
+++ b/addons/mil_c2istar/stringtable.xml
@@ -152,6 +152,30 @@
 <Key ID="STR_ALIVE_C2ISTAR_DISPLAY_INTEL_COMMENT">
     <English>Displays current events on the battlefield on the map</English>
 </Key>
+<Key ID="STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY">
+    <English>Map Intel Visibility:</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY_COMMENT">
+    <English>Controls who receives C2ISTAR map intel from OPCOM events. Side limits reports to players on the commander side. Faction limits reports to players whose unit faction is commanded by that OPCOM.</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY_SIDE">
+    <English>Same Side</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY_FACTION">
+    <English>Same Faction</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY_FRIENDLY">
+    <English>Friendly Sides</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_MAP_INTEL_VISIBILITY_ALL">
+    <English>All Players</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_MAP_INTEL_REVEAL_INSTALLATIONS">
+    <English>Reveal Asymmetric Installations:</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_MAP_INTEL_REVEAL_INSTALLATIONS_COMMENT">
+    <English>When enabled, C2ISTAR map intel can show exact asymmetric OPCOM installation markers. Disabled by default to avoid revealing insurgency infrastructure.</English>
+</Key>
 <Key ID="STR_ALIVE_C2ISTAR_SPOTREP_DIARY_ENTRIES">
     <English>Spotrep Diary Entries:</English>
 </Key>


### PR DESCRIPTION
… markers only for allowed recipients.

Defaulting to same-side visibility. The module now has options for same side, same faction, friendly sides, or all players. Asymmetric installation markers are hidden by default and only shown when Reveal Asymmetric Installations is enabled. I also removed the profile debug-marker creation from those intel reports, so it no longer exposes exact commander assets.