### PR TITLE
[SYS_FACTIONCOMPILER] added a new addon

### DIFF
--- a/addons/mil_placement/CfgPatches.hpp
+++ b/addons/mil_placement/CfgPatches.hpp
@@ -4,7 +4,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ALIVE_fnc_strategic"};
+        requiredAddons[] = {"ALIVE_fnc_strategic","ALIVE_sys_factioncompiler"};
         versionDesc = "ALiVE";
         //versionAct = "['mil_placement',_this] execVM '\x\alive\addons\main\about.sqf';";
         VERSION_CONFIG;

--- a/addons/mil_placement/CfgVehicles.hpp
+++ b/addons/mil_placement/CfgVehicles.hpp
@@ -136,9 +136,10 @@ class CfgVehicles {
                 class ModuleDescription
                 {
                     description[] = {"$STR_ALIVE_MP_COMMENT","","$STR_ALIVE_MP_USAGE"};
-                    sync[] = {"ALiVE_mil_OPCOM","ALiVE_mil_CQB"};
+                    sync[] = {"ALiVE_mil_OPCOM","ALiVE_mil_CQB","ALiVE_sys_factioncompiler"};
                     class ALiVE_mil_OPCOM { description[] = {"$STR_ALIVE_OPCOM_COMMENT","","$STR_ALIVE_OPCOM_USAGE"}; position=0; direction=0; optional=1; duplicate=1; };
                     class ALiVE_mil_CQB { description[] = {"$STR_ALIVE_CQB_COMMENT","","$STR_ALIVE_CQB_USAGE"}; position=0; direction=0; optional=1; duplicate=1; };
+                    class ALiVE_sys_factioncompiler { description[] = {"Compiled custom faction override module."}; position=0; direction=0; optional=1; duplicate=1; };
                 };
         };
 };

--- a/addons/mil_placement/CfgVehicles.hpp
+++ b/addons/mil_placement/CfgVehicles.hpp
@@ -139,7 +139,7 @@ class CfgVehicles {
                     sync[] = {"ALiVE_mil_OPCOM","ALiVE_mil_CQB","ALiVE_sys_factioncompiler"};
                     class ALiVE_mil_OPCOM { description[] = {"$STR_ALIVE_OPCOM_COMMENT","","$STR_ALIVE_OPCOM_USAGE"}; position=0; direction=0; optional=1; duplicate=1; };
                     class ALiVE_mil_CQB { description[] = {"$STR_ALIVE_CQB_COMMENT","","$STR_ALIVE_CQB_USAGE"}; position=0; direction=0; optional=1; duplicate=1; };
-                    class ALiVE_sys_factioncompiler { description[] = {"Compiled custom faction override module."}; position=0; direction=0; optional=1; duplicate=1; };
+                    class ALiVE_sys_factioncompiler { description[] = {"Compiled custom faction override module."}; position=0; direction=0; optional=1; duplicate=0; };
                 };
         };
 };

--- a/addons/mil_placement/fnc_MP.sqf
+++ b/addons/mil_placement/fnc_MP.sqf
@@ -154,6 +154,13 @@ switch(_operation) do {
     // Determine force faction
     case "faction": {
         _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_configGetFactions] call ALIVE_fnc_OOsimpleOperation;
+
+        if !(_args isEqualType "") then {
+            private _compiledFaction = [_logic] call ALiVE_fnc_factionCompilerResolveForModule;
+            if !(_compiledFaction isEqualTo "") then {
+                _result = _compiledFaction;
+            };
+        };
     };
     // Return the Ambient Vehicle Amount
     case "ambientVehicleAmount": {
@@ -894,7 +901,8 @@ switch(_operation) do {
             if(_placeSupplies) then {
 
                 // attempt to get supplies by faction
-                _supplyClasses = [ALIVE_factionDefaultSupplies,_faction,[]] call ALIVE_fnc_hashGet;
+                private _staticFaction = [_faction] call ALiVE_fnc_factionCompilerGetConfigFaction;
+                _supplyClasses = [ALIVE_factionDefaultSupplies,_staticFaction,[]] call ALIVE_fnc_hashGet;
 
                 //["SUPPLY CLASSES: %1",_supplyClasses] call ALIVE_fnc_dump;
 
@@ -1161,7 +1169,8 @@ switch(_operation) do {
                 _landClasses = _carClasses + _armorClasses;
                 _landClasses = _landClasses - ALiVE_PLACEMENT_VEHICLEBLACKLIST;
 
-                _supportClasses = [ALIVE_factionDefaultSupports,_faction,[]] call ALIVE_fnc_hashGet;
+                private _staticFaction = [_faction] call ALiVE_fnc_factionCompilerGetConfigFaction;
+                _supportClasses = [ALIVE_factionDefaultSupports,_staticFaction,[]] call ALIVE_fnc_hashGet;
 
                 //["SUPPORT CLASSES: %1",_supportClasses] call ALIVE_fnc_dump;
 

--- a/addons/mil_placement_custom/CfgPatches.hpp
+++ b/addons/mil_placement_custom/CfgPatches.hpp
@@ -4,7 +4,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ALIVE_fnc_strategic"};
+        requiredAddons[] = {"ALIVE_fnc_strategic","ALIVE_sys_factioncompiler"};
         versionDesc = "ALiVE";
         //versionAct = "['mil_placement',_this] execVM '\x\alive\addons\main\about.sqf';";
         VERSION_CONFIG;

--- a/addons/mil_placement_custom/CfgVehicles.hpp
+++ b/addons/mil_placement_custom/CfgVehicles.hpp
@@ -101,7 +101,7 @@ class CfgVehicles {
                     sync[] = {"ALiVE_mil_OPCOM","ALiVE_mil_CQB","ALiVE_sys_factioncompiler"};
                     class ALiVE_mil_OPCOM { description[] = {"$STR_ALIVE_OPCOM_COMMENT","","$STR_ALIVE_OPCOM_USAGE"}; position=0; direction=0; optional=1; duplicate=1; };
                     class ALiVE_mil_CQB { description[] = {"$STR_ALIVE_CQB_COMMENT","","$STR_ALIVE_CQB_USAGE"}; position=0; direction=0; optional=1; duplicate=1; };
-                    class ALiVE_sys_factioncompiler { description[] = {"Compiled custom faction override module."}; position=0; direction=0; optional=1; duplicate=1; };
+                    class ALiVE_sys_factioncompiler { description[] = {"Compiled custom faction override module."}; position=0; direction=0; optional=1; duplicate=0; };
                 };
         };
 };

--- a/addons/mil_placement_custom/CfgVehicles.hpp
+++ b/addons/mil_placement_custom/CfgVehicles.hpp
@@ -98,9 +98,10 @@ class CfgVehicles {
                 class ModuleDescription
                 {
                     description[] = {"$STR_ALIVE_CMP_COMMENT","","$STR_ALIVE_CMP_USAGE"};
-                    sync[] = {"ALiVE_mil_OPCOM","ALiVE_mil_CQB"};
+                    sync[] = {"ALiVE_mil_OPCOM","ALiVE_mil_CQB","ALiVE_sys_factioncompiler"};
                     class ALiVE_mil_OPCOM { description[] = {"$STR_ALIVE_OPCOM_COMMENT","","$STR_ALIVE_OPCOM_USAGE"}; position=0; direction=0; optional=1; duplicate=1; };
                     class ALiVE_mil_CQB { description[] = {"$STR_ALIVE_CQB_COMMENT","","$STR_ALIVE_CQB_USAGE"}; position=0; direction=0; optional=1; duplicate=1; };
+                    class ALiVE_sys_factioncompiler { description[] = {"Compiled custom faction override module."}; position=0; direction=0; optional=1; duplicate=1; };
                 };
         };
 };

--- a/addons/mil_placement_custom/fnc_CMP.sqf
+++ b/addons/mil_placement_custom/fnc_CMP.sqf
@@ -150,6 +150,13 @@ switch(_operation) do {
 
     case "faction": {
         _result = [_logic,_operation,_args,DEFAULT_FACTION,[] call ALiVE_fnc_configGetFactions] call ALIVE_fnc_OOsimpleOperation;
+
+        if !(_args isEqualType "") then {
+            private _compiledFaction = [_logic] call ALiVE_fnc_factionCompilerResolveForModule;
+            if !(_compiledFaction isEqualTo "") then {
+                _result = _compiledFaction;
+            };
+        };
     };
     
     case "guardProbability": {
@@ -727,7 +734,8 @@ switch(_operation) do {
             if(_placeSupplies) then {
 
                 // attempt to get supplies by faction
-                private _supplyClasses = [ALIVE_factionDefaultSupplies,_faction,[]] call ALIVE_fnc_hashGet;
+                private _staticFaction = [_faction] call ALiVE_fnc_factionCompilerGetConfigFaction;
+                private _supplyClasses = [ALIVE_factionDefaultSupplies,_staticFaction,[]] call ALIVE_fnc_hashGet;
 
                 //["SUPPLY CLASSES: %1",_supplyClasses] call ALIVE_fnc_dump;
 
@@ -823,7 +831,8 @@ switch(_operation) do {
                 private _landClasses = _carClasses + _armorClasses;
                 _landClasses = _landClasses - ALiVE_PLACEMENT_VEHICLEBLACKLIST;
 
-                private _supportClasses = [ALIVE_factionDefaultSupports,_faction,[]] call ALIVE_fnc_hashGet;
+                private _staticFaction = [_faction] call ALiVE_fnc_factionCompilerGetConfigFaction;
+                private _supportClasses = [ALIVE_factionDefaultSupports,_staticFaction,[]] call ALIVE_fnc_hashGet;
 
                 //["SUPPORT CLASSES: %1",_supportClasses] call ALIVE_fnc_dump;
 

--- a/addons/sys_factioncompiler/CfgFunctions.hpp
+++ b/addons/sys_factioncompiler/CfgFunctions.hpp
@@ -1,0 +1,54 @@
+class CfgFunctions {
+    class PREFIX {
+        class COMPONENT {
+            class factionCompilerInit {
+                description = "Compile mission-local faction templates from Eden groups";
+                file = "\x\alive\addons\sys_factioncompiler\fnc_factionCompilerInit.sqf";
+                RECOMPILE;
+            };
+
+            class factionCompilerResolveForModule {
+                description = "Resolve a compiled faction synced to a placement module";
+                file = "\x\alive\addons\sys_factioncompiler\fnc_factionCompilerResolveForModule.sqf";
+                RECOMPILE;
+            };
+
+            class factionCompilerGetFactionData {
+                description = "Get compiled faction registry data";
+                file = "\x\alive\addons\sys_factioncompiler\fnc_factionCompilerGetFactionData.sqf";
+                RECOMPILE;
+            };
+
+            class factionCompilerGetConfigFaction {
+                description = "Resolve the config-backed proxy faction for a compiled faction";
+                file = "\x\alive\addons\sys_factioncompiler\fnc_factionCompilerGetConfigFaction.sqf";
+                RECOMPILE;
+            };
+
+            class factionCompilerIsCompiledFaction {
+                description = "Check whether a faction id belongs to the compiler registry";
+                file = "\x\alive\addons\sys_factioncompiler\fnc_factionCompilerIsCompiledFaction.sqf";
+                RECOMPILE;
+            };
+
+            class factionCompilerFindVehicleType {
+                description = "Return vehicles or units from compiled factions matching a findVehicleType query";
+                file = "\x\alive\addons\sys_factioncompiler\fnc_factionCompilerFindVehicleType.sqf";
+                RECOMPILE;
+            };
+
+            class factionCompilerApplyLoadout {
+                description = "Apply a compiled loadout to a spawned profiled unit";
+                file = "\x\alive\addons\sys_factioncompiler\fnc_factionCompilerApplyLoadout.sqf";
+                RECOMPILE;
+            };
+
+            class factionCompilerCreateProfilesFromGroup {
+                description = "Create profiles from a compiler-managed group definition";
+                file = "\x\alive\addons\sys_factioncompiler\fnc_factionCompilerCreateProfilesFromGroup.sqf";
+                RECOMPILE;
+            };
+        };
+    };
+};
+

--- a/addons/sys_factioncompiler/CfgPatches.hpp
+++ b/addons/sys_factioncompiler/CfgPatches.hpp
@@ -1,0 +1,20 @@
+class CfgPatches {
+    class ADDON {
+        units[] = {
+            "ALiVE_sys_factioncompiler",
+            "ALiVE_sys_factioncompiler_category"
+        };
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "ALIVE_main",
+            "ALIVE_x_lib"
+        };
+        versionDesc = "ALiVE";
+        VERSION_CONFIG;
+        author = MODULE_AUTHOR;
+        authors[] = {"Codex"};
+        authorUrl = "http://alivemod.com/";
+    };
+};
+

--- a/addons/sys_factioncompiler/CfgVehicles.hpp
+++ b/addons/sys_factioncompiler/CfgVehicles.hpp
@@ -1,0 +1,148 @@
+class CfgVehicles {
+    class Logic;
+    class Module_F : Logic {
+        class AttributesBase {
+            class Edit;
+            class Combo;
+            class ModuleDescription;
+        };
+    };
+    class ModuleAliveBase : Module_F {
+        class AttributesBase : AttributesBase {
+            class ALiVE_ModuleSubTitle;
+        };
+        class ModuleDescription;
+    };
+
+    class ALiVE_sys_factioncompiler : ModuleAliveBase {
+        scope = 2;
+        displayName = "ALiVE Custom Faction Compiler";
+        function = "ALiVE_fnc_factionCompilerInit";
+        author = MODULE_AUTHOR;
+        functionPriority = 1;
+        isGlobal = 1;
+        class Attributes : AttributesBase {
+            class debug : Combo {
+                property = "ALiVE_sys_factioncompiler_debug";
+                displayName = "Debug";
+                tooltip = "Enable debug output for compiler processing.";
+                defaultValue = """false""";
+                class Values {
+                    class Yes {name = "Yes"; value = true;};
+                    class No {name = "No"; value = false; default = 1;};
+                };
+            };
+            class factionId : Edit {
+                property = "ALiVE_sys_factioncompiler_factionId";
+                displayName = "Faction ID";
+                tooltip = "Internal faction id used by synced placement modules.";
+                defaultValue = """ALIVE_CUSTOM_FACTION""";
+            };
+            class displayName : Edit {
+                property = "ALiVE_sys_factioncompiler_displayName";
+                displayName = "Display Name";
+                tooltip = "Human-readable name stored with the compiled faction.";
+                defaultValue = """Custom Faction""";
+            };
+            class proxyFaction {
+                property = "ALiVE_sys_factioncompiler_proxyFaction";
+                displayName = "Proxy Faction";
+                tooltip = "Config-backed faction used for side, compositions, and static fallback data.";
+                control = "ALiVE_FactionChoice_Military";
+                typeName = "STRING";
+                expression = "_this setVariable ['proxyFaction', _value];";
+                defaultValue = """OPF_F""";
+            };
+            class deleteTemplates : Combo {
+                property = "ALiVE_sys_factioncompiler_deleteTemplates";
+                displayName = "Delete Templates";
+                tooltip = "Delete synced template groups after they are compiled.";
+                defaultValue = """true""";
+                class Values {
+                    class Yes {name = "Yes"; value = true; default = 1;};
+                    class No {name = "No"; value = false;};
+                };
+            };
+            class ModuleDescription : ModuleDescription {};
+        };
+        class ModuleDescription : ModuleDescription {
+            description[] = {
+                "Compile synced Eden template groups into a mission-local ALiVE faction.",
+                "",
+                "Sync one or more category helper modules to this compiler, then sync one unit from each template group to a category helper. Sync placement modules to this compiler to use the compiled faction at runtime."
+            };
+            sync[] = {
+                "ALiVE_sys_factioncompiler_category",
+                "ALiVE_mil_placement",
+                "ALiVE_mil_placement_custom"
+            };
+            class ALiVE_sys_factioncompiler_category {
+                description[] = {"Group category helper module."};
+                position = 0;
+                direction = 0;
+                optional = 1;
+                duplicate = 1;
+            };
+            class ALiVE_mil_placement {
+                description[] = {"Military Placement module."};
+                position = 0;
+                direction = 0;
+                optional = 1;
+                duplicate = 1;
+            };
+            class ALiVE_mil_placement_custom {
+                description[] = {"Custom Military Placement module."};
+                position = 0;
+                direction = 0;
+                optional = 1;
+                duplicate = 1;
+            };
+        };
+    };
+
+    class ALiVE_sys_factioncompiler_category : ModuleAliveBase {
+        scope = 2;
+        displayName = "ALiVE Custom Faction Group Category";
+        author = MODULE_AUTHOR;
+        functionPriority = 2;
+        isGlobal = 0;
+        class Attributes : AttributesBase {
+            class category : Combo {
+                property = "ALiVE_sys_factioncompiler_category_category";
+                displayName = "Category";
+                tooltip = "ALiVE group category assigned to all template groups synced here.";
+                defaultValue = """Infantry""";
+                class Values {
+                    class Infantry {name = "Infantry"; value = "Infantry"; default = 1;};
+                    class SpecOps {name = "Spec Ops"; value = "SpecOps";};
+                    class Motorized {name = "Motorized"; value = "Motorized";};
+                    class MotorizedMTP {name = "Motorized MTP"; value = "Motorized_MTP";};
+                    class Mechanized {name = "Mechanized"; value = "Mechanized";};
+                    class MechanizedMTP {name = "Mechanized MTP"; value = "Mechanized_MTP";};
+                    class Armored {name = "Armored"; value = "Armored";};
+                    class Air {name = "Air"; value = "Air";};
+                    class Naval {name = "Naval"; value = "Naval";};
+                    class Support {name = "Support"; value = "Support";};
+                    class Artillery {name = "Artillery"; value = "Artillery";};
+                };
+            };
+            class ModuleDescription : ModuleDescription {};
+        };
+        class ModuleDescription : ModuleDescription {
+            description[] = {
+                "Assign synced template groups to an ALiVE force category.",
+                "",
+                "Sync this module to a compiler module, then sync one unit from each template group to this helper."
+            };
+            sync[] = {"ALiVE_sys_factioncompiler"};
+            class ALiVE_sys_factioncompiler {
+                description[] = {"Compiler module."};
+                position = 0;
+                direction = 0;
+                optional = 0;
+                duplicate = 0;
+            };
+        };
+    };
+};
+

--- a/addons/sys_factioncompiler/PboPrefix.txt
+++ b/addons/sys_factioncompiler/PboPrefix.txt
@@ -1,0 +1,8 @@
+x\alive\addons\sys_factioncompiler
+=======HEADER=======
+prefix=x\alive\addons\sys_factioncompiler
+Mikero=DePbo.dll
+product=Arma 3
+version=1
+Pbo Type is: Arma Addon
+==================

--- a/addons/sys_factioncompiler/config.cpp
+++ b/addons/sys_factioncompiler/config.cpp
@@ -1,0 +1,6 @@
+#include "script_component.hpp"
+
+#include "CfgPatches.hpp"
+#include "CfgVehicles.hpp"
+#include "CfgFunctions.hpp"
+

--- a/addons/sys_factioncompiler/fnc_factionCompilerApplyLoadout.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerApplyLoadout.sqf
@@ -1,0 +1,29 @@
+#include "\x\alive\addons\sys_factioncompiler\script_component.hpp"
+SCRIPT(factionCompilerApplyLoadout);
+
+params [
+    ["_unit", objNull, [objNull]],
+    ["_factionId", "", [""]],
+    ["_groupId", "", [""]]
+];
+
+if (isNull _unit || {_factionId isEqualTo ""} || {_groupId isEqualTo ""}) exitWith {false};
+
+private _factionData = [_factionId] call ALIVE_fnc_factionCompilerGetFactionData;
+if (isNil "_factionData") exitWith {false};
+
+private _compiledGroups = [_factionData, "compiledGroups"] call ALIVE_fnc_hashGet;
+private _groupData = [_compiledGroups, _groupId] call ALIVE_fnc_hashGet;
+if (isNil "_groupData") exitWith {false};
+
+private _units = [_groupData, "units", []] call ALIVE_fnc_hashGet;
+private _unitIndex = _unit getVariable ["profileIndex", -1];
+if (_unitIndex < 0 || {_unitIndex >= count _units}) exitWith {false};
+
+private _unitData = _units select _unitIndex;
+private _loadout = [_unitData, "loadout", []] call ALIVE_fnc_hashGet;
+if (_loadout isEqualTo []) exitWith {false};
+
+_unit setUnitLoadout _loadout;
+true
+

--- a/addons/sys_factioncompiler/fnc_factionCompilerCreateProfilesFromGroup.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerCreateProfilesFromGroup.sqf
@@ -44,7 +44,7 @@ private _entityProfileID = format ["%1-%2", _factionId, _entityID];
 [_profileEntity, "isSPE", _isSPE] call ALIVE_fnc_profileEntity;
 [_profileEntity, "aiBehaviour", _aiBehaviour] call ALIVE_fnc_profileEntity;
 
-private _spawnHook = format ["[_this select 0, '%1', '%2'] call ALiVE_fnc_factionCompilerApplyLoadout;", _factionId, _groupClass];
+private _spawnHook = format ["[_this select 0, %1, %2] call ALiVE_fnc_factionCompilerApplyLoadout;", str _factionId, str _groupClass];
 if !(_onEachSpawn isEqualTo "") then {
     _spawnHook = format ["%1 %2", _spawnHook, _onEachSpawn];
 };

--- a/addons/sys_factioncompiler/fnc_factionCompilerCreateProfilesFromGroup.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerCreateProfilesFromGroup.sqf
@@ -1,0 +1,139 @@
+#include "\x\alive\addons\sys_factioncompiler\script_component.hpp"
+SCRIPT(factionCompilerCreateProfilesFromGroup);
+
+params [
+    "_groupClass",
+    "_position",
+    ["_direction", 0],
+    ["_spawnGoodPosition", true],
+    ["_factionId", ""],
+    ["_busy", false],
+    ["_isSPE", false],
+    ["_aiBehaviour", "STEALTH"],
+    ["_onEachSpawn", ""],
+    ["_onEachSpawnOnce", true]
+];
+
+private _groupProfiles = [];
+if (_factionId isEqualTo "") exitWith {_groupProfiles};
+if (count _position == 2) then {
+    _position pushBack 0;
+};
+
+private _factionData = [_factionId] call ALIVE_fnc_factionCompilerGetFactionData;
+if (isNil "_factionData") exitWith {_groupProfiles};
+
+private _compiledGroups = [_factionData, "compiledGroups"] call ALIVE_fnc_hashGet;
+private _groupData = [_compiledGroups, _groupClass] call ALIVE_fnc_hashGet;
+if (isNil "_groupData") exitWith {_groupProfiles};
+
+private _side = [_groupData, "side", [_factionData, "side", "EAST"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashGet;
+private _unitEntries = [_groupData, "units", []] call ALIVE_fnc_hashGet;
+private _vehicleEntries = [_groupData, "vehicles", []] call ALIVE_fnc_hashGet;
+
+private _entityID = [ALIVE_profileHandler, "getNextInsertEntityID"] call ALIVE_fnc_profileHandler;
+private _profileEntity = [nil, "create"] call ALIVE_fnc_profileEntity;
+[_profileEntity, "init"] call ALIVE_fnc_profileEntity;
+private _entityProfileID = format ["%1-%2", _factionId, _entityID];
+[_profileEntity, "profileID", _entityProfileID] call ALIVE_fnc_profileEntity;
+[_profileEntity, "position", _position] call ALIVE_fnc_profileEntity;
+[_profileEntity, "side", _side] call ALIVE_fnc_profileEntity;
+[_profileEntity, "faction", _factionId] call ALIVE_fnc_profileEntity;
+[_profileEntity, "objectType", _groupClass] call ALIVE_fnc_profileEntity;
+[_profileEntity, "busy", _busy] call ALIVE_fnc_profileEntity;
+[_profileEntity, "isSPE", _isSPE] call ALIVE_fnc_profileEntity;
+[_profileEntity, "aiBehaviour", _aiBehaviour] call ALIVE_fnc_profileEntity;
+
+private _spawnHook = format ["[_this select 0, '%1', '%2'] call ALiVE_fnc_factionCompilerApplyLoadout;", _factionId, _groupClass];
+if !(_onEachSpawn isEqualTo "") then {
+    _spawnHook = format ["%1 %2", _spawnHook, _onEachSpawn];
+};
+[_profileEntity, "onEachSpawn", _spawnHook] call ALIVE_fnc_profileEntity;
+[_profileEntity, "onEachSpawnOnce", _onEachSpawnOnce] call ALIVE_fnc_profileEntity;
+
+if !_spawnGoodPosition then {
+    [_profileEntity, "despawnPosition", _position] call ALIVE_fnc_profileEntity;
+};
+
+_groupProfiles pushBack _profileEntity;
+[ALIVE_profileHandler, "registerProfile", _profileEntity] call ALIVE_fnc_profileHandler;
+
+{
+    private _unitData = _x;
+    private _unitDistance = [_unitData, "offsetDistance", 0] call ALIVE_fnc_hashGet;
+    private _unitBearing = [_unitData, "offsetBearing", 0] call ALIVE_fnc_hashGet;
+    private _unitHeight = [_unitData, "offsetHeight", 0] call ALIVE_fnc_hashGet;
+    private _unitPosition = +_position;
+
+    if (_unitDistance > 0) then {
+        _unitPosition = _position getPos [_unitDistance, _direction + _unitBearing];
+    };
+    _unitPosition set [2, (_position select 2) + _unitHeight];
+
+    [_profileEntity, "addUnit", [
+        [_unitData, "class", ""] call ALIVE_fnc_hashGet,
+        _unitPosition,
+        [_unitData, "damage", 0] call ALIVE_fnc_hashGet,
+        [_unitData, "rank", "PRIVATE"] call ALIVE_fnc_hashGet
+    ]] call ALIVE_fnc_profileEntity;
+} forEach _unitEntries;
+
+{
+    private _vehicleData = _x;
+    private _vehicleDistance = [_vehicleData, "offsetDistance", 0] call ALIVE_fnc_hashGet;
+    private _vehicleBearing = [_vehicleData, "offsetBearing", 0] call ALIVE_fnc_hashGet;
+    private _vehicleHeight = [_vehicleData, "offsetHeight", 0] call ALIVE_fnc_hashGet;
+    private _vehicleDirectionOffset = [_vehicleData, "directionOffset", 0] call ALIVE_fnc_hashGet;
+    private _vehiclePosition = +_position;
+
+    if (_vehicleDistance > 0) then {
+        _vehiclePosition = _position getPos [_vehicleDistance, _direction + _vehicleBearing];
+    };
+    _vehiclePosition set [2, (_position select 2) + _vehicleHeight];
+
+    private _vehicleID = [ALIVE_profileHandler, "getNextInsertVehicleID"] call ALIVE_fnc_profileHandler;
+    private _profileVehicle = [nil, "create"] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "init"] call ALIVE_fnc_profileVehicle;
+    private _vehicleProfileID = format ["%1-%2", _factionId, _vehicleID];
+    [_profileVehicle, "profileID", _vehicleProfileID] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "vehicleClass", [_vehicleData, "class", ""] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "position", _vehiclePosition] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "direction", _direction + _vehicleDirectionOffset] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "side", _side] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "faction", _factionId] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "damage", [_vehicleData, "damage", []] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "fuel", [_vehicleData, "fuel", 1] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "ammo", [_vehicleData, "ammo", []] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "busy", _busy] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "canFire", [_vehicleData, "canFire", true] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "canMove", [_vehicleData, "canMove", true] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+    [_profileVehicle, "needReload", [_vehicleData, "needReload", 0] call ALIVE_fnc_hashGet] call ALIVE_fnc_profileVehicle;
+
+    if ([_vehicleData, "engineOn", false] call ALIVE_fnc_hashGet) then {
+        [_profileVehicle, "engineOn", true] call ALIVE_fnc_profileVehicle;
+    };
+
+    if !_spawnGoodPosition then {
+        [_profileVehicle, "despawnPosition", _vehiclePosition] call ALIVE_fnc_profileVehicle;
+    };
+
+    _groupProfiles pushBack _profileVehicle;
+    [ALIVE_profileHandler, "registerProfile", _profileVehicle] call ALIVE_fnc_profileHandler;
+
+    private _assignment = [_vehicleData, "assignment", []] call ALIVE_fnc_hashGet;
+    private _hasAssignment = false;
+    {
+        if (count _x > 0) exitWith {
+            _hasAssignment = true;
+        };
+    } forEach _assignment;
+
+    if (_hasAssignment) then {
+        private _vehicleAssignment = [_vehicleProfileID, _entityProfileID, _assignment];
+        [_profileEntity, "addVehicleAssignment", _vehicleAssignment] call ALIVE_fnc_profileEntity;
+        [_profileVehicle, "addVehicleAssignment", _vehicleAssignment] call ALIVE_fnc_profileVehicle;
+    };
+} forEach _vehicleEntries;
+
+_groupProfiles
+

--- a/addons/sys_factioncompiler/fnc_factionCompilerFindVehicleType.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerFindVehicleType.sqf
@@ -1,0 +1,50 @@
+#include "\x\alive\addons\sys_factioncompiler\script_component.hpp"
+SCRIPT(factionCompilerFindVehicleType);
+
+params [
+    ["_cargoslots", 0, [0]],
+    ["_fac", nil],
+    ["_type", nil],
+    ["_noWeapons", false, [true]],
+    ["_minScope", 1, [0]]
+];
+
+private _factions = if (_fac isEqualType []) then {_fac} else {[_fac]};
+private _result = [];
+private _typeDefined = !(isNil "_type") && {!(_type isEqualTo "")};
+
+{
+    if (_x isEqualType "" && {[_x] call ALIVE_fnc_factionCompilerIsCompiledFaction}) then {
+        private _factionData = [_x] call ALIVE_fnc_factionCompilerGetFactionData;
+        if !(isNil "_factionData") then {
+            {
+                private _class = _x;
+                private _cfg = configFile >> "CfgVehicles" >> _class;
+
+                if (isClass _cfg) then {
+                    if (getNumber (_cfg >> "scope") >= _minScope) then {
+                        if (getNumber (_cfg >> "TransportSoldier") >= _cargoslots) then {
+                            private _matchesType = true;
+                            if (_typeDefined) then {
+                                _matchesType = _class isKindOf _type;
+                            };
+
+                            if (_matchesType) then {
+                                if (_noWeapons) then {
+                                    if ([_class] call ALIVE_fnc_isArmed) then {
+                                        _result pushBackUnique _class;
+                                    };
+                                } else {
+                                    _result pushBackUnique _class;
+                                };
+                            };
+                        };
+                    };
+                };
+            } forEach (([_factionData, "unitClasses", []] call ALIVE_fnc_hashGet) + ([_factionData, "vehicleClasses", []] call ALIVE_fnc_hashGet));
+        };
+    };
+} forEach _factions;
+
+_result
+

--- a/addons/sys_factioncompiler/fnc_factionCompilerGetConfigFaction.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerGetConfigFaction.sqf
@@ -1,0 +1,21 @@
+#include "\x\alive\addons\sys_factioncompiler\script_component.hpp"
+SCRIPT(factionCompilerGetConfigFaction);
+
+params [
+    ["_factionId", ""]
+];
+
+if !(_factionId isEqualType "") exitWith {_factionId};
+if (_factionId isEqualTo "") exitWith {""};
+if (isNil "ALIVE_factionCustomMappings") exitWith {_factionId};
+if !(_factionId in (ALIVE_factionCustomMappings select 1)) exitWith {_factionId};
+
+private _mapping = [ALIVE_factionCustomMappings, _factionId] call ALIVE_fnc_hashGet;
+private _configFaction = [_mapping, "ConfigFactionName", _factionId] call ALIVE_fnc_hashGet;
+
+if (_configFaction isEqualTo "") then {
+    _configFaction = [_mapping, "GroupFactionName", _factionId] call ALIVE_fnc_hashGet;
+};
+
+_configFaction
+

--- a/addons/sys_factioncompiler/fnc_factionCompilerGetFactionData.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerGetFactionData.sqf
@@ -1,0 +1,13 @@
+#include "\x\alive\addons\sys_factioncompiler\script_component.hpp"
+SCRIPT(factionCompilerGetFactionData);
+
+params [
+    ["_factionId", ""]
+];
+
+if !(_factionId isEqualType "") exitWith {nil};
+if (_factionId isEqualTo "") exitWith {nil};
+if (isNil "ALIVE_compiledFactions") exitWith {nil};
+
+[ALIVE_compiledFactions, _factionId] call ALIVE_fnc_hashGet
+

--- a/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
@@ -6,6 +6,10 @@ params [
     ["_syncedObjects", [], [[]]]
 ];
 
+// Module callbacks do not consistently provide non-unit sync peers in the second
+// argument, so resolve the live sync graph from the module itself.
+_syncedObjects = synchronizedObjects _logic;
+
 if (!isServer) exitWith {true};
 if (isNull _logic) exitWith {false};
 

--- a/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
@@ -83,6 +83,9 @@ private _templateVehicles = [];
 private _sideText = "";
 private _groupIndex = 0;
 private _standardCategories = ["Infantry", "SpecOps", "Motorized", "Motorized_MTP", "Mechanized", "Mechanized_MTP", "Armored", "Air", "Naval", "Support", "Artillery"];
+{
+    [_groupsByCategory, _x, []] call ALIVE_fnc_hashSet;
+} forEach _standardCategories;
 
 {
     if ((typeOf _x) isEqualTo "ALiVE_sys_factioncompiler_category") then {

--- a/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
@@ -1,0 +1,254 @@
+#include "\x\alive\addons\sys_factioncompiler\script_component.hpp"
+SCRIPT(factionCompilerInit);
+
+params [
+    ["_logic", objNull, [objNull]],
+    ["_syncedObjects", [], [[]]]
+];
+
+if (!isServer) exitWith {true};
+if (isNull _logic) exitWith {false};
+
+private _moduleID = [_logic, true] call ALIVE_fnc_dumpModuleInit;
+
+private _parseBool = {
+    params [["_value", false]];
+
+    if (_value isEqualType true) exitWith {_value};
+    if (_value isEqualType "") exitWith {(toLower _value) isEqualTo "true"};
+
+    false
+};
+
+call ALiVE_fnc_staticDataHandler;
+
+if (isNil "ALIVE_compiledFactions") then {
+    ALIVE_compiledFactions = [] call ALIVE_fnc_hashCreate;
+};
+
+private _debug = [(_logic getVariable ["debug", false])] call _parseBool;
+private _deleteTemplates = [(_logic getVariable ["deleteTemplates", true])] call _parseBool;
+private _factionId = _logic getVariable ["factionId", "ALIVE_CUSTOM_FACTION"];
+if !(_factionId isEqualType "") then {
+    _factionId = str _factionId;
+};
+_factionId = [_factionId, " ", "_"] call CBA_fnc_replace;
+_factionId = [_factionId, "-", "_"] call CBA_fnc_replace;
+if (_factionId isEqualTo "") then {
+    _factionId = "ALIVE_CUSTOM_FACTION";
+};
+
+private _displayName = _logic getVariable ["displayName", _factionId];
+if !(_displayName isEqualType "") then {
+    _displayName = str _displayName;
+};
+if (_displayName isEqualTo "") then {
+    _displayName = _factionId;
+};
+
+private _proxyFaction = _logic getVariable ["proxyFaction", "OPF_F"];
+if !(_proxyFaction isEqualType "") then {
+    _proxyFaction = str _proxyFaction;
+};
+if (_proxyFaction isEqualTo "") then {
+    _proxyFaction = "OPF_F";
+};
+
+private _groupsByCategory = [] call ALIVE_fnc_hashCreate;
+private _compiledGroups = [] call ALIVE_fnc_hashCreate;
+private _unitClasses = [];
+private _vehicleClasses = [];
+private _templateGroups = [];
+private _templateVehicles = [];
+private _sideText = "";
+private _groupIndex = 0;
+private _standardCategories = ["Infantry", "SpecOps", "Motorized", "Motorized_MTP", "Mechanized", "Mechanized_MTP", "Armored", "Air", "Naval", "Support", "Artillery"];
+
+{
+    if ((typeOf _x) isEqualTo "ALiVE_sys_factioncompiler_category") then {
+        private _categoryModule = _x;
+        private _category = _categoryModule getVariable ["category", "Infantry"];
+        if (_category isEqualTo "") then {
+            _category = "Infantry";
+        };
+
+        private _categoryGroups = [_groupsByCategory, _category, []] call ALIVE_fnc_hashGet;
+
+        {
+            private _unit = _x;
+            if (_unit isKindOf "CAManBase" && {side _unit != sideLogic}) then {
+                private _group = group _unit;
+                if !(isNull _group) then {
+                    if !(_group in _templateGroups) then {
+                        private _leader = leader _group;
+                        if !(isNull _leader) then {
+                            private _groupSideNumber = [side _group] call ALIVE_fnc_sideObjectToNumber;
+                            private _groupSideText = [_groupSideNumber] call ALIVE_fnc_sideNumberToText;
+
+                            if (_sideText isEqualTo "") then {
+                                _sideText = _groupSideText;
+                            };
+
+                            if (_sideText isEqualTo _groupSideText) then {
+                                private _leaderPos = getPosATL _leader;
+                                private _leaderDir = getDir _leader;
+                                private _unitEntries = [];
+                                private _groupVehicles = [];
+                                private _vehicleEntries = [];
+
+                                {
+                                    private _member = _x;
+                                    private _memberPos = getPosATL _member;
+                                    private _unitData = [] call ALIVE_fnc_hashCreate;
+                                    private _memberClass = typeOf _member;
+
+                                    [_unitData, "class", _memberClass] call ALIVE_fnc_hashSet;
+                                    [_unitData, "rank", rank _member] call ALIVE_fnc_hashSet;
+                                    [_unitData, "damage", damage _member] call ALIVE_fnc_hashSet;
+                                    [_unitData, "loadout", getUnitLoadout _member] call ALIVE_fnc_hashSet;
+                                    [_unitData, "offsetDistance", _leader distance2D _member] call ALIVE_fnc_hashSet;
+                                    [_unitData, "offsetBearing", (_leader getDir _member) - _leaderDir] call ALIVE_fnc_hashSet;
+                                    [_unitData, "offsetHeight", (_memberPos select 2) - (_leaderPos select 2)] call ALIVE_fnc_hashSet;
+
+                                    _unitEntries pushBack _unitData;
+                                    _unitClasses pushBackUnique _memberClass;
+
+                                    private _vehicle = vehicle _member;
+                                    if !(_vehicle isEqualTo _member) then {
+                                        _groupVehicles pushBackUnique _vehicle;
+                                        _templateVehicles pushBackUnique _vehicle;
+                                    };
+                                } forEach (units _group);
+
+                                {
+                                    private _vehicle = _x;
+                                    private _vehiclePos = getPosATL _vehicle;
+                                    private _vehicleClass = typeOf _vehicle;
+                                    private _vehicleData = [] call ALIVE_fnc_hashCreate;
+
+                                    [_vehicleData, "class", _vehicleClass] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "directionOffset", (getDir _vehicle) - _leaderDir] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "damage", _vehicle call ALIVE_fnc_vehicleGetDamage] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "fuel", fuel _vehicle] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "ammo", _vehicle call ALIVE_fnc_vehicleGetAmmo] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "engineOn", isEngineOn _vehicle] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "canFire", canFire _vehicle] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "canMove", canMove _vehicle] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "needReload", needReload _vehicle] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "offsetDistance", _leader distance2D _vehicle] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "offsetBearing", (_leader getDir _vehicle) - _leaderDir] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "offsetHeight", (_vehiclePos select 2) - (_leaderPos select 2)] call ALIVE_fnc_hashSet;
+                                    [_vehicleData, "assignment", [_vehicle, _group] call ALIVE_fnc_vehicleAssignmentToProfileVehicleAssignment] call ALIVE_fnc_hashSet;
+
+                                    _vehicleEntries pushBack _vehicleData;
+                                    _vehicleClasses pushBackUnique _vehicleClass;
+                                } forEach _groupVehicles;
+
+                                _groupIndex = _groupIndex + 1;
+                                private _groupId = format ["%1_GROUP_%2", _factionId, _groupIndex];
+                                private _groupName = groupId _group;
+                                if (_groupName isEqualTo "") then {
+                                    _groupName = format ["%1 %2", _category, _groupIndex];
+                                };
+
+                                private _groupData = [] call ALIVE_fnc_hashCreate;
+                                [_groupData, "groupId", _groupId] call ALIVE_fnc_hashSet;
+                                [_groupData, "name", _groupName] call ALIVE_fnc_hashSet;
+                                [_groupData, "category", _category] call ALIVE_fnc_hashSet;
+                                [_groupData, "side", _groupSideText] call ALIVE_fnc_hashSet;
+                                [_groupData, "units", _unitEntries] call ALIVE_fnc_hashSet;
+                                [_groupData, "vehicles", _vehicleEntries] call ALIVE_fnc_hashSet;
+
+                                [ _compiledGroups, _groupId, _groupData ] call ALIVE_fnc_hashSet;
+                                _categoryGroups pushBack _groupId;
+                                _templateGroups pushBack _group;
+
+                                if (_debug) then {
+                                    ["Faction compiler [%1] captured group %2 in %3", _factionId, _groupId, _category] call ALIVE_fnc_dump;
+                                };
+                            } else {
+                                if (_debug) then {
+                                    ["Faction compiler [%1] skipped group with mismatched side %2", _factionId, _groupSideText] call ALIVE_fnc_dump;
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        } forEach (synchronizedObjects _categoryModule);
+
+        [ _groupsByCategory, _category, _categoryGroups ] call ALIVE_fnc_hashSet;
+    };
+} forEach _syncedObjects;
+
+if (_groupIndex == 0) exitWith {
+    _logic setVariable ["compiledFactionId", "", true];
+    if (_debug) then {
+        ["Faction compiler [%1] found no template groups", _factionId] call ALIVE_fnc_dump;
+    };
+    [_logic, false, _moduleID] call ALIVE_fnc_dumpModuleInit;
+    false
+};
+
+private _typeMappings = [] call ALIVE_fnc_hashCreate;
+{
+    [_typeMappings, _x, _x] call ALIVE_fnc_hashSet;
+} forEach _standardCategories;
+
+private _mapping = [] call ALIVE_fnc_hashCreate;
+[_mapping, "Side", _sideText] call ALIVE_fnc_hashSet;
+[_mapping, "GroupSideName", _sideText] call ALIVE_fnc_hashSet;
+[_mapping, "FactionName", _factionId] call ALIVE_fnc_hashSet;
+[_mapping, "ConfigFactionName", _proxyFaction] call ALIVE_fnc_hashSet;
+[_mapping, "GroupFactionName", _proxyFaction] call ALIVE_fnc_hashSet;
+[_mapping, "GroupFactionTypes", _typeMappings] call ALIVE_fnc_hashSet;
+[_mapping, "Groups", _groupsByCategory] call ALIVE_fnc_hashSet;
+[_mapping, "CompiledFaction", true] call ALIVE_fnc_hashSet;
+[_mapping, "DisplayName", _displayName] call ALIVE_fnc_hashSet;
+
+private _factionData = [] call ALIVE_fnc_hashCreate;
+[_factionData, "factionId", _factionId] call ALIVE_fnc_hashSet;
+[_factionData, "displayName", _displayName] call ALIVE_fnc_hashSet;
+[_factionData, "proxyFaction", _proxyFaction] call ALIVE_fnc_hashSet;
+[_factionData, "side", _sideText] call ALIVE_fnc_hashSet;
+[_factionData, "groupsByCategory", _groupsByCategory] call ALIVE_fnc_hashSet;
+[_factionData, "compiledGroups", _compiledGroups] call ALIVE_fnc_hashSet;
+[_factionData, "unitClasses", _unitClasses] call ALIVE_fnc_hashSet;
+[_factionData, "vehicleClasses", _vehicleClasses] call ALIVE_fnc_hashSet;
+
+[ALIVE_compiledFactions, _factionId, _factionData] call ALIVE_fnc_hashSet;
+[ALIVE_factionCustomMappings, _factionId, _mapping] call ALIVE_fnc_hashSet;
+
+_logic setVariable ["compiledFactionId", _factionId, true];
+_logic setVariable ["compiledProxyFaction", _proxyFaction, true];
+_logic setVariable ["compiledFactionSide", _sideText, true];
+_logic setVariable ["compiledFactionDisplayName", _displayName, true];
+_logic setVariable ["compiledFactionGroupCount", _groupIndex, true];
+
+if (_deleteTemplates) then {
+    {
+        if !(isNull _x) then {
+            {
+                if !(isNull _x) then {
+                    deleteVehicle _x;
+                };
+            } forEach (units _x);
+
+            _x call ALiVE_fnc_DeleteGroupRemote;
+        };
+    } forEach _templateGroups;
+
+    {
+        if !(isNull _x) then {
+            deleteVehicle _x;
+        };
+    } forEach _templateVehicles;
+};
+
+if (_debug) then {
+    ["Faction compiler [%1] registered %2 groups for side %3 using proxy %4", _factionId, _groupIndex, _sideText, _proxyFaction] call ALIVE_fnc_dump;
+};
+
+[_logic, false, _moduleID] call ALIVE_fnc_dumpModuleInit;
+true
+

--- a/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
@@ -28,11 +28,11 @@ if (isNil "ALIVE_compiledFactions") then {
 
 private _debug = [(_logic getVariable ["debug", false])] call _parseBool;
 private _deleteTemplates = [(_logic getVariable ["deleteTemplates", true])] call _parseBool;
-private _factionId = _logic getVariable ["factionId", "ALIVE_CUSTOM_FACTION"];
-if !(_factionId isEqualType "") then {
-    _factionId = str _factionId;
+private _requestedFactionId = _logic getVariable ["factionId", "ALIVE_CUSTOM_FACTION"];
+if !(_requestedFactionId isEqualType "") then {
+    _requestedFactionId = str _requestedFactionId;
 };
-
+private _factionId = _requestedFactionId;
 private _normalizedFactionId = [];
 private _lastWasUnderscore = false;
 private _hasIdentifierChar = false;
@@ -74,6 +74,54 @@ if (_proxyFaction isEqualTo "") then {
     _proxyFaction = "OPF_F";
 };
 
+private _moduleSourceId = netId _logic;
+if (_moduleSourceId isEqualTo "") then {
+    _moduleSourceId = str _logic;
+};
+
+private _ownsExistingId = (_logic getVariable ["compiledFactionId", ""]) isEqualTo _factionId;
+private _collisionReason = "";
+private _collisionOwner = "";
+private _collisionSourceId = "";
+
+if (_factionId in (ALIVE_compiledFactions select 1)) then {
+    private _existingFactionData = [ALIVE_compiledFactions, _factionId] call ALIVE_fnc_hashGet;
+    private _existingSourceModule = [_existingFactionData, "sourceModule", objNull] call ALIVE_fnc_hashGet;
+    private _existingSourceModuleId = [_existingFactionData, "sourceModuleId", ""] call ALIVE_fnc_hashGet;
+
+    if ((isNull _existingSourceModule && {!_ownsExistingId && {_existingSourceModuleId != _moduleSourceId}}) || {!isNull _existingSourceModule && {!(_existingSourceModule isEqualTo _logic)}}) then {
+        _collisionReason = "compiled faction";
+        _collisionOwner = [_existingFactionData, "displayName", _factionId] call ALIVE_fnc_hashGet;
+        _collisionSourceId = _existingSourceModuleId;
+    };
+};
+
+if (_collisionReason isEqualTo "" && {!isNil "ALIVE_factionCustomMappings"} && {_factionId in (ALIVE_factionCustomMappings select 1)}) then {
+    private _existingMapping = [ALIVE_factionCustomMappings, _factionId] call ALIVE_fnc_hashGet;
+    private _mappingIsCompiled = [_existingMapping, "CompiledFaction", false] call ALIVE_fnc_hashGet;
+    private _existingSourceModule = [_existingMapping, "SourceModule", objNull] call ALIVE_fnc_hashGet;
+    private _existingSourceModuleId = [_existingMapping, "SourceModuleId", ""] call ALIVE_fnc_hashGet;
+    private _mappingOwnedByCurrentModule = _mappingIsCompiled && {(!isNull _existingSourceModule && {_existingSourceModule isEqualTo _logic}) || {(isNull _existingSourceModule) && {_ownsExistingId || {_existingSourceModuleId isEqualTo _moduleSourceId}}}};
+
+    if (!_mappingOwnedByCurrentModule) then {
+        _collisionReason = if (_mappingIsCompiled) then {"compiled faction mapping"} else {"custom faction mapping"};
+        _collisionOwner = [_existingMapping, "DisplayName", [_existingMapping, "FactionName", _factionId] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashGet;
+        _collisionSourceId = _existingSourceModuleId;
+    };
+};
+
+if !(_collisionReason isEqualTo "") exitWith {
+    private _collisionSourceText = if (_collisionSourceId isEqualTo "") then {""} else {format [" (module %1)", _collisionSourceId]};
+    _logic setVariable ["compiledFactionId", "", true];
+    _logic setVariable ["compiledProxyFaction", "", true];
+    _logic setVariable ["compiledFactionSide", "", true];
+    _logic setVariable ["compiledFactionDisplayName", _displayName, true];
+    _logic setVariable ["compiledFactionGroupCount", 0, true];
+    _logic setVariable ["compiledFactionError", format ["Duplicate compiled faction id %1", _factionId], true];
+    ["Warning Faction compiler [%1] rejected normalized id %2 (requested %3) because it collides with existing %4 %5%6", _displayName, _factionId, _requestedFactionId, _collisionReason, _collisionOwner, _collisionSourceText] call ALIVE_fnc_dump;
+    [_logic, false, _moduleID] call ALIVE_fnc_dumpModuleInit;
+    false
+};
 private _groupsByCategory = [] call ALIVE_fnc_hashCreate;
 private _compiledGroups = [] call ALIVE_fnc_hashCreate;
 private _unitClasses = [];
@@ -228,6 +276,8 @@ private _mapping = [] call ALIVE_fnc_hashCreate;
 [_mapping, "Groups", _groupsByCategory] call ALIVE_fnc_hashSet;
 [_mapping, "CompiledFaction", true] call ALIVE_fnc_hashSet;
 [_mapping, "DisplayName", _displayName] call ALIVE_fnc_hashSet;
+[_mapping, "SourceModule", _logic] call ALIVE_fnc_hashSet;
+[_mapping, "SourceModuleId", _moduleSourceId] call ALIVE_fnc_hashSet;
 
 private _factionData = [] call ALIVE_fnc_hashCreate;
 [_factionData, "factionId", _factionId] call ALIVE_fnc_hashSet;
@@ -238,7 +288,8 @@ private _factionData = [] call ALIVE_fnc_hashCreate;
 [_factionData, "compiledGroups", _compiledGroups] call ALIVE_fnc_hashSet;
 [_factionData, "unitClasses", _unitClasses] call ALIVE_fnc_hashSet;
 [_factionData, "vehicleClasses", _vehicleClasses] call ALIVE_fnc_hashSet;
-
+[_factionData, "sourceModule", _logic] call ALIVE_fnc_hashSet;
+[_factionData, "sourceModuleId", _moduleSourceId] call ALIVE_fnc_hashSet;
 [ALIVE_compiledFactions, _factionId, _factionData] call ALIVE_fnc_hashSet;
 [ALIVE_factionCustomMappings, _factionId, _mapping] call ALIVE_fnc_hashSet;
 
@@ -247,6 +298,7 @@ _logic setVariable ["compiledProxyFaction", _proxyFaction, true];
 _logic setVariable ["compiledFactionSide", _sideText, true];
 _logic setVariable ["compiledFactionDisplayName", _displayName, true];
 _logic setVariable ["compiledFactionGroupCount", _groupIndex, true];
+_logic setVariable ["compiledFactionError", "", true];
 
 if (_deleteTemplates) then {
     {

--- a/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
@@ -57,7 +57,6 @@ if (!_hasIdentifierChar || {_factionId isEqualTo ""}) then {
     _factionId = "ALIVE_CUSTOM_FACTION";
 };
 
-_logic setVariable ["factionId", _factionId, true];
 private _displayName = _logic getVariable ["displayName", _factionId];
 if !(_displayName isEqualType "") then {
     _displayName = str _displayName;
@@ -112,6 +111,7 @@ if (_collisionReason isEqualTo "" && {!isNil "ALIVE_factionCustomMappings"} && {
 
 if !(_collisionReason isEqualTo "") exitWith {
     private _collisionSourceText = if (_collisionSourceId isEqualTo "") then {""} else {format [" (module %1)", _collisionSourceId]};
+    _logic setVariable ["factionId", _requestedFactionId, true];
     _logic setVariable ["compiledFactionId", "", true];
     _logic setVariable ["compiledProxyFaction", "", true];
     _logic setVariable ["compiledFactionSide", "", true];
@@ -253,7 +253,13 @@ private _standardCategories = ["Infantry", "SpecOps", "Motorized", "Motorized_MT
 } forEach _syncedObjects;
 
 if (_groupIndex == 0) exitWith {
+    _logic setVariable ["factionId", _requestedFactionId, true];
     _logic setVariable ["compiledFactionId", "", true];
+    _logic setVariable ["compiledProxyFaction", "", true];
+    _logic setVariable ["compiledFactionSide", "", true];
+    _logic setVariable ["compiledFactionDisplayName", _displayName, true];
+    _logic setVariable ["compiledFactionGroupCount", 0, true];
+    _logic setVariable ["compiledFactionError", "No template groups captured", true];
     if (_debug) then {
         ["Faction compiler [%1] found no template groups", _factionId] call ALIVE_fnc_dump;
     };
@@ -293,6 +299,7 @@ private _factionData = [] call ALIVE_fnc_hashCreate;
 [ALIVE_compiledFactions, _factionId, _factionData] call ALIVE_fnc_hashSet;
 [ALIVE_factionCustomMappings, _factionId, _mapping] call ALIVE_fnc_hashSet;
 
+_logic setVariable ["factionId", _factionId, true];
 _logic setVariable ["compiledFactionId", _factionId, true];
 _logic setVariable ["compiledProxyFaction", _proxyFaction, true];
 _logic setVariable ["compiledFactionSide", _sideText, true];

--- a/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerInit.sqf
@@ -32,12 +32,32 @@ private _factionId = _logic getVariable ["factionId", "ALIVE_CUSTOM_FACTION"];
 if !(_factionId isEqualType "") then {
     _factionId = str _factionId;
 };
-_factionId = [_factionId, " ", "_"] call CBA_fnc_replace;
-_factionId = [_factionId, "-", "_"] call CBA_fnc_replace;
-if (_factionId isEqualTo "") then {
+
+private _normalizedFactionId = [];
+private _lastWasUnderscore = false;
+private _hasIdentifierChar = false;
+{
+    private _charCode = _x;
+    private _isAlphaNumeric = (_charCode >= 48 && _charCode <= 57) || {(_charCode >= 65 && _charCode <= 90) || (_charCode >= 97 && _charCode <= 122)};
+
+    if (_isAlphaNumeric) then {
+        _normalizedFactionId pushBack _charCode;
+        _lastWasUnderscore = false;
+        _hasIdentifierChar = true;
+    } else {
+        if !(_lastWasUnderscore) then {
+            _normalizedFactionId pushBack 95;
+            _lastWasUnderscore = true;
+        };
+    };
+} forEach (toArray _factionId);
+
+_factionId = toString _normalizedFactionId;
+if (!_hasIdentifierChar || {_factionId isEqualTo ""}) then {
     _factionId = "ALIVE_CUSTOM_FACTION";
 };
 
+_logic setVariable ["factionId", _factionId, true];
 private _displayName = _logic getVariable ["displayName", _factionId];
 if !(_displayName isEqualType "") then {
     _displayName = str _displayName;

--- a/addons/sys_factioncompiler/fnc_factionCompilerIsCompiledFaction.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerIsCompiledFaction.sqf
@@ -1,0 +1,13 @@
+#include "\x\alive\addons\sys_factioncompiler\script_component.hpp"
+SCRIPT(factionCompilerIsCompiledFaction);
+
+params [
+    ["_factionId", ""]
+];
+
+if !(_factionId isEqualType "") exitWith {false};
+if (_factionId isEqualTo "") exitWith {false};
+
+private _factionData = [_factionId] call ALIVE_fnc_factionCompilerGetFactionData;
+!(isNil "_factionData")
+

--- a/addons/sys_factioncompiler/fnc_factionCompilerResolveForModule.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerResolveForModule.sqf
@@ -1,0 +1,26 @@
+#include "\x\alive\addons\sys_factioncompiler\script_component.hpp"
+SCRIPT(factionCompilerResolveForModule);
+
+params [
+    ["_logic", objNull, [objNull]]
+];
+
+if (isNull _logic) exitWith {""};
+
+private _result = "";
+
+{
+    if ((typeOf _x) isEqualTo "ALiVE_sys_factioncompiler") exitWith {
+        private _compiledFaction = _x getVariable ["compiledFactionId", ""];
+        if (_compiledFaction isEqualTo "") then {
+            _compiledFaction = _x getVariable ["factionId", ""];
+        };
+
+        if ([_compiledFaction] call ALIVE_fnc_factionCompilerIsCompiledFaction) then {
+            _result = _compiledFaction;
+        };
+    };
+} forEach (synchronizedObjects _logic);
+
+_result
+

--- a/addons/sys_factioncompiler/fnc_factionCompilerResolveForModule.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerResolveForModule.sqf
@@ -12,7 +12,9 @@ private _result = "";
 {
     if ((typeOf _x) isEqualTo "ALiVE_sys_factioncompiler") exitWith {
         private _compiledFaction = _x getVariable ["compiledFactionId", ""];
-        if (_compiledFaction isEqualTo "") then {
+        private _compilerError = _x getVariable ["compiledFactionError", ""];
+
+        if (_compiledFaction isEqualTo "" && {_compilerError isEqualTo ""}) then {
             _compiledFaction = _x getVariable ["factionId", ""];
         };
 

--- a/addons/sys_factioncompiler/fnc_factionCompilerResolveForModule.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerResolveForModule.sqf
@@ -8,9 +8,32 @@ params [
 if (isNull _logic) exitWith {""};
 
 private _result = "";
+private _compilerModules = (synchronizedObjects _logic) select {(typeOf _x) isEqualTo "ALiVE_sys_factioncompiler"};
+
+if (count _compilerModules > 1) exitWith {
+    private _moduleDescriptions = _compilerModules apply {
+        private _displayName = _x getVariable ["displayName", _x getVariable ["compiledFactionDisplayName", ""]];
+        private _compiledFactionId = _x getVariable ["compiledFactionId", ""];
+        private _configuredFactionId = _x getVariable ["factionId", ""];
+        private _label = if (_displayName isEqualTo "") then {_configuredFactionId} else {_displayName};
+
+        if (_compiledFactionId isEqualTo "") then {
+            if (_configuredFactionId isEqualTo "") then {
+                _label
+            } else {
+                format ["%1 [%2]", _label, _configuredFactionId]
+            };
+        } else {
+            format ["%1 [%2]", _label, _compiledFactionId]
+        };
+    };
+
+    ["Warning placement module %1 has multiple synced faction compiler modules (%2). Only one compiler sync is supported.", typeOf _logic, _moduleDescriptions joinString ", "] call ALIVE_fnc_dump;
+    ""
+};
 
 {
-    if (_result isEqualTo "" && {(typeOf _x) isEqualTo "ALiVE_sys_factioncompiler"}) then {
+    if (_result isEqualTo "") then {
         private _compiledFaction = _x getVariable ["compiledFactionId", ""];
         private _compilerError = _x getVariable ["compiledFactionError", ""];
 
@@ -24,7 +47,6 @@ private _result = "";
             };
         };
     };
-} forEach (synchronizedObjects _logic);
+} forEach _compilerModules;
 
 _result
-

--- a/addons/sys_factioncompiler/fnc_factionCompilerResolveForModule.sqf
+++ b/addons/sys_factioncompiler/fnc_factionCompilerResolveForModule.sqf
@@ -10,7 +10,7 @@ if (isNull _logic) exitWith {""};
 private _result = "";
 
 {
-    if ((typeOf _x) isEqualTo "ALiVE_sys_factioncompiler") exitWith {
+    if (_result isEqualTo "" && {(typeOf _x) isEqualTo "ALiVE_sys_factioncompiler"}) then {
         private _compiledFaction = _x getVariable ["compiledFactionId", ""];
         private _compilerError = _x getVariable ["compiledFactionError", ""];
 
@@ -18,8 +18,10 @@ private _result = "";
             _compiledFaction = _x getVariable ["factionId", ""];
         };
 
-        if ([_compiledFaction] call ALIVE_fnc_factionCompilerIsCompiledFaction) then {
-            _result = _compiledFaction;
+        if !(_compiledFaction isEqualTo "") then {
+            if ([_compiledFaction] call ALIVE_fnc_factionCompilerIsCompiledFaction) then {
+                _result = _compiledFaction;
+            };
         };
     };
 } forEach (synchronizedObjects _logic);

--- a/addons/sys_factioncompiler/script_component.hpp
+++ b/addons/sys_factioncompiler/script_component.hpp
@@ -1,0 +1,13 @@
+#define COMPONENT sys_factioncompiler
+#include "\x\alive\addons\main\script_mod.hpp"
+
+#ifdef DEBUG_ENABLED_SYS_FACTIONCOMPILER
+#define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_ENABLED_SYS_FACTIONCOMPILER
+#define DEBUG_SETTINGS DEBUG_ENABLED_SYS_FACTIONCOMPILER
+#endif
+
+#include "\x\cba\addons\main\script_macros.hpp"
+

--- a/addons/sys_profile/CfgPatches.hpp
+++ b/addons/sys_profile/CfgPatches.hpp
@@ -4,7 +4,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ALIVE_main"};
+        requiredAddons[] = {"ALIVE_main","ALIVE_sys_factioncompiler"};
         versionDesc = "ALiVE";
         //versionAct = "['SYS_PROFILE',_this] execVM '\x\alive\addons\main\about.sqf';";
         VERSION_CONFIG;

--- a/addons/sys_profile/fnc_createProfilesFromGroupConfig.sqf
+++ b/addons/sys_profile/fnc_createProfilesFromGroupConfig.sqf
@@ -57,6 +57,7 @@ private _groupProfiles = [];
 // groups/units and don't get substitution applied.
 private _originalFaction = _prefix;
 private _isInferredRedirect = false;
+private _compiledFaction = "";
 
 // Check to see if faction has a mapping
 if(!isNil "ALIVE_factionCustomMappings") then {
@@ -66,6 +67,9 @@ if(!isNil "ALIVE_factionCustomMappings") then {
         // HashMaps - getOrDefault doesn't apply. Use the 3-arg form of
         // ALiVE_fnc_hashGet which returns the default when the key is
         // absent (curated mappings never set "Inferred").
+        if ([_customMappings, "CompiledFaction", false] call ALIVE_fnc_hashGet) then {
+            _compiledFaction = [_customMappings, "FactionName", _prefix] call ALIVE_fnc_hashGet;
+        };
         if ([_customMappings, "Inferred", false] call ALIVE_fnc_hashGet) then {
             _isInferredRedirect = true;
         };
@@ -74,6 +78,11 @@ if(!isNil "ALIVE_factionCustomMappings") then {
 };
 
 // ["Group faction: %1",_prefix] call ALIVE_fnc_dump;
+
+if !(_compiledFaction isEqualTo "") then {
+    private _compiledProfiles = [_groupClass, _position, _direction, _spawnGoodPosition, _compiledFaction, _busy, _isSPE, _aiBehaviour, _onEachSpawn, _onEachSpawnOnce] call ALIVE_fnc_factionCompilerCreateProfilesFromGroup;
+    if (count _compiledProfiles > 0) exitWith {_compiledProfiles};
+};
 
 private _config = [_prefix, _groupClass] call ALIVE_fnc_configGetGroup;
 

--- a/addons/x_lib/functions/composition/fnc_spawnComposition.sqf
+++ b/addons/x_lib/functions/composition/fnc_spawnComposition.sqf
@@ -38,6 +38,8 @@ ARJay
 
 params ["_config","_position","_azi","_faction"];
 
+private _configFaction = if (!isNil "ALiVE_fnc_factionCompilerGetConfigFaction") then {[_faction] call ALiVE_fnc_factionCompilerGetConfigFaction} else {_faction};
+
 ["Spawning Composition: %1", _this] call ALiVE_fnc_dump;
 
 private ["_posX", "_posY"];
@@ -172,7 +174,7 @@ for "_i" from 0 to ((count _objects) - 1) do {
     // if object is faction-specific
     // and doesn't belong to passed faction
     // delete it
-    if (faction _newObj != _faction && {_newObj iskindof "LandVehicle" || {_newObj iskindof "FlagCarrier"}}) then {
+    if (faction _newObj != _configFaction && {_newObj iskindof "LandVehicle" || {_newObj iskindof "FlagCarrier"}}) then {
         deleteVehicle _newObj;
     } else {
         _newObj setDir (_azi + _azimuth);
@@ -236,6 +238,4 @@ _charge = createVehicle ["ALIVE_DemoCharge_Remote_Ammo",_position, [], 0, "CAN_C
 _charge setvariable [QGVAR(COMPOSITION_OBJECTS),_created];
 _charge enableSimulation false;
 _charge hideObjectGlobal true;
-
-
 

--- a/addons/x_lib/functions/config/fnc_configGetFactionClass.sqf
+++ b/addons/x_lib/functions/config/fnc_configGetFactionClass.sqf
@@ -31,10 +31,10 @@ nil
 private "_value";
 
 if (typeName _this == "ARRAY") then {
-	["INCORRECT TYPE PASSED TO configGetFactionClass: %1", _this] call ALiVE_fnc_dump;
-	_value = _this select 0;
+    ["INCORRECT TYPE PASSED TO configGetFactionClass: %1", _this] call ALiVE_fnc_dump;
+    _value = _this select 0;
 } else {
-	_value = _this;
+    _value = _this;
 };
 
 private _path = missionConfigFile >> "CfgFactionClasses" >> _value;
@@ -42,22 +42,32 @@ private _path = missionConfigFile >> "CfgFactionClasses" >> _value;
 if !(isClass _path) then {_path = configFile >> "CfgFactionClasses" >> _value};
 
 if !(isClass _path) then {
-	// Check to see if faction has a mapping within groups
-	if (!isnil "ALiVE_factionCustomMappings") then {
-		{
-	       private _factionData = [ALiVE_factionCustomMappings, _x] call ALiVE_fnc_hashGet;
+    if (!isNil "ALiVE_factionCustomMappings" && {_value in (ALiVE_factionCustomMappings select 1)}) then {
+        private _factionData = [ALiVE_factionCustomMappings, _value] call ALiVE_fnc_hashGet;
+        private _configFaction = [_factionData, "ConfigFactionName", [_factionData, "FactionName", _value] call ALiVE_fnc_hashGet] call ALiVE_fnc_hashGet;
 
-		   private _factionSide = [_factionData,"GroupSideName"] call ALiVE_fnc_hashGet;
+        _path = missionConfigFile >> "CfgFactionClasses" >> _configFaction;
+        if !(isClass _path) then {_path = configFile >> "CfgFactionClasses" >> _configFaction};
+    };
+};
 
-		   private _faction = [_factionData,"GroupFactionName"] call ALiVE_fnc_hashGet;
+if !(isClass _path) then {
+    // Check to see if faction has a mapping within groups
+    if (!isnil "ALiVE_factionCustomMappings") then {
+        {
+           private _factionData = [ALiVE_factionCustomMappings, _x] call ALiVE_fnc_hashGet;
 
-		   if (_value == _faction) then {
-		   		_path = missionConfigFile >> "CfgFactionClasses" >> _x;
-				if !(isClass _path) then {_path = configFile >> "CfgFactionClasses" >> _x};
-		   };
+           private _factionSide = [_factionData,"GroupSideName"] call ALiVE_fnc_hashGet;
 
-		} foreach (ALiVE_factionCustomMappings select 1);
-	};
+           private _faction = [_factionData,"GroupFactionName"] call ALiVE_fnc_hashGet;
+
+           if (_value == _faction) then {
+                _path = missionConfigFile >> "CfgFactionClasses" >> _x;
+                if !(isClass _path) then {_path = configFile >> "CfgFactionClasses" >> _x};
+           };
+
+        } foreach (ALiVE_factionCustomMappings select 1);
+    };
 };
 
 _path

--- a/addons/x_lib/functions/vehicles/fnc_findVehicleType.sqf
+++ b/addons/x_lib/functions/vehicles/fnc_findVehicleType.sqf
@@ -59,14 +59,22 @@ if (!isNil "ALiVE_fnc_factionCompilerFindVehicleType") then {
 if (!isNil "ALiVE_fnc_factionCompilerIsCompiledFaction") then {
     if (_fac isEqualType "") then {
         if ([_fac] call ALiVE_fnc_factionCompilerIsCompiledFaction) then {
-            _fac = [_fac] call ALiVE_fnc_factionCompilerGetConfigFaction;
+            if (count _compiledVehicles == 0) then {
+                _fac = [_fac] call ALiVE_fnc_factionCompilerGetConfigFaction;
+            } else {
+                _fac = [];
+            };
         };
     } else {
         if (_fac isEqualType []) then {
             private _resolvedFactions = [];
             {
-                if ([_x] call ALiVE_fnc_factionCompilerIsCompiledFaction) then {
-                    _resolvedFactions pushBackUnique ([_x] call ALiVE_fnc_factionCompilerGetConfigFaction);
+                if (_x isEqualType "" && {[_x] call ALiVE_fnc_factionCompilerIsCompiledFaction}) then {
+                    private _compiledFactionVehicles = [_cargoslots, _x, _type, _noWeapons, _minScope] call ALiVE_fnc_factionCompilerFindVehicleType;
+
+                    if (count _compiledFactionVehicles == 0) then {
+                        _resolvedFactions pushBackUnique ([_x] call ALiVE_fnc_factionCompilerGetConfigFaction);
+                    };
                 } else {
                     _resolvedFactions pushBackUnique _x;
                 };
@@ -75,7 +83,6 @@ if (!isNil "ALiVE_fnc_factionCompilerIsCompiledFaction") then {
         };
     };
 };
-
 _nonConfigs = ["StaticWeapon","CruiseMissile1","CruiseMissile2","Chukar_EP1","Chukar","Chukar_AllwaysEnemy_EP1"];
 _nonSims = ["parachute","house"];
 

--- a/addons/x_lib/functions/vehicles/fnc_findVehicleType.sqf
+++ b/addons/x_lib/functions/vehicles/fnc_findVehicleType.sqf
@@ -2,7 +2,7 @@
 SCRIPT(findVehicleType);
 
 /* ----------------------------------------------------------------------------
-Function: ALiVE_fnc_findVehicleType
+Function: ALIVE_fnc_findVehicleType
 
 Description:
 Used to find vehicles for specific type, side and free cargo slots
@@ -44,12 +44,37 @@ if (typeName _fac == "ARRAY") then {
     _id = [_id, "[", ""] call CBA_fnc_replace;
     _id = [_id, "]", ""] call CBA_fnc_replace;
     _id = [_id, "'", ""] call CBA_fnc_replace;
-    _id = [_id, """", ""] call CBA_fnc_replace;
+    _id = [_id, "\"", ""] call CBA_fnc_replace;
 };
 
 private _searchBag = format["ALiVE_X_LIB_SEARCHBAG_%1_%2_%3",_id,_type,_noWeapons];
 
 if !(isnil {call compile _searchBag}) exitwith {call compile _searchBag};
+
+private _compiledVehicles = [];
+if (!isNil "ALiVE_fnc_factionCompilerFindVehicleType") then {
+    _compiledVehicles = [_cargoslots, _fac, _type, _noWeapons, _minScope] call ALiVE_fnc_factionCompilerFindVehicleType;
+};
+
+if (!isNil "ALiVE_fnc_factionCompilerIsCompiledFaction") then {
+    if (_fac isEqualType "") then {
+        if ([_fac] call ALiVE_fnc_factionCompilerIsCompiledFaction) then {
+            _fac = [_fac] call ALiVE_fnc_factionCompilerGetConfigFaction;
+        };
+    } else {
+        if (_fac isEqualType []) then {
+            private _resolvedFactions = [];
+            {
+                if ([_x] call ALiVE_fnc_factionCompilerIsCompiledFaction) then {
+                    _resolvedFactions pushBackUnique ([_x] call ALiVE_fnc_factionCompilerGetConfigFaction);
+                } else {
+                    _resolvedFactions pushBackUnique _x;
+                };
+            } forEach _fac;
+            _fac = _resolvedFactions;
+        };
+    };
+};
 
 _nonConfigs = ["StaticWeapon","CruiseMissile1","CruiseMissile2","Chukar_EP1","Chukar","Chukar_AllwaysEnemy_EP1"];
 _nonSims = ["parachute","house"];
@@ -71,7 +96,7 @@ if (typename _fac == "STRING") then {
     } foreach _fac;
 };
 
-_allvehs = [];
+_allvehs = +_compiledVehicles;
 
 for "_y" from 1 to count(configFile >> "CfgVehicles") - 1 do {
     _entry = (configFile >> "CfgVehicles") select _y;
@@ -127,6 +152,6 @@ for "_y" from 1 to count(configFile >> "CfgVehicles") - 1 do {
     };
 };
 
-//call compile (format["%1 = %2",_searchbag,_allvehs]);
+_allvehs = _allvehs arrayIntersect _allvehs;
 
 _allvehs

--- a/addons/x_lib/functions/vehicles/fnc_findVehicleType.sqf
+++ b/addons/x_lib/functions/vehicles/fnc_findVehicleType.sqf
@@ -44,7 +44,7 @@ if (typeName _fac == "ARRAY") then {
     _id = [_id, "[", ""] call CBA_fnc_replace;
     _id = [_id, "]", ""] call CBA_fnc_replace;
     _id = [_id, "'", ""] call CBA_fnc_replace;
-    _id = [_id, "\"", ""] call CBA_fnc_replace;
+    _id = [_id, toString [34], ""] call CBA_fnc_replace;
 };
 
 private _searchBag = format["ALiVE_X_LIB_SEARCHBAG_%1_%2_%3",_id,_type,_noWeapons];


### PR DESCRIPTION
With a compiler module, a category helper module, runtime faction registry, compiled-group profile creation, and per-unit loadout reapplication on spawn. The integration points are wired.

Placement modules now resolve a synced compiler module as a runtime faction override, with sync metadata updated. I also added the required addon dependencies.