### PR TITLE
Objective object spawn CHANCE

### DIFF
--- a/addons/civ_placement/CfgVehicles.hpp
+++ b/addons/civ_placement/CfgVehicles.hpp
@@ -293,6 +293,13 @@ class CfgVehicles {
                                 tooltip      = "$STR_ALIVE_OBJECTIVE_OBJECTS_COUNT_COMMENT";
                                 defaultValue = """0""";
                         };
+                        class objectiveObjectsChance : Edit
+                        {
+                                property     = "ALiVE_civ_placement_objectiveObjectsChance";
+                                displayName  = "$STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE";
+                                tooltip      = "$STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE_COMMENT";
+                                defaultValue = """100""";
+                        };
                         class objectiveObjectsBehaviour : Combo
                         {
                                 property     = "ALiVE_civ_placement_objectiveObjectsBehaviour";

--- a/addons/civ_placement/fnc_CP.sqf
+++ b/addons/civ_placement/fnc_CP.sqf
@@ -1488,7 +1488,9 @@ switch(_operation) do {
             private _objCountStr_CP = [_logic, "objectiveObjectsCount"] call MAINCLASS;
             private _objCount_CP = if (typeName _objCountStr_CP == "STRING" && {_objCountStr_CP != ""}) then { parseNumber _objCountStr_CP } else { 0 };
             private _objBehaviour_CP = [_logic, "objectiveObjectsBehaviour"] call MAINCLASS;
-            private _countObjectiveObjects_CP = [_logic, position _logic, 250, _objCount_CP, _objBehaviour_CP, _debugCP] call ALiVE_fnc_spawnObjectiveObjects;
+            private _objChanceStr_CP = [_logic, "objectiveObjectsChance"] call MAINCLASS;
+            private _objChance_CP = if (typeName _objChanceStr_CP == "STRING" && {_objChanceStr_CP != ""}) then { parseNumber _objChanceStr_CP } else { 100 };
+            private _countObjectiveObjects_CP = [_logic, position _logic, 250, _objCount_CP, _objBehaviour_CP, _objChance_CP, _debugCP] call ALiVE_fnc_spawnObjectiveObjects;
             if (_debugCP) then {
                 ["CP - Objective objects placed: %1 of %2 (behaviour=%3)",
                     _countObjectiveObjects_CP, _objCount_CP, _objBehaviour_CP] call ALiVE_fnc_dump;

--- a/addons/civ_placement_custom/CfgVehicles.hpp
+++ b/addons/civ_placement_custom/CfgVehicles.hpp
@@ -116,6 +116,13 @@ class CfgVehicles {
                     tooltip      = "$STR_ALIVE_OBJECTIVE_OBJECTS_COUNT_COMMENT";
                     defaultValue = """0""";
             };
+            class objectiveObjectsChance : Edit
+            {
+                    property     = "ALiVE_civ_placement_custom_objectiveObjectsChance";
+                    displayName  = "$STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE";
+                    tooltip      = "$STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE_COMMENT";
+                    defaultValue = """100""";
+            };
             class objectiveObjectsBehaviour : Combo
             {
                     property     = "ALiVE_civ_placement_custom_objectiveObjectsBehaviour";

--- a/addons/civ_placement_custom/fnc_CPC.sqf
+++ b/addons/civ_placement_custom/fnc_CPC.sqf
@@ -1029,7 +1029,9 @@ switch (_operation) do {
             private _objCountStr_CPC = [_logic, "objectiveObjectsCount"] call MAINCLASS;
             private _objCount_CPC = if (typeName _objCountStr_CPC == "STRING" && {_objCountStr_CPC != ""}) then { parseNumber _objCountStr_CPC } else { 0 };
             private _objBehaviour_CPC = [_logic, "objectiveObjectsBehaviour"] call MAINCLASS;
-            private _countObjectiveObjects_CPC = [_logic, _position, _objSizeRadius_CPC, _objCount_CPC, _objBehaviour_CPC, _debug] call ALiVE_fnc_spawnObjectiveObjects;
+            private _objChanceStr_CPC = [_logic, "objectiveObjectsChance"] call MAINCLASS;
+            private _objChance_CPC = if (typeName _objChanceStr_CPC == "STRING" && {_objChanceStr_CPC != ""}) then { parseNumber _objChanceStr_CPC } else { 100 };
+            private _countObjectiveObjects_CPC = [_logic, _position, _objSizeRadius_CPC, _objCount_CPC, _objBehaviour_CPC, _objChance_CPC, _debug] call ALiVE_fnc_spawnObjectiveObjects;
             if (_debug) then {
                 ["CPC - Objective objects placed: %1 of %2 (radius=%3 behaviour=%4)",
                     _countObjectiveObjects_CPC, _objCount_CPC, _objSizeRadius_CPC, _objBehaviour_CPC] call ALiVE_fnc_dump;

--- a/addons/main/fnc_spawnObjectiveObjects.sqf
+++ b/addons/main/fnc_spawnObjectiveObjects.sqf
@@ -53,6 +53,12 @@ Parameters:
     _count       : SCALAR - how many objects to spawn. <=0 = skip.
     _behaviour   : STRING - "clustered" / "dispersed" / "perimeter".
                             Empty / unrecognised falls back to "dispersed".
+    _chance      : SCALAR - per-objective spawn chance, 0-100. One roll
+                            decides whether THIS objective gets its objective
+                            objects at all: pass = spawn the full _count,
+                            fail = spawn nothing. >=100 always passes (default
+                            / redundancy for modules that never set it); <=0
+                            never spawns.
     _debug       : BOOL   - whether to log spawn results via ALiVE_fnc_dump
 
 Returns:
@@ -68,11 +74,23 @@ params [
     ["_baseRadius", 150, [0]],
     ["_count", 0, [0]],
     ["_behaviour", "dispersed", [""]],
+    ["_chance", 100, [0]],
     ["_debug", false, [false]]
 ];
 
 if (isNull _logic) exitWith { 0 };
 if (_count <= 0) exitWith { 0 };
+
+// #875 - per-objective spawn gate. One roll decides whether THIS objective
+// gets its objective objects at all. _chance >= 100 short-circuits the RNG so
+// behaviour is identical to the pre-gate code path (default / redundancy for
+// modules that never set the attribute). _chance <= 0 never spawns.
+if (_chance <= 0 || {_chance < 100 && {random 100 >= _chance}}) exitWith {
+    if (_debug) then {
+        ["ALiVE_fnc_spawnObjectiveObjects: objective skipped by chance gate (chance=%1%%)", _chance] call ALiVE_fnc_dump;
+    };
+    0
+};
 
 private _raw = _logic getVariable ["objectiveObjects", ""];
 if (typeName _raw != "STRING" || {_raw == ""}) exitWith { 0 };

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -162,6 +162,26 @@
     <Russian>Сколько декоративных объектов создать на цели, выбранных случайно из пула селектора Объектов цели. По умолчанию 0 (отключено - декорации не создаются). Выборка с возвратом, поэтому маленький пул с большим количеством означает появление дубликатов.</Russian>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
+<Key ID="STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE">
+    <English>Objective Spawn Chance %</English>
+    <Chinese>目標生成機率 %</Chinese>
+    <Chinesesimp>目标生成几率 %</Chinesesimp>
+    <Spanish>Probabilidad de aparición del objetivo %</Spanish>
+    <French>Chance d'apparition de l'objectif %</French>
+    <Portuguese>Chance de aparição do objetivo %</Portuguese>
+    <Russian>Шанс появления на цели %</Russian>
+</Key>
+<!-- AI-translated; native-speaker review welcome -->
+<Key ID="STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE_COMMENT">
+    <English>Percentage chance (0-100) that this objective spawns its objective objects at all. Rolled once per objective: on success the full Spawn Objective Units count is placed; on failure none are. Default 100 (always spawn). Independent of the count and picker settings.</English>
+    <Chinese>此目標生成其目標物件的百分比機率（0-100）。每個目標擲骰一次：成功時放置完整的生成目標單位數量；失敗時不放置任何物件。預設為100（總是生成）。與數量和選擇器設定無關。</Chinese>
+    <Chinesesimp>此目标生成其目标物件的百分比几率（0-100）。每个目标掷骰一次：成功时放置完整的生成目标单位数量；失败时不放置任何物件。默认为100（总是生成）。与数量和选择器设定无关。</Chinesesimp>
+    <Spanish>Probabilidad porcentual (0-100) de que este objetivo genere sus objetos del objetivo. Se tira una vez por objetivo: si tiene éxito se coloca el conteo completo de Generar unidades del objetivo; si falla no se coloca ninguno. Por defecto 100 (siempre generar). Independiente de los ajustes de conteo y selector.</Spanish>
+    <French>Probabilité en pourcentage (0-100) que cet objectif génère ses objets d'objectif. Tirée une fois par objectif : en cas de succès, le nombre complet d'Apparition unités d'objectif est placé ; en cas d'échec, aucun. Par défaut 100 (toujours générer). Indépendant des réglages de nombre et du sélecteur.</French>
+    <Portuguese>Chance percentual (0-100) de este objetivo gerar seus objetos do objetivo. Sorteada uma vez por objetivo: em caso de sucesso, a contagem completa de Gerar unidades do objetivo é colocada; em caso de falha, nenhuma. Padrão 100 (sempre gerar). Independente das configurações de contagem e seletor.</Portuguese>
+    <Russian>Процентный шанс (0-100), что эта цель вообще создаст свои объекты цели. Бросок один раз на цель: при успехе размещается полное количество Создать единицы цели; при неудаче - ни одного. По умолчанию 100 (всегда создавать). Независимо от настроек количества и селектора.</Russian>
+</Key>
+<!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_OBJECTIVE_OBJECTS_BEHAVIOUR">
     <English>Objective Behaviour</English>
     <Chinese>目標行為</Chinese>

--- a/addons/mil_ato/CfgVehicles.hpp
+++ b/addons/mil_ato/CfgVehicles.hpp
@@ -176,6 +176,13 @@ class CfgVehicles
                         tooltip      = "$STR_ALIVE_OBJECTIVE_OBJECTS_COUNT_COMMENT";
                         defaultValue = """0""";
                 };
+                class objectiveObjectsChance : Edit
+                {
+                        property     = "ALiVE_mil_ato_objectiveObjectsChance";
+                        displayName  = "$STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE";
+                        tooltip      = "$STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE_COMMENT";
+                        defaultValue = """100""";
+                };
                 class objectiveObjectsBehaviour : Combo
                 {
                         property     = "ALiVE_mil_ato_objectiveObjectsBehaviour";

--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -1773,7 +1773,9 @@ switch(_operation) do {
             private _objCountStr_ATO = [_logic, "objectiveObjectsCount"] call MAINCLASS;
             private _objCount_ATO = if (typeName _objCountStr_ATO == "STRING" && {_objCountStr_ATO != ""}) then { parseNumber _objCountStr_ATO } else { 0 };
             private _objBehaviour_ATO = [_logic, "objectiveObjectsBehaviour"] call MAINCLASS;
-            private _countObjectiveObjects_ATO = [_logic, position _logic, 350, _objCount_ATO, _objBehaviour_ATO, _debug] call ALiVE_fnc_spawnObjectiveObjects;
+            private _objChanceStr_ATO = [_logic, "objectiveObjectsChance"] call MAINCLASS;
+            private _objChance_ATO = if (typeName _objChanceStr_ATO == "STRING" && {_objChanceStr_ATO != ""}) then { parseNumber _objChanceStr_ATO } else { 100 };
+            private _countObjectiveObjects_ATO = [_logic, position _logic, 350, _objCount_ATO, _objBehaviour_ATO, _objChance_ATO, _debug] call ALiVE_fnc_spawnObjectiveObjects;
             if (_debug) then {
                 ["ATO %1 - Objective objects placed: %2 of %3 (behaviour=%4)",
                     _logic, _countObjectiveObjects_ATO, _objCount_ATO, _objBehaviour_ATO] call ALiVE_fnc_dump;

--- a/addons/mil_placement/CfgVehicles.hpp
+++ b/addons/mil_placement/CfgVehicles.hpp
@@ -209,6 +209,13 @@ class CfgVehicles {
                                 tooltip      = "$STR_ALIVE_OBJECTIVE_OBJECTS_COUNT_COMMENT";
                                 defaultValue = """0""";
                         };
+                        class objectiveObjectsChance : Edit
+                        {
+                                property     = "ALiVE_mil_placement_objectiveObjectsChance";
+                                displayName  = "$STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE";
+                                tooltip      = "$STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE_COMMENT";
+                                defaultValue = """100""";
+                        };
                         class objectiveObjectsBehaviour : Combo
                         {
                                 property     = "ALiVE_mil_placement_objectiveObjectsBehaviour";

--- a/addons/mil_placement/fnc_MP.sqf
+++ b/addons/mil_placement/fnc_MP.sqf
@@ -1039,7 +1039,9 @@ switch(_operation) do {
             private _objCountStr_MP = [_logic, "objectiveObjectsCount"] call MAINCLASS;
             private _objCount_MP = if (typeName _objCountStr_MP == "STRING" && {_objCountStr_MP != ""}) then { parseNumber _objCountStr_MP } else { 0 };
             private _objBehaviour_MP = [_logic, "objectiveObjectsBehaviour"] call MAINCLASS;
-            private _countObjectiveObjects_MP = [_logic, position _logic, 250, _objCount_MP, _objBehaviour_MP, _debug] call ALiVE_fnc_spawnObjectiveObjects;
+            private _objChanceStr_MP = [_logic, "objectiveObjectsChance"] call MAINCLASS;
+            private _objChance_MP = if (typeName _objChanceStr_MP == "STRING" && {_objChanceStr_MP != ""}) then { parseNumber _objChanceStr_MP } else { 100 };
+            private _countObjectiveObjects_MP = [_logic, position _logic, 250, _objCount_MP, _objBehaviour_MP, _objChance_MP, _debug] call ALiVE_fnc_spawnObjectiveObjects;
             if (_debug) then {
                 ["MP [%1] - Objective objects placed: %2 of %3 (behaviour=%4)",
                     _faction, _countObjectiveObjects_MP, _objCount_MP, _objBehaviour_MP] call ALiVE_fnc_dump;

--- a/addons/mil_placement_custom/CfgVehicles.hpp
+++ b/addons/mil_placement_custom/CfgVehicles.hpp
@@ -198,6 +198,13 @@ class CfgVehicles {
                                 tooltip      = "$STR_ALIVE_OBJECTIVE_OBJECTS_COUNT_COMMENT";
                                 defaultValue = """0""";
                         };
+                        class objectiveObjectsChance : Edit
+                        {
+                                property     = "ALiVE_mil_placement_custom_objectiveObjectsChance";
+                                displayName  = "$STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE";
+                                tooltip      = "$STR_ALIVE_OBJECTIVE_OBJECTS_CHANCE_COMMENT";
+                                defaultValue = """100""";
+                        };
                         class objectiveObjectsBehaviour : Combo
                         {
                                 property     = "ALiVE_mil_placement_custom_objectiveObjectsBehaviour";

--- a/addons/mil_placement_custom/fnc_CMP.sqf
+++ b/addons/mil_placement_custom/fnc_CMP.sqf
@@ -1476,7 +1476,9 @@ switch(_operation) do {
             private _objCountStr = [_logic, "objectiveObjectsCount"] call MAINCLASS;
             private _objCount = if (typeName _objCountStr == "STRING" && {_objCountStr != ""}) then { parseNumber _objCountStr } else { 0 };
             private _objBehaviour = [_logic, "objectiveObjectsBehaviour"] call MAINCLASS;
-            private _countObjectiveObjects = [_logic, _position, _objSizeRadius, _objCount, _objBehaviour, _debug] call ALiVE_fnc_spawnObjectiveObjects;
+            private _objChanceStr = [_logic, "objectiveObjectsChance"] call MAINCLASS;
+            private _objChance = if (typeName _objChanceStr == "STRING" && {_objChanceStr != ""}) then { parseNumber _objChanceStr } else { 100 };
+            private _countObjectiveObjects = [_logic, _position, _objSizeRadius, _objCount, _objBehaviour, _objChance, _debug] call ALiVE_fnc_spawnObjectiveObjects;
             if (_debug) then {
                 ["CMP [%1] - Objective objects placed: %2 of %3 (radius=%4 behaviour=%5)",
                     _faction, _countObjectiveObjects, _objCount, _objSizeRadius, _objBehaviour] call ALiVE_fnc_dump;


### PR DESCRIPTION
## Summary

Objective objects (radars, antennas, jammers, etc. — #875) previously spawned at **every** objective with 100% certainty. This adds a per-objective **% spawn chance** so mission makers can make only *some* objectives carry these objects.

- New **"Objective Spawn Chance %"** Edit attribute (default `100`) on all five objective-object modules.
- Shared spawner `ALiVE_fnc_spawnObjectiveObjects` gains a `_chance` parameter. One roll per objective gates the whole objective: pass → spawn the full configured count as before, fail → spawn nothing.

## Roll behaviour

Per-objective gate (single roll), not per-object — an objective either gets its full set or none.

## Redundancy / backwards compatibility

Four layers keep existing behaviour identical when the attribute isn't set:

1. New `_chance` parameter defaults to `100`.
2. Each call site falls back to `100` when the Eden attribute is blank/unset.
3. Eden `defaultValue = "100"`.
4. `_chance >= 100` short-circuits the RNG entirely.

## Files changed

| Area | Files |
|---|---|
| Spawner | `addons/main/fnc_spawnObjectiveObjects.sqf` |
| Localization | `addons/main/stringtable.xml` (2 new keys) |
| Eden attributes | `CfgVehicles.hpp` × 5 (mil_placement, mil_placement_custom, civ_placement, civ_placement_custom, mil_ato) |
| Call sites | `fnc_MP/CMP/CP/CPC/ATO.sqf` |


Should resolve #914 