### PR TITLE
[MIL_OPCOM]  patched the asymmetric installation teardown so a shared…

### DIFF
--- a/addons/mil_opcom/fnc_INS_helpers.sqf
+++ b/addons/mil_opcom/fnc_INS_helpers.sqf
@@ -1425,7 +1425,14 @@ ALiVE_fnc_INS_registerInstallationOnBuilding = {
     if (isNull _building) exitwith {};
     if (_installationVar == "") exitwith {};
 
-    _building setVariable [_installationVar, _id, true];
+    private _installationIDs = _building getVariable [_installationVar, []];
+    if !(_installationIDs isEqualType []) then {
+        _installationIDs = [_installationIDs];
+    };
+    if !(_id in _installationIDs) then {
+        _installationIDs pushBack _id;
+    };
+    _building setVariable [_installationVar, _installationIDs, true];
 
     if (_disabledVar != "") then {
         _building setVariable [_disabledVar, false, true];
@@ -1447,9 +1454,15 @@ ALiVE_fnc_INS_getBuildingInstallations = {
     {
         _x params ["_objectiveKey", "_installationVar", "_disabledVar", "_actionKey"];
 
-        private _id = _building getVariable [_installationVar, nil];
-        if !(isNil "_id") then {
-            _installations pushBack [_objectiveKey, _installationVar, _disabledVar, _actionKey, _id];
+        private _ids = _building getVariable [_installationVar, nil];
+        if !(isNil "_ids") then {
+            if !(_ids isEqualType []) then {
+                _ids = [_ids];
+            };
+
+            {
+                _installations pushBack [_objectiveKey, _installationVar, _disabledVar, _actionKey, _x];
+            } forEach _ids;
         };
     } forEach [
         ["factory", QGVAR(factory), "ALiVE_MIL_OPCOM_FACTORY_DISABLED", "factory"],
@@ -1770,7 +1783,7 @@ ALIVE_fnc_INS_buildingKilledEH = {
     // fire event
     // TODO: cba events should be fired from core event loop, not here
 
-    private _opcomID = "";
+    private _hostilityUpdates = [];
 
     {
         _x params ["_objectiveKey", "_installationVar", "_disabledVar", "_actionKey", "_id"];
@@ -1783,9 +1796,14 @@ ALIVE_fnc_INS_buildingKilledEH = {
 
         private _objective = [[],"getobjectivebyid",_id] call ALiVE_fnc_OPCOM;
         if ([_objective] call ALIVE_fnc_isHash) then {
-            if (_opcomID == "") then {
-                _opcomID = [_objective,"opcomID",""] call ALiVE_fnc_HashGet;
-                _pos = [_objective,"center",_pos] call ALiVE_fnc_HashGet;
+            private _objectiveOpcomID = [_objective,"opcomID",""] call ALiVE_fnc_HashGet;
+            private _objectivePos = [_objective,"center",_pos] call ALiVE_fnc_HashGet;
+
+            if (
+                _objectiveOpcomID != ""
+                && {(_hostilityUpdates findIf {(_x select 0) == _objectiveOpcomID && {(_x select 1) isEqualTo _objectivePos}}) == -1}
+            ) then {
+                _hostilityUpdates pushBack [_objectiveOpcomID, _objectivePos];
             };
 
             [_objective,_objectiveKey] call ALiVE_fnc_HashRem;
@@ -1804,21 +1822,24 @@ ALIVE_fnc_INS_buildingKilledEH = {
     {deleteVehicle _x} foreach _furniture;
     _building setvariable [QGVAR(furnitured),[], true];
 
-    if (_opcomID != "") then {
+    {
+        _x params ["_opcomID", "_objectivePos"];
+
+        private _objectiveOpcom = [];
         {
             if (([_x,"opcomID"," "] call ALiVE_fnc_HashGet) == _opcomID) exitwith {
-                _opcom = _x
+                _objectiveOpcom = _x
             }
         } foreach OPCOM_instances;
 
-        if !(isnil "_opcom") then {
-            private _opcomSide = [_opcom,"side",""] call ALiVE_fnc_HashGet;
+        if ([_objectiveOpcom] call ALIVE_fnc_isHash) then {
+            private _opcomSide = [_objectiveOpcom,"side",""] call ALiVE_fnc_HashGet;
             private _allSides = ["EAST","WEST","GUER"];
 
-            [_pos,[_opcomSide], 50] call ALiVE_fnc_updateSectorHostility;
-            [_pos,_allSides - [_opcomSide], -50] call ALiVE_fnc_updateSectorHostility;
+            [_objectivePos,[_opcomSide], 50] call ALiVE_fnc_updateSectorHostility;
+            [_objectivePos,_allSides - [_opcomSide], -50] call ALiVE_fnc_updateSectorHostility;
         };
-    };
+    } forEach _hostilityUpdates;
 };
 
 ALiVE_fnc_INS_compileList = {

--- a/addons/mil_opcom/fnc_INS_helpers.sqf
+++ b/addons/mil_opcom/fnc_INS_helpers.sqf
@@ -1414,6 +1414,72 @@ ALiVE_fnc_INS_protectInstallationActionObject = {
     _object setVariable [QGVAR(INSTALLATION_ACTION_OBJECT), true, true];
 };
 
+ALiVE_fnc_INS_registerInstallationOnBuilding = {
+    params [
+        ["_building", objNull, [objNull]],
+        ["_installationVar", "", [""]],
+        "_id",
+        ["_disabledVar", "", [""]]
+    ];
+
+    if (isNull _building) exitwith {};
+    if (_installationVar == "") exitwith {};
+
+    _building setVariable [_installationVar, _id, true];
+
+    if (_disabledVar != "") then {
+        _building setVariable [_disabledVar, false, true];
+    };
+
+    if !(_building getVariable [QGVAR(INSTALLATION_KILLED_EH_ADDED), false]) then {
+        _building addEventHandler ["Killed", ALIVE_fnc_INS_buildingKilledEH];
+        _building setVariable [QGVAR(INSTALLATION_KILLED_EH_ADDED), true, true];
+    };
+};
+
+ALiVE_fnc_INS_getBuildingInstallations = {
+    params [["_building", objNull, [objNull]]];
+
+    if (isNull _building) exitwith {[]};
+
+    private _installations = [];
+
+    {
+        _x params ["_objectiveKey", "_installationVar", "_disabledVar", "_actionKey"];
+
+        private _id = _building getVariable [_installationVar, nil];
+        if !(isNil "_id") then {
+            _installations pushBack [_objectiveKey, _installationVar, _disabledVar, _actionKey, _id];
+        };
+    } forEach [
+        ["factory", QGVAR(factory), "ALiVE_MIL_OPCOM_FACTORY_DISABLED", "factory"],
+        ["HQ", QGVAR(HQ), "ALiVE_MIL_OPCOM_HQ_DISABLED", "recruit"],
+        ["depot", QGVAR(depot), "ALiVE_MIL_OPCOM_DEPOT_DISABLED", "depot"]
+    ];
+
+    _installations
+};
+
+ALiVE_fnc_INS_disableBuildingInstallations = {
+    params [
+        ["_building", objNull, [objNull]],
+        ["_caller", objNull, [objNull]]
+    ];
+
+    if (isNull _building) exitwith {};
+
+    {
+        _x params ["_objectiveKey", "_installationVar", "_disabledVar"];
+        _building setVariable [_disabledVar, true, true];
+    } forEach ([_building] call ALiVE_fnc_INS_getBuildingInstallations);
+
+    if (isServer) then {
+        [_building, _caller] call ALIVE_fnc_INS_buildingKilledEH;
+    } else {
+        [_building, _caller] remoteExec ["ALIVE_fnc_INS_buildingKilledEH", 2];
+    };
+};
+
 ALiVE_fnc_spawnFurniture = {
 
     private ["_pos","_furniture","_bomb","_box","_created"];
@@ -1595,10 +1661,8 @@ ALiVE_fnc_INS_addInstallationHoldActions = {
 
                     if (isNull _building) exitWith {};
 
-                    _building setVariable [_disabledVar,true,true];
                     [_target, _ID] remoteExec ["BIS_fnc_holdActionRemove", 0, _target];
-
-                    [_building, _caller] remoteExec ["ALIVE_fnc_INS_buildingKilledEH",2];
+                    [_building, _caller] call ALiVE_fnc_INS_disableBuildingInstallations;
 
                     [_subtitleTitle, format [_subtitleText,name _caller, mapGridPosition _building]] remoteExec ["BIS_fnc_showSubtitle",side (group _caller)];
                 },
@@ -1618,8 +1682,7 @@ ALiVE_fnc_INS_spawnIEDfactory = {
 
     if !(alive _building) exitwith {};
 
-    _building setvariable [QGVAR(factory),_id];
-    _building addEventHandler["killed", ALIVE_fnc_INS_buildingKilledEH];
+    [_building, QGVAR(factory), _id, "ALiVE_MIL_OPCOM_FACTORY_DISABLED"] call ALiVE_fnc_INS_registerInstallationOnBuilding;
     private _duration = 10 + ((count (_building getvariable [QGVAR(furnitured),[]]))*4);
 
     [_building,true,false,false] call ALiVE_fnc_spawnFurniture;
@@ -1642,8 +1705,7 @@ ALiVE_fnc_INS_spawnHQ = {
 
     if !(alive _building) exitwith {};
 
-    _building setvariable [QGVAR(HQ),_id];
-    _building addEventHandler["killed", ALIVE_fnc_INS_buildingKilledEH];
+    [_building, QGVAR(HQ), _id, "ALiVE_MIL_OPCOM_HQ_DISABLED"] call ALiVE_fnc_INS_registerInstallationOnBuilding;
     private _duration = 10 + ((count (_building getvariable [QGVAR(furnitured),[]]))*4);
 
     [_building,true,false,false] call ALiVE_fnc_spawnFurniture;
@@ -1667,8 +1729,7 @@ ALiVE_fnc_INS_spawnDepot = {
 
     if !(alive _building) exitwith {};
 
-    _building setvariable [QGVAR(depot),_id];
-    _building addEventHandler["killed", ALIVE_fnc_INS_buildingKilledEH];
+    [_building, QGVAR(depot), _id, "ALiVE_MIL_OPCOM_DEPOT_DISABLED"] call ALiVE_fnc_INS_registerInstallationOnBuilding;
     private _duration = 10 + ((count (_building getvariable [QGVAR(furnitured),[]]))*4);
 
     [_building,true,false,true] call ALiVE_fnc_spawnFurniture;
@@ -1695,73 +1756,68 @@ ALiVE_fnc_getRelativeTop = {
 
 ALIVE_fnc_INS_buildingKilledEH = {
 
-    private ["_building","_killer","_id","_opcom","_pos"];
+    private ["_building","_killer","_opcom","_pos"];
 
     _building = _this select 0;
     _killer = _this select 1;
     _pos = getposATL _building;
 
-    private _factory = _building getvariable QGVAR(factory);
-    private _depot = _building getvariable QGVAR(depot);
-    private _HQ = _building getvariable QGVAR(HQ);
     private _furniture = _building getvariable [QGVAR(furnitured),[]];
+    private _installations = [_building] call ALiVE_fnc_INS_getBuildingInstallations;
 
-    private _installationType = "";
-    if !(isnil "_factory") then {
-        _id = _factory;
-        _installationType = "factory";
-    };
-    if !(isnil "_depot") then {
-        _id = _depot;
-        _installationType = "depot";
-    };
-    if !(isnil "_HQ") then {
-        _id = _HQ;
-        _installationType = "hq";
-    };
-
-    if (isnil "_id") exitwith {};
+    if (_installations isEqualTo []) exitwith {};
 
     // fire event
     // TODO: cba events should be fired from core event loop, not here
 
-    ["ASYMM_INSTALLATION_DESTROYED", [_installationType,_building,_killer]] call CBA_fnc_globalEvent;
-
-    private _event = ['ASYMM_INSTALLATION_DESTROYED', [_installationType,_building,_killer],"OPCOM"] call ALIVE_fnc_event;
-    [ALiVE_eventLog, "addEvent", _event] call ALIVE_fnc_eventLog;
-
-    private _objective = [[],"getobjectivebyid",_id] call ALiVE_fnc_OPCOM;
-    private _opcomID = [_objective,"opcomID",""] call ALiVE_fnc_HashGet;
-    _pos = [_objective,"center",_pos] call ALiVE_fnc_HashGet;
-
-    if !(isnil "_factory") then {
-        [_objective,"factory"] call ALiVE_fnc_HashRem;
-        [_objective,"actionsFulfilled",([_objective,"actionsFulfilled",[]] call ALiVE_fnc_HashGet) - ["factory"]] call ALiVE_fnc_HashSet;
-    };
-    if !(isnil "_depot") then {
-        [_objective,"depot"] call ALiVE_fnc_HashRem;
-        [_objective,"actionsFulfilled",([_objective,"actionsFulfilled",[]] call ALiVE_fnc_HashGet) - ["depot"]] call ALiVE_fnc_HashSet;
-    };
-    if !(isnil "_HQ") then {
-        [_objective,"HQ"] call ALiVE_fnc_HashRem;
-        [_objective,"actionsFulfilled",([_objective,"actionsFulfilled",[]] call ALiVE_fnc_HashGet) - ["recruit"]] call ALiVE_fnc_HashSet;
-    };
-
-    {deleteVehicle _x} foreach _furniture;
-    _building setvariable [QGVAR(furnitured),[]];
+    private _opcomID = "";
 
     {
-        if (([_x,"opcomID"," "] call ALiVE_fnc_HashGet) == _opcomID) exitwith {
-            _opcom = _x
-        }
-    } foreach OPCOM_instances;
+        _x params ["_objectiveKey", "_installationVar", "_disabledVar", "_actionKey", "_id"];
 
-    if !(isnil "_opcom") then {
-        private _opcomSide = [_opcom,"side",""] call ALiVE_fnc_HashGet;
-        private _allSides = ["EAST","WEST","GUER"];
+        private _installationType = toLower _objectiveKey;
+        ["ASYMM_INSTALLATION_DESTROYED", [_installationType,_building,_killer]] call CBA_fnc_globalEvent;
 
-        [_pos,[_opcomSide], 50] call ALiVE_fnc_updateSectorHostility;
-        [_pos,_allSides - [_opcomSide], -50] call ALiVE_fnc_updateSectorHostility;
+        private _event = ['ASYMM_INSTALLATION_DESTROYED', [_installationType,_building,_killer],"OPCOM"] call ALIVE_fnc_event;
+        [ALiVE_eventLog, "addEvent", _event] call ALiVE_fnc_eventLog;
+
+        private _objective = [[],"getobjectivebyid",_id] call ALiVE_fnc_OPCOM;
+        if ([_objective] call ALIVE_fnc_isHash) then {
+            if (_opcomID == "") then {
+                _opcomID = [_objective,"opcomID",""] call ALiVE_fnc_HashGet;
+                _pos = [_objective,"center",_pos] call ALiVE_fnc_HashGet;
+            };
+
+            [_objective,_objectiveKey] call ALiVE_fnc_HashRem;
+            [_objective,"actionsFulfilled",([_objective,"actionsFulfilled",[]] call ALiVE_fnc_HashGet) - [_actionKey]] call ALiVE_fnc_HashSet;
+        };
+
+        _building setVariable [_installationVar, nil, true];
+        _building setVariable [_disabledVar, true, true];
+    } forEach _installations;
+
+    {
+        _x setVariable [QGVAR(INSTALLATION_ACTIONS_ADDED), [], true];
+        _x setVariable ["ALiVE_MIL_OPCOM_INSTALLATION_BUILDING", nil, true];
+    } forEach (([_building, _furniture] call ALiVE_fnc_INS_getInstallationActionObjects) + [_building]);
+
+    {deleteVehicle _x} foreach _furniture;
+    _building setvariable [QGVAR(furnitured),[], true];
+
+    if (_opcomID != "") then {
+        {
+            if (([_x,"opcomID"," "] call ALiVE_fnc_HashGet) == _opcomID) exitwith {
+                _opcom = _x
+            }
+        } foreach OPCOM_instances;
+
+        if !(isnil "_opcom") then {
+            private _opcomSide = [_opcom,"side",""] call ALiVE_fnc_HashGet;
+            private _allSides = ["EAST","WEST","GUER"];
+
+            [_pos,[_opcomSide], 50] call ALiVE_fnc_updateSectorHostility;
+            [_pos,_allSides - [_opcomSide], -50] call ALiVE_fnc_updateSectorHostility;
+        };
     };
 };
 

--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -2152,23 +2152,42 @@ switch(_operation) do {
 
             if (_installationType in ["HQ", "factory", "depot"]) then {
                 private _buildings = [_center, _size] call ALiVE_fnc_INS_filterObjectiveBuildings;
-                private _usedBuildings = [];
+                private _locallyUsedBuildings = [];
+                private _externallyUsedBuildings = [];
 
                 {
                     private _occupied = [_logic, "convertObject", [_objective, _x, []] call ALiVE_fnc_HashGet] call ALiVE_fnc_OPCOM;
                     if (alive _occupied) then {
-                        _usedBuildings pushBackUnique _occupied;
+                        _locallyUsedBuildings pushBackUnique _occupied;
                     };
                 } foreach ["factory", "HQ", "depot"];
 
+                {
+                    private _candidateObjective = _x;
+                    if (([_candidateObjective, "objectiveID", ""] call ALiVE_fnc_HashGet) != _objectiveID) then {
+                        {
+                            private _occupied = [_logic, "convertObject", [_candidateObjective, _x, []] call ALiVE_fnc_HashGet] call ALiVE_fnc_OPCOM;
+                            if (alive _occupied) then {
+                                _externallyUsedBuildings pushBackUnique _occupied;
+                            };
+                        } foreach ["factory", "HQ", "depot"];
+                    };
+                } foreach ([_logic, "objectives", []] call ALiVE_fnc_HashGet);
+
                 private _candidateBuildings = [];
                 {
-                    if !(_x in _usedBuildings) then {
+                    if !(_x in _externallyUsedBuildings) then {
                         _candidateBuildings pushBack _x;
                     };
                 } foreach _buildings;
-                if (count _candidateBuildings == 0) then {
-                    _candidateBuildings = _buildings;
+
+                private _preferredBuildings = _candidateBuildings select {
+                    !(_x in _locallyUsedBuildings)
+                };
+                private _selectionBuildings = if (count _preferredBuildings > 0) then {
+                    _preferredBuildings
+                } else {
+                    _candidateBuildings
                 };
 
                 if (_target isEqualType objNull && {!isNull _target} && {alive _target} && {_target in _candidateBuildings}) then {
@@ -2176,7 +2195,7 @@ switch(_operation) do {
                 };
 
                 if (isNull _selectedTarget) then {
-                    private _sortedBuildings = [_candidateBuildings, [_anchorPos], {_Input0 distance2D _x}, "ASCEND"] call ALiVE_fnc_SortBy;
+                    private _sortedBuildings = [_selectionBuildings, [_anchorPos], {_Input0 distance2D _x}, "ASCEND"] call ALiVE_fnc_SortBy;
                     if (count _sortedBuildings > 0) then {
                         if (_useClosestBuilding || {(_anchorPos distance2D (_sortedBuildings select 0)) <= 15}) then {
                             _selectedTarget = _sortedBuildings select 0;

--- a/addons/mil_opcom/fnc_OPCOMfriendlyDisableInstallations.sqf
+++ b/addons/mil_opcom/fnc_OPCOMfriendlyDisableInstallations.sqf
@@ -107,6 +107,7 @@ private _PROXIMITY_RADIUS = 150;
 private _CAPTURE_RADIUS = 200;
 
 private _objectives = [_handler, "objectives", []] call ALiVE_fnc_HashGet;
+private _processedBuildings = [];
 
 {
     private _objective = _x;
@@ -153,6 +154,7 @@ private _objectives = [_handler, "objectives", []] call ALiVE_fnc_HashGet;
 
         private _canProceed = !isNull _building
             && {alive _building}
+            && {!(_building in _processedBuildings)}
             // Idempotence: if a player hold-action (or an earlier scan)
             // already disabled this building, don't re-fire. The hold-
             // action path sets this same variable at fnc_INS_helpers.sqf
@@ -193,8 +195,8 @@ private _objectives = [_handler, "objectives", []] call ALiVE_fnc_HashGet;
             };
 
             if (_triggered) then {
-                _building setVariable [_disabledVar, true, true];
-                [_building, _caller] remoteExec ["ALIVE_fnc_INS_buildingKilledEH", 2];
+                _processedBuildings pushBack _building;
+                [_building, _caller] call ALiVE_fnc_INS_disableBuildingInstallations;
 
                 // Subtitle: if we have a specific caller (proximity or
                 // capture with unit nearby) use their name and target


### PR DESCRIPTION
… building is now handled deliberately instead of accidentally.

I added building-level registration and disable helpers, switched the player hold action to use that shared path, and changed the spawn paths so a building only gets one kill EH and its disabled flags are reset correctly on reuse. The cleanup function now walks every installation registered on that building, removes each objective entry, emits destroy events per installation type, and clears shared action-anchor metadata.

 I made the AI auto-disable path dedupe by building and call the same helper. That keeps player and AI behavior aligned.

Result: if multiple installations share the same building or anchor set, disabling one now explicitly dismantles all colocated installations, so you do not end up with a stranded second interaction.