### PR TITLE
Update instructions for creating and deleting Advanced Markers

### DIFF
--- a/addons/sys_marker/fnc_marker.sqf
+++ b/addons/sys_marker/fnc_marker.sqf
@@ -301,7 +301,7 @@ switch (_operation) do {
                             _display = findDisplay _display;
                             _control = _display displayCtrl MAP_CONTROL;
                             _control ctrlAddEventHandler ["MouseButtonClick", "[ALiVE_SYS_marker,'mouseButton',[player, _this]] call ALiVE_fnc_marker;"];
-                            _control ctrlAddEventHandler ["MouseButtonDblClick", "if !(ALIVE_SYS_MARKER_HINT) then { hintSilent 'Only ALIVE Advanced Markers will be stored. Default BIS markers are not supported by ALIVE. CTRL-MOUSE BUTTON to create an Advanced Marker.'; ALIVE_SYS_MARKER_HINT = true;};"];
+                            _control ctrlAddEventHandler ["MouseButtonDblClick", "if !(ALIVE_SYS_MARKER_HINT) then { hintSilent 'Only ALIVE Advanced Markers will be stored when persistent saving. Default BIS markers will not be stored by ALIVE. CTRL-ALT-LEFT MOUSE BUTTON to create an Advanced Marker. CTRL-ALT-RIGHT MOUSE BUTTON to delete an Advanced Marker.'; ALIVE_SYS_MARKER_HINT = true;};"];
                             _control ctrlAddEventHandler ["draw", "[ALiVE_SYS_marker,'draw',[player, _this]] call ALiVE_fnc_marker;"];
                             _control ctrlAddEventHandler ["MouseMoving", {[ALiVE_SYS_marker,"mouseMoving",[player, _this]] call ALiVE_fnc_marker;}];
 
@@ -342,7 +342,7 @@ switch (_operation) do {
 
                     _control = _display displayCtrl MAP_CONTROL;
                     _control ctrlAddEventHandler ["MouseButtonClick", "[ALiVE_SYS_marker,'mouseButton',[player, _this]] call ALiVE_fnc_marker;"];
-                    _control ctrlAddEventHandler ["MouseButtonDblClick", "if !(ALIVE_SYS_MARKER_HINT) then { hintSilent 'Only ALIVE Advanced Markers will be stored. Default BIS markers are not supported by ALIVE. CTRL-MOUSE BUTTON to create an Advanced Marker.'; ALIVE_SYS_MARKER_HINT = true;};"];
+                    _control ctrlAddEventHandler ["MouseButtonDblClick", "if !(ALIVE_SYS_MARKER_HINT) then { hintSilent 'Only ALIVE Advanced Markers will be stored when persistent saving. Default BIS markers will not be stored by ALIVE. CTRL-ALT-LEFT MOUSE BUTTON to create an Advanced Marker. CTRL-ALT-RIGHT MOUSE BUTTON to delete an Advanced Marker.'; ALIVE_SYS_MARKER_HINT = true;};"];
                     _control ctrlAddEventHandler ["draw", "[ALiVE_SYS_marker,'draw',[player, _this]] call ALiVE_fnc_marker;"];
                     _control ctrlAddEventHandler ["MouseMoving", {[ALiVE_SYS_marker,"mouseMoving",[player, _this]] call ALiVE_fnc_marker;}];
 


### PR DESCRIPTION
The purpose of this change is to bring clarity and make corrections for the use of ALiVE Advanced Markers. 

Currently, when a user double clicks on the map, a message pops up warning the user that vanilla BIS markers are not supported by ALiVE. It instructs the user to press CTRL and left click to place an Advanced Marker, which is incorrect, and never tells the user how to delete Advanced Markers.

This update informs the user of the correct controls for creating an Advanced Marker (CTRL + ALT + left click), informs the user how to delete an Advanced Marker (CTRL + ALT + right click), and brings better clarity for the purpose of the message.