### PR TITLE
[MIL_OPCOM] Call-for-fire rate lever reads the key artillery publishes

### DIFF
--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -943,7 +943,9 @@ switch (_operation) do {
         // cooldown, independent of the 90s maneuver cooldown above. [0,0] (Normal,
         // or no artillery module) skips this block entirely - maneuver behaviour
         // is unchanged, so this is additive and default-off.
-        private _artyRate = missionNamespace getVariable [format ["ALIVE_MilArtillery_requestRate_%1", toUpper str _side], [0,0]];
+        // _side is already the side TEXT here ("EAST"), so str would wrap it in
+        // quote characters and build a key the artillery module never publishes
+        private _artyRate = missionNamespace getVariable [format ["ALIVE_MilArtillery_requestRate_%1", toUpper _side], [0,0]];
         if ((_artyRate select 0) > 0 && {["ALiVE_mil_artillery"] call ALiVE_fnc_IsModuleAvailable}) then {
             private _artyMax = _artyRate select 0;
             private _artyCd = _artyRate select 1;


### PR DESCRIPTION
## What

One-token fix in `fnc_OPCOM.sqf`: the call-for-fire rate read builds its key with `toUpper str _side`, but `_side` at that point is already the side text (`"EAST"`), set from `ALiVE_fnc_sideToSideText` at OPCOM init and fetched off the handler hash in `attackentity`. `str` on a string wraps it in quote characters, so the read looks up `ALIVE_MilArtillery_requestRate_"EAST"` while the artillery module publishes `ALIVE_MilArtillery_requestRate_EAST` (bare side text, `fnc_ARTILLERY.sqf` `resolveSides` → the publish loop).

The keys can never match, the read always falls back to `[0,0]`, and the `> 0` gate below never opens — so the High and Surge "Call-for-fire rate" settings never fan a single extra fire mission. Normal behaviour is unaffected (it is `[0,0]` by design).

## Why reader-side

The publisher's bare-side-text key format matches every other side-keyed global in the codebase, and it is the shape a mission maker would type at the debug console. Fixing the reader keeps that.

## Scope

Exactly one line changed (plus a two-line comment stating the constraint so the `str` doesn't come back). No behaviour change at Normal. Sole publisher and sole reader of this global were both traced — there are no other consumers.

## Known adjacent gap (out of scope)

An artillery module with nothing synced serves every unclaimed side but builds an empty `_final`, so the publish loop writes no rate keys at all and the lever stays inert in that configuration even with this fix. That is a publisher-side issue and belongs in its own change.
