### PR TITLE
[MIL_ATO] Virtual Air Base: fixed wing operations on maps without a runway

### DIFF
--- a/addons/mil_ato/CfgVehicles.hpp
+++ b/addons/mil_ato/CfgVehicles.hpp
@@ -251,6 +251,40 @@ class CfgVehicles
                         defaultValue = """""";
                         typeName = "STRING";
                 };
+                // ---- Virtual air base ----------------------------------------------
+                // For airspaces with no airfield in them at all. The commander needs a
+                // cluster of military buildings to call home; without one it never
+                // starts, and the faction has no air arm for the whole mission. An
+                // ingress point stands in for the field: aircraft wait virtualized
+                // there, launch airborne and return to it.
+                class HDR_INGRESS : ALiVE_ModuleSubTitle { property = "ALiVE_mil_ato_HDR_INGRESS"; displayName = "VIRTUAL AIR BASE"; };
+                class ingressMode : Combo
+                {
+                        property = "ALiVE_mil_ato_ingressMode";
+                        displayName = "$STR_ALIVE_ATO_INGRESS_MODE";
+                        tooltip = "$STR_ALIVE_ATO_INGRESS_MODE_COMMENT";
+                        defaultValue = """off""";
+                        class Values
+                        {
+                            class Off { name = "Off"; value = "off"; default = 1; };
+                            class Fallback { name = "Fallback (no usable airfield)"; value = "fallback"; };
+                        };
+                };
+                class ingressMarker : Edit
+                {
+                        property = "ALiVE_mil_ato_ingressMarker";
+                        displayName = "$STR_ALIVE_ATO_INGRESS_MARKER";
+                        tooltip = "$STR_ALIVE_ATO_INGRESS_MARKER_COMMENT";
+                        defaultValue = """""";
+                        typeName = "STRING";
+                };
+                class ingressCount : Edit
+                {
+                        property     = "ALiVE_mil_ato_ingressCount";
+                        displayName  = "$STR_ALIVE_ATO_INGRESS_COUNT";
+                        tooltip      = "$STR_ALIVE_ATO_INGRESS_COUNT_COMMENT";
+                        defaultValue = """6""";
+                };
                 // ---- Objective Objects (#875) ---------------------------------------
                 class HDR_OBJECTIVES : ALiVE_ModuleSubTitle { property = "ALiVE_mil_ato_HDR_OBJECTIVES"; displayName = "$STR_ALIVE_OBJECTIVE_HDR"; };
                 // Airfield radar arrays are a strong thematic fit for ATO.

--- a/addons/mil_ato/CfgVehicles.hpp
+++ b/addons/mil_ato/CfgVehicles.hpp
@@ -257,7 +257,7 @@ class CfgVehicles
                 // starts, and the faction has no air arm for the whole mission. An
                 // ingress point stands in for the field: aircraft wait virtualized
                 // there, launch airborne and return to it.
-                class HDR_INGRESS : ALiVE_ModuleSubTitle { property = "ALiVE_mil_ato_HDR_INGRESS"; displayName = "VIRTUAL AIR BASE"; };
+                class HDR_INGRESS : ALiVE_ModuleSubTitle { property = "ALiVE_mil_ato_HDR_INGRESS"; displayName = "$STR_ALIVE_ATO_INGRESS_HDR"; };
                 class ingressMode : Combo
                 {
                         property = "ALiVE_mil_ato_ingressMode";

--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -5416,11 +5416,30 @@ switch(_operation) do {
                                             };
                                         };
 
+                                        // Is the aircraft standing in its own place? For one
+                                        // that belongs to a real airfield this is a point in
+                                        // three dimensions and is left exactly as it was.
+                                        //
+                                        // For one from the Virtual Air Base its home is an XY
+                                        // point on the map. The height it comes back at is
+                                        // whatever the despawn snapshot happened to record -
+                                        // near ground over land, six hundred metres over water
+                                        // - so measuring in three dimensions would hang the
+                                        // answer on a number nothing sets deliberately, and an
+                                        // aircraft recovered over the sea would never read as
+                                        // home again. Slots sit forty metres apart, so fifteen
+                                        // metres in plan still picks out one aircraft's own.
+                                        private _atHome = if ([_aircraft,"virtualBase",false] call ALiVE_fnc_hashGet) then {
+                                            _position distance2D _currentPosition < 15
+                                        } else {
+                                            _position distance _currentPosition < 15
+                                        };
+
                                         // Don't reroute an aircraft twice
                                         if !([_aircraft,"reroute", false] call ALiVE_fnc_hashGet) then {
 
                                             // If parked and not doing anything add, if on CAP and request is DCA,CAS,SEAD then reroute, if its CAS and currently on CAS don't reroute - make sure aircraft is fit for purpose
-                                            if ( ( ((_position distance _currentPosition < 15) && _currentOp == "") || (_currentOp == "CAP" && _eventType in ["DCA","CAS","SEAD"]) || (_currentOp != "CAS" && _eventType == "CAS") ) && (_fuel > _eventMinFuel && _ammo > _eventMinWeap && _damage < 0.5)) then {
+                                            if ( ( (_atHome && _currentOp == "") || (_currentOp == "CAP" && _eventType in ["DCA","CAS","SEAD"]) || (_currentOp != "CAS" && _eventType == "CAS") ) && (_fuel > _eventMinFuel && _ammo > _eventMinWeap && _damage < 0.5)) then {
 
                                                 [_aircraft,"currentPos",_currentPosition] call ALiVE_fnc_hashSet;
                                                 [_aircraft,"profileID",_x] call ALiVE_fnc_hashSet;
@@ -7503,12 +7522,27 @@ switch(_operation) do {
                         // The recall can also fire while the aircraft is still in the
                         // air, with the engine shut down a few lines above, so without
                         // this it is left falling.
-                        private _playerAboard = (crew _vehicle) findIf {isPlayer _x};
-                        if (!isNull _vehicle && {alive _vehicle} && {_playerAboard < 0}) then {
-                            _vehicle setDir _startDir;
-                            _vehicle setPosATL [_startPosition select 0, _startPosition select 1, (_startPosition select 2) + 1];
-                            _vehicle setVectorUp [0,0,1];
-                            _vehicle setVelocity [0,0,0];
+                        // Nullity is settled by the outer test before anything asks the
+                        // aircraft a question about itself.
+                        if (!isNull _vehicle) then {
+
+                            private _playerAboard = (crew _vehicle) findIf {isPlayer _x};
+
+                            if (alive _vehicle && {_playerAboard < 0}) then {
+                                _vehicle setDir _startDir;
+
+                                // Over water there is no ground to stand the aircraft on
+                                // and no settled meaning for a height above terrain, so
+                                // put it up where the launch leg puts it and let it sit
+                                // there for the few seconds before the profile system
+                                // takes it back. Should the sea claim it first, the slot
+                                // rebuilds itself - but that is a backstop, not a plan.
+                                private _recoveryHeight = if (surfaceIsWater _startPosition) then {600} else {(_startPosition select 2) + 1};
+
+                                _vehicle setPosATL [_startPosition select 0, _startPosition select 1, _recoveryHeight];
+                                _vehicle setVectorUp [0,0,1];
+                                _vehicle setVelocity [0,0,0];
+                            };
                         };
 
                         // Belt and braces for the case where there is no object to move,

--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -5187,7 +5187,14 @@ switch(_operation) do {
                                         _returnHome = true;
                                     } else {
 
+                                    //
+                                    // A virtual aircraft is left out of this entirely.
+                                    // Its home is a point on the map with no runway data
+                                    // anywhere near it, so the test can only ever answer
+                                    // that it is not an airfield - and the aircraft would
+                                    // be declared stranded on the very spot it belongs.
                                     if (!isNil "ALiVE_fnc_isAirfieldPosition"
+                                        && {!([_aircraft,"virtualBase",false] call ALiVE_fnc_hashGet)}
                                         && {!_liveObjMissing}
                                         && {_currentOp == ""}
                                         && {!_playerOccupied}
@@ -5488,6 +5495,15 @@ switch(_operation) do {
                             };
                         };
 
+                        // A ground takeoff needs a runway, and an aircraft flying from an
+                        // ingress point has none. A player can fly out to the marker and
+                        // watch it, which is exactly the case the check above is for, so
+                        // this has to be settled by where the aircraft lives rather than
+                        // by who is looking at it.
+                        if ([_selectedAsset,"virtualBase",false] call ALiVE_fnc_hashGet) then {
+                            _takeoff = false;
+                        };
+
                         // Add entity profile ID
                         _eventFriendlyProfiles pushback _profileID;
 
@@ -5655,6 +5671,7 @@ switch(_operation) do {
                 private _aircraftReady = [_aircraft,"ready",false] call ALiVE_fnc_hashGet;
                 private _isOnCarrier = [_aircraft,"isOnCarrier",false] call ALiVE_fnc_hashGet;
                 private _isPlane = _vehicleClass iskindof "Plane" && (_isVTOL < 3);
+                private _virtualBase = [_aircraft,"virtualBase",false] call ALiVE_fnc_hashGet;
 
                 private _count = [_logic, "checkEvent", _event] call MAINCLASS;
 
@@ -5698,7 +5715,11 @@ switch(_operation) do {
                 if !(_aircraftReady) then {
 
                     // Prep aircraft (launch if not spawned)
-                    if (_takeoff) then {
+                    // A virtual aircraft never takes the runway branch - the tasking
+                    // already refuses to ask it for a ground takeoff - but the runway
+                    // lock, the catapult search and the ILS taxi lookup all live in
+                    // there, so say so here rather than rely on that holding.
+                    if (_takeoff && !_virtualBase) then {
 
                         private _airportBusy = false;
                         private _airportID = 0;
@@ -6252,7 +6273,14 @@ switch(_operation) do {
                                 private _taxiDir = [_profile,"direction"] call ALiVE_fnc_hashGet;
                                 _taxiPosition set [2,300];
 
-                                if (_isPlane) then {
+                                // Not for a virtual aircraft. It holds no airport
+                                // identifier, so the default here would go and find the
+                                // nearest real airfield and launch the sortie from there
+                                // instead - which on most terrains is somewhere the
+                                // faction has never been, and quite possibly the enemy's.
+                                // Launching straight up from the ingress point, which is
+                                // what the parked position above already says, is right.
+                                if (_isPlane && !_virtualBase) then {
                                     // Set position relative to TaxiOff (but 300m up)
                                     private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
                                     private _taxiPositions = [_airportID, "ilsTaxiOff",4,_startPosition] call ALiVE_fnc_getAirportTaxiPos;
@@ -7108,6 +7136,7 @@ switch(_operation) do {
                 private _vehicleClass = [_aircraft,"vehicleClass"] call ALiVE_fnc_hashGet;
                 private _isVTOL = [_vehicleClass] call ALiVE_fnc_isVTOL;
                 private _isPlane = _vehicleClass iskindof "Plane" && (_isVTOL < 3);
+                private _virtualBase = [_aircraft,"virtualBase",false] call ALiVE_fnc_hashGet;
                 private _count = [_logic, "checkEvent", _event] call MAINCLASS;
 
                 if(_count == 0) exitWith {
@@ -7185,7 +7214,11 @@ switch(_operation) do {
                     _vehicle setVelocity [0,0,0];
 
                     // Set position if plane to taxi position
-                    if (_vehicle iskindOf "Plane") then {
+                    // Never for a virtual aircraft: with no airport identifier of its
+                    // own the lookup falls back to the nearest real field, and the
+                    // returning aircraft would be set down on a taxiway belonging to
+                    // somebody else. It goes back to the ingress point below instead.
+                    if (_vehicle iskindOf "Plane" && !_virtualBase) then {
                         private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
                         private _taxiPositions = [_airportID, "ilsTaxiIn",0,_startPosition] call ALiVE_fnc_getAirportTaxiPos;
 
@@ -7219,6 +7252,18 @@ switch(_operation) do {
                                 private _atoPosition = position _logic;
                                 private _crewpos = +_startPosition;
                                 _crewPos = + _atoPosition;
+
+                                if (_virtualBase) then {
+
+                                    // Aircrew stay with their aircraft at the ingress
+                                    // point. There is nothing out there to walk into, and
+                                    // the module's own position - where the search below
+                                    // sends them - can be the far side of the map, which
+                                    // would march the pilots off across country after
+                                    // every sortie and leave the aircraft without a crew.
+                                    _crewPos = _startPosition getPos [8 + random 8, random 360];
+
+                                } else {
                         				
                         				
                                  // if pilotbuilding is defined
@@ -7281,6 +7326,8 @@ switch(_operation) do {
 											              // DEBUG -------------------------------------------------------------------------------------
                                  };
 
+                                 };
+
                         // tell crew to move to nearest building
                         if (_isOnCarrier) then {
                                 private _bridge = (_startPosition nearObjects ["Land_Carrier_01_island_02_F",700]) select 0;
@@ -7312,10 +7359,31 @@ switch(_operation) do {
 
                     //Move back to original position (safe reposition - guards against hangar detonation)
                     private _startDir = [_aircraft,"startDir"] call ALiVE_fnc_hashGet;
-                    if !(_isOnCarrier) then {
-                        [_vehicle, [_startPosition select 0, _startPosition select 1, (_startPosition select 2) + 1], _startDir] call _fnc_safeReposition;
+                    if (_virtualBase) then {
+
+                        // The safe reposition earns its name by asking the air spawn
+                        // validator for a clear parking spot and then forcing the frame
+                        // down to ground level, which is what keeps an airframe from
+                        // detonating inside its hangar. At an ingress point there is no
+                        // hangar to be inside, and often no ground either - a point
+                        // offshore resolves to sea level, and that is where the aircraft
+                        // would be put down.
+                        //
+                        // Write the profile back to the ingress point instead. That is
+                        // the position the availability test measures against, so this is
+                        // the step that closes the sortie loop and makes the aircraft
+                        // askable for again.
+                        [_profile,"position",_startPosition] call ALiVE_fnc_profileVehicle;
+                        [_profile,"despawnPosition",_startPosition] call ALiVE_fnc_profileVehicle;
+                        [_profile,"direction",_startDir] call ALiVE_fnc_profileVehicle;
+
                     } else {
-                        _vehicle setDir _startDir;
+
+                        if !(_isOnCarrier) then {
+                            [_vehicle, [_startPosition select 0, _startPosition select 1, (_startPosition select 2) + 1], _startDir] call _fnc_safeReposition;
+                        } else {
+                            _vehicle setDir _startDir;
+                        };
                     };
 
                     // Airport is no longer busy - but only release the lock THIS landing took.

--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -1342,6 +1342,24 @@ switch(_operation) do {
 
                 private _position = +([_vehicleProfile,"position"] call ALIVE_fnc_HashGet);
 
+                // Does this airframe belong to the virtual air base? Worked out from
+                // where it is standing rather than taken as a parameter, so every route
+                // into registration gets the same answer: the fleet created at startup,
+                // a replacement the commander builds for itself, an aircraft handed over
+                // by the logistics commander, and the whole roster on a persistent
+                // mission being registered again from a save.
+                //
+                // Everything below that assumes runways, taxiways, hangars and airport
+                // identifiers keys off this one flag.
+                private _virtualBase = false;
+                if (([_logic,"virtualBaseActive"] call MAINCLASS) && {count _position > 1}) then {
+                    private _ingressPos = [_logic,"ingressPos"] call MAINCLASS;
+                    if (count _ingressPos > 1 && {_position distance2D _ingressPos < 500}) then {
+                        _virtualBase = true;
+                    };
+                };
+                [_asset,"virtualBase",_virtualBase] call ALiVE_fnc_hashSet;
+
                 // Adopted aircraft are taken wherever they happen to be standing, and whatever
                 // placed them had no idea aircraft need to taxi past. A parked airframe on the
                 // runway or a taxiway stops every aircraft trying to get out, because the engine
@@ -1354,7 +1372,11 @@ switch(_operation) do {
                 //
                 // Runway and taxiway only: an apron, hardstand or helipad is a proper parking spot
                 // and is left exactly as placed.
-                if (!isNil "ALiVE_fnc_airsideClear" && {count _position > 1}) then {
+                //
+                // Skipped for the virtual air base: there is no runway and no taxiway
+                // out at the ingress point, so the only thing the nudge could do is
+                // move the airframe off the spot it was deliberately put on.
+                if (!isNil "ALiVE_fnc_airsideClear" && {count _position > 1} && {!_virtualBase}) then {
                     private _clearPos = [_position, [1,2]] call ALiVE_fnc_airsideClear;
                     if ((_clearPos distance2D _position) > 1) then {
                         if (_debug) then {
@@ -1392,12 +1414,23 @@ switch(_operation) do {
 
                 if (_vehicleClass iskindof "Plane" && (_isVTOL < 3) ) then {
 
-                    // Get airportID
-                    private _airportID = [_position] call ALiVE_fnc_getNearestAirportID;
-                    [_asset,"airportID",_airportID] call ALiVE_fnc_hashSet;
-                    [_logic,"addRunway",_airportID] call MAINCLASS;
+                    // A virtual aircraft is given no airport identifier at all. The
+                    // nearest one could be half a map away and belong to the other side,
+                    // and every taxi, ILS and runway-lock lookup would then answer
+                    // against a field this aircraft has never been to. Leaving the key
+                    // absent is what tells the sortie cycle to skip those lookups.
+                    if !(_virtualBase) then {
+                        // Get airportID
+                        private _airportID = [_position] call ALiVE_fnc_getNearestAirportID;
+                        [_asset,"airportID",_airportID] call ALiVE_fnc_hashSet;
+                        [_logic,"addRunway",_airportID] call MAINCLASS;
+                    };
 
                 } else {
+
+                    // Kept for the virtual air base too. An invisible pad costs nothing
+                    // and it keeps the rotary landing paths pointed at somewhere the
+                    // aircraft can actually put down.
 
                     // Heli or VTOL?
                     // Get HeliH object
@@ -1472,8 +1505,19 @@ switch(_operation) do {
                                 _crewPos = + _atoPosition;
 
 
+                                if (_virtualBase) then {
+
+                                    // Aircrew live beside their aircraft out at the ingress
+                                    // point. There is nothing out there to look inside, and
+                                    // the module's own position - where the search below
+                                    // would otherwise leave them - can be the far side of
+                                    // the map from the flight line.
+                                    _crewPos = _position getPos [8 + random 8, random 360];
+
+                                } else {
+
                                 if !(_isOnCarrier) then {
-                                
+
                                  // if pilotbuilding is defined
                                  private _pilotbuilding = [_logic, "pilotbuilding"] call MAINCLASS;
                                  
@@ -1538,6 +1582,8 @@ switch(_operation) do {
                                     private _bridge = (_position nearObjects ["Land_Carrier_01_island_02_F",700]) select 0;
                                     _crewPos = ASLtoATL (_bridge modelToWorld [-2.43359,1.98047,0]); // entities are saved as ATL positions
                                     // ["ATO PLACE CREW AT %1 (pos: %2)", _crewpos, _position] call ALiVE_fnc_dump;
+                                };
+
                                 };
 
                                 // Check for no building?

--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -39,6 +39,9 @@ Tupolov & Jman
 #define DEFAULT_FACTION "OPF_F"
 #define DEFAULT_AIRSPACE []
 #define DEFAULT_PILOTBUILDING ""
+#define DEFAULT_INGRESS_MODE "off"
+#define DEFAULT_INGRESS_MARKER ""
+#define DEFAULT_INGRESS_COUNT "6"
 #define DEFAULT_RUNWAYSTARTPOS ""
 #define DEFAULT_RUNWAYENDPOS ""
 #define DEFAULT_RUNWAYWIDTH ""
@@ -309,6 +312,59 @@ ALiVE_fnc_isAntiAir = {
     ];
 
     [_class] call ALiVE_fnc_isAntiAirCapable
+};
+
+// Where a commander with no airfield flies from. Empty array means the virtual
+// air base does not apply to this module, which is the answer for every mission
+// that has not asked for it - so every caller can treat an empty result as
+// "carry on exactly as before".
+//
+// Deliberately a plain lookup with no side effects: it is asked at startup to
+// report a mistyped marker, and again when the commander decides whether it has
+// a base at all, and the two must not be able to disagree.
+ALiVE_fnc_ATOIngressPos = {
+    params [["_logic", objNull, [objNull]]];
+
+    private _result = [];
+
+    if (isNull _logic) exitWith {_result};
+
+    private _mode = toLower ([_logic, "ingressMode"] call MAINCLASS);
+    if !(_mode == "fallback") exitWith {_result};
+
+    private _marker = [_logic, "ingressMarker"] call MAINCLASS;
+    if (_marker == "") exitWith {
+        ["ATO %1 - Warning, Virtual Air Base is set to Fallback but no ingress marker is named, so it cannot take effect. Set this module's Ingress Point Marker.", _logic] call ALiVE_fnc_dumpR;
+        _result
+    };
+
+    // Same test the airspace markers get: a misspelled name would otherwise
+    // survive as far as the position lookup, which answers [0,0,0] and puts the
+    // fleet in the corner of the map with nothing to explain it.
+    if (markerShape _marker == "") exitWith {
+        ["ATO %1 - Warning, ingress marker %2 does not exist. Check the spelling in this module's Ingress Point Marker setting.", _logic, _marker] call ALiVE_fnc_dumpR;
+        _result
+    };
+
+    private _pos = markerPos _marker;
+    _pos set [2, 0];
+
+    // Advisory only, both of them. A point off the edge of the map is almost
+    // certainly a mistake; a point over water is not - offshore reads perfectly
+    // well as aircraft arriving from a carrier or a base across the sea - but it
+    // is worth saying so, because a mission maker who meant to put the fleet on
+    // land will want to know.
+    if ((_pos select 0) < 0 || {(_pos select 0) > worldSize} || {(_pos select 1) < 0} || {(_pos select 1) > worldSize}) then {
+        ["ATO %1 - Warning, ingress marker %2 lies outside the map at %3.", _logic, _marker, _pos] call ALiVE_fnc_dumpR;
+    };
+
+    if (surfaceIsWater _pos) then {
+        ["ATO %1 - Information, ingress marker %2 is over water. Aircraft will still operate from it.", _logic, _marker] call ALiVE_fnc_dumpR;
+    };
+
+    _result = _pos;
+
+    _result
 };
 
 ALiVE_fnc_DrawRunwayBlacklistMarkers = {
@@ -887,6 +943,33 @@ switch(_operation) do {
     };
     case "pilotbuilding": {
         _result = [_logic,_operation,_args,DEFAULT_PILOTBUILDING] call ALIVE_fnc_OOsimpleOperation;
+    };
+    // Whether this commander may stand in a virtual air base for a missing
+    // airfield. "fallback" only takes effect when the airspace holds nothing to
+    // fly from; "off" is the behaviour that has always applied.
+    case "ingressMode": {
+        _result = [_logic,_operation,_args,DEFAULT_INGRESS_MODE] call ALIVE_fnc_OOsimpleOperation;
+
+        // Anything else is a value nobody wrote deliberately - a hand-edited
+        // mission, or a mode from a later version. Say so and fall back to off
+        // rather than leaving the commander in a state that has no meaning. The
+        // corrected value is written back, so this is said once and not on every
+        // subsequent read.
+        if !(toLower _result in ["off","fallback"]) then {
+            ["ATO %1 - Warning, Virtual Air Base mode %2 is not recognised and has been treated as Off.", _logic, str _result] call ALiVE_fnc_dumpR;
+            _result = DEFAULT_INGRESS_MODE;
+            _logic setVariable [_operation, _result];
+        };
+    };
+    // Marker the virtual fleet flies from and returns to. It need not lie inside
+    // the airspace - a point offshore reads as aircraft arriving from elsewhere.
+    case "ingressMarker": {
+        _result = [_logic,_operation,_args,DEFAULT_INGRESS_MARKER] call ALIVE_fnc_OOsimpleOperation;
+    };
+    // How many airframes the ingress point holds. Held as typed and decoded where
+    // it is used, like the other numeric text settings on this module.
+    case "ingressCount": {
+        _result = [_logic,_operation,_args,DEFAULT_INGRESS_COUNT] call ALIVE_fnc_OOsimpleOperation;
     };
     case "runwaystartpos": {
         _result = [_logic,_operation,_args,DEFAULT_RUNWAYSTARTPOS] call ALIVE_fnc_OOsimpleOperation;
@@ -1790,6 +1873,13 @@ switch(_operation) do {
                 [_logic, "airspace", [_marker]] call MAINCLASS;
             };
 
+            // Ask for the ingress point now, while the mission is still starting, so a
+            // marker name that matches nothing is reported here rather than an hour
+            // later when the commander turns out to have no aircraft. The answer is
+            // deliberately not kept: it is worked out again when the base is decided,
+            // and a single copy shared between the two could only ever go stale.
+            [_logic] call ALiVE_fnc_ATOIngressPos;
+
             // DEBUG -------------------------------------------------------------------------------------
             if(_debug) then {
                 ["----------------------------------------------------------------------------------------"] call ALIVE_fnc_dump;
@@ -1807,6 +1897,9 @@ switch(_operation) do {
                 ["ATO - Runway Start Position: %1",[_logic, "runwaystartpos"] call MAINCLASS] call ALiVE_fnc_dump;
                 ["ATO - Runway End Position: %1",[_logic, "runwayendpos"] call MAINCLASS] call ALiVE_fnc_dump;
                 ["ATO - Runway Width: %1",[_logic, "runwaywidth"] call MAINCLASS] call ALiVE_fnc_dump;
+                ["ATO - Virtual Air Base: %1",[_logic, "ingressMode"] call MAINCLASS] call ALiVE_fnc_dump;
+                ["ATO - Ingress Point Marker: %1",[_logic, "ingressMarker"] call MAINCLASS] call ALiVE_fnc_dump;
+                ["ATO - Ingress Fleet Size: %1",[_logic, "ingressCount"] call MAINCLASS] call ALiVE_fnc_dump;
             };
             // DEBUG -------------------------------------------------------------------------------------
 

--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -1016,6 +1016,28 @@ switch(_operation) do {
 
         _result = _args;
     };
+    // Whether this commander ended up standing a virtual air base in for a missing
+    // airfield. Decided once at startup and read all over the sortie cycle, which
+    // has to know not to look for runways, taxiways and hangars that are not there.
+    case "virtualBaseActive": {
+        if (_args isEqualType true) then {
+            _logic setVariable ["virtualBaseActive", _args];
+        } else {
+            _args = _logic getVariable ["virtualBaseActive", false];
+        };
+        if (_args isEqualType "") then {
+            if(_args == "true") then {_args = true;} else {_args = false;};
+            _logic setVariable ["virtualBaseActive", _args];
+        };
+        ASSERT_TRUE(_args isEqualType true,str _args);
+
+        _result = _args;
+    };
+    // The ingress point itself, resolved from the marker at startup. Empty unless a
+    // virtual air base is in use.
+    case "ingressPos": {
+        _result = [_logic,_operation,_args,[]] call ALIVE_fnc_OOsimpleOperation;
+    };
     case "assets": {
         _result = [_logic,_operation,_args,[]] call ALIVE_fnc_OOsimpleOperation;
     };
@@ -1984,10 +2006,6 @@ switch(_operation) do {
                  _airClusters = [(ALIVE_clustersMil select 2), _airspace] call ALIVE_fnc_clustersInsideMarker;
             };
 
-            if (count _airClusters == 0) exitWith {
-                ["ATO - Warning no usable military buildings within airspace found, the ATO module for %1 may be incorrectly configured.", _faction] call ALiVE_fnc_dumpR;
-            };
-
             // Select the nearest cluster to the module or use Aircraft Carrier
             private _position = getposATL _logic;
 
@@ -1996,9 +2014,45 @@ switch(_operation) do {
                 _isCarrier = true;
             };
 
-            // Sort clusters by distance
-            private _tmp = [_airclusters,[_position],{_Input0 distance ([_x,"center",[0,0,0]] call ALiVE_fnc_HashGet)},"ASCEND"] call ALiVE_fnc_SortBy;
-            private _baseCluster = _tmp select 0;
+            // Where this commander operates from when the airspace holds nothing to
+            // fly from. Empty for every mission that has not asked for it.
+            private _ingressPos = [_logic] call ALiVE_fnc_ATOIngressPos;
+            [_logic,"ingressPos",_ingressPos] call MAINCLASS;
+
+            // A carrier is a real base with a real deck, so it settles the question
+            // before the fallback is considered at all.
+            private _virtualBase = (count _airClusters == 0) && {count _ingressPos > 0} && {!_isCarrier};
+            [_logic,"virtualBaseActive",_virtualBase] call MAINCLASS;
+
+            if (count _airClusters == 0 && {!_virtualBase}) exitWith {
+                ["ATO - Warning no usable military buildings within airspace found, the ATO module for %1 may be incorrectly configured.", _faction] call ALiVE_fnc_dumpR;
+            };
+
+            private _baseCluster = [] call ALiVE_fnc_hashCreate;
+
+            if (_virtualBase) then {
+
+                // Nothing on the ground to sort, so describe the base rather than
+                // finding it. Everything downstream asks a cluster for its centre,
+                // its size and its identity, and those three answers are all a
+                // commander flying from an ingress point actually needs.
+                //
+                // The centre is the module's own position, not the marker: the HQ,
+                // the aircrew and the radio all belong where the mission maker put
+                // the module, and the marker is only where the aircraft are.
+                [_baseCluster,"center",_position] call ALiVE_fnc_hashSet;
+                [_baseCluster,"size",150] call ALiVE_fnc_hashSet;
+                [_baseCluster,"nodes",[]] call ALiVE_fnc_hashSet;
+                [_baseCluster,"clusterID",format ["ATO_VIRTUAL_%1", [_logic,"side"] call MAINCLASS]] call ALiVE_fnc_hashSet;
+
+                ["ATO %1 - No usable airfield within the airspace; operating a virtual air base with an ingress point at %2.", _logic, _ingressPos] call ALiVE_fnc_dumpR;
+
+            } else {
+
+                // Sort clusters by distance
+                private _tmp = [_airclusters,[_position],{_Input0 distance ([_x,"center",[0,0,0]] call ALiVE_fnc_HashGet)},"ASCEND"] call ALiVE_fnc_SortBy;
+                _baseCluster = _tmp select 0;
+            };
 
             // Always use the carrier as the base if the module is close to the carrier
             if (_isCarrier) then {
@@ -2199,7 +2253,10 @@ switch(_operation) do {
             // Set the base location
             [_logic,"currentBase", _baseCluster] call MAINCLASS;
 
-            if(count _modules > 0 && !_isCarrier) then {
+            // A virtual base has no ground to hold: its cluster describes the module's
+            // own position and has no nodes. Handing that to the ground commander as a
+            // strategic objective would send troops to garrison an empty field.
+            if(count _modules > 0 && !_isCarrier && !_virtualBase) then {
                 // Tell OPCOM this is a high priority reserve objective
                 private _opcom = selectRandom _modules;
                 private _id = format["OPCOM_%1_objective_%2",[_opcom,"opcomID"] call ALiVE_fnc_hashGet, format["ATO_%1",ceil(random 1000)]];
@@ -2812,6 +2869,99 @@ switch(_operation) do {
                             [_logic,"registerProfile",[_profileID,_baseAirspace]] call MAINCLASS;
                         };
                     } forEach _aprofiles;
+                };
+
+                // With no airfield anywhere in the airspace there is nothing to adopt
+                // and nothing for the block above to park, so the fleet is created at
+                // the ingress point instead. These are ordinary profiles in every
+                // respect - real airframes with real aircrew - they simply sit
+                // virtualized at a point on the map rather than on an apron, and are
+                // released into the air rather than down a runway.
+                if ([_logic,"virtualBaseActive"] call MAINCLASS) then {
+
+                    private _ingressPos = [_logic,"ingressPos"] call MAINCLASS;
+
+                    if (count _ingressPos == 0) then {
+                        ["ATO %1 - Warning, virtual air base is active but the ingress point resolved to nothing, so no aircraft were created.", _logic] call ALiVE_fnc_dumpR;
+                    } else {
+
+                        private _ingressMarker = [_logic,"ingressMarker"] call MAINCLASS;
+                        private _ingressDir = if (markerShape _ingressMarker != "") then {markerDir _ingressMarker} else {0};
+
+                        // Same decode as the other numeric text settings on this module.
+                        // Held to a dozen: past that the fleet stops being a squadron and
+                        // starts being a profile-count problem.
+                        private _ingressCountStr = [_logic,"ingressCount"] call MAINCLASS;
+                        private _ingressCount = if (typeName _ingressCountStr == "STRING" && {_ingressCountStr != ""}) then { (round (parseNumber _ingressCountStr)) max 1 min 12 } else { 6 };
+
+                        private _ingressSide = [_logic, "side"] call MAINCLASS;
+                        private _ingressFaction = [_logic, "faction"] call MAINCLASS;
+                        private _ingressAirspace = _airspace select 0;
+
+                        // Same capability test the adoption gate and the physical
+                        // placement path use: an airframe that resolves to no role is no
+                        // use to the commander however well it flies.
+                        private _ingressClasses = ([0,_ingressFaction,"Plane"] call ALiVE_fnc_findVehicleType) - ALiVE_PLACEMENT_VEHICLEBLACKLIST;
+                        _ingressClasses = _ingressClasses select {count ([_x] call ALiVE_fnc_getAircraftRoles) > 0};
+
+                        // Plenty of factions catalogue no fixed wing aircraft at all.
+                        // Rotary flies from a point on the map just as happily, and a
+                        // commander with helicopters is a great deal better than one with
+                        // nothing.
+                        private _ingressRotary = false;
+                        if (count _ingressClasses == 0) then {
+                            _ingressRotary = true;
+                            _ingressClasses = ([0,_ingressFaction,"Helicopter"] call ALiVE_fnc_findVehicleType) - ALiVE_PLACEMENT_VEHICLEBLACKLIST;
+                            _ingressClasses = _ingressClasses select {count ([_x] call ALiVE_fnc_getAircraftRoles) > 0};
+                        };
+
+                        if (count _ingressClasses == 0) then {
+                            ["ATO %1 - Warning, virtual air base is active but faction %2 has no aircraft that resolve to a role, so none were created.", _logic, _ingressFaction] call ALiVE_fnc_dumpR;
+                        } else {
+
+                            private _ingressProfiles = [];
+
+                            for "_i" from 0 to (_ingressCount - 1) do {
+
+                                // Spread along the line rather than stacked on the marker:
+                                // nothing is watching them while they are virtualized, but
+                                // a player who flies out to the point should see a flight
+                                // line rather than one airframe wearing five others.
+                                private _slotPos = [(_ingressPos select 0) + (_i * 40), _ingressPos select 1, 0];
+                                private _vehicleClass = selectRandom _ingressClasses;
+
+                                if (_ingressRotary) then {
+                                    private _tmp = [_vehicleClass,_ingressSide,_ingressFaction,"CAPTAIN",_slotPos,_ingressDir,false,_ingressFaction,false] call ALIVE_fnc_createProfilesCrewedVehicle;
+                                    {
+                                        if ([_x,"type"] call ALiVE_fnc_hashGet == "entity") then {
+                                            _ingressProfiles pushback ([_x,"profileID"] call ALiVE_fnc_hashGet);
+                                        };
+                                    } forEach _tmp;
+                                } else {
+                                    private _tmp = [_vehicleClass,_ingressSide,_ingressFaction,_slotPos,_ingressDir,false,_ingressFaction] call ALIVE_fnc_createProfileVehicle;
+                                    if !(isNil "_tmp") then {
+                                        _ingressProfiles pushback ([_tmp, "profileID"] call ALIVE_fnc_hashGet);
+                                    };
+                                };
+                            };
+
+                            // No airside nudge on the way in. There is no runway or
+                            // taxiway to be clear of, and the whole point of the ingress
+                            // point is that the aircraft stay exactly where it is.
+                            {
+                                private _profileID = _x;
+                                private _profile = [ALIVE_profileHandler, "getProfile",_profileID] call ALIVE_fnc_profileHandler;
+
+                                if !(isnil "_profile") then {
+                                    [_logic,"registerProfile",[_profileID,_ingressAirspace]] call MAINCLASS;
+                                };
+                            } forEach _ingressProfiles;
+
+                            if (_debug) then {
+                                ["ATO %1 - %2 aircraft created at the ingress point %3 facing %4 (rotary: %5)", _logic, count _ingressProfiles, _ingressPos, round _ingressDir, _ingressRotary] call ALiVE_fnc_dump;
+                            };
+                        };
+                    };
                 };
 
                 // Place drones. Separate from placing crewed aircraft on purpose:

--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -4442,7 +4442,13 @@ switch(_operation) do {
                         private _useLogcom = (["ALiVE_MIL_LOGISTICS"] call ALiVE_fnc_isModuleAvailable)
                             && {!([_asset,"isOnCarrier",false] call ALiVE_fnc_hashGet)}
                             // Set by the sweep after LOGCOM failed us twice - take the proven path.
-                            && {!([_asset,"forceSelfCreate",false] call ALiVE_fnc_hashGet)};
+                            && {!([_asset,"forceSelfCreate",false] call ALiVE_fnc_hashGet)}
+                            // A virtual air base has no airfield for LOGCOM to deliver to -
+                            // it would route the replacement to the HQ and leave it on the
+                            // ground there. The self-create path below rebuilds at the
+                            // asset's own start position, which is the ingress point, and
+                            // registration works the flag out again from where it lands.
+                            && {!([_asset,"virtualBase",false] call ALiVE_fnc_hashGet)};
 
                         if (_useLogcom) then {
 

--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -1434,8 +1434,15 @@ switch(_operation) do {
 
                     // Heli or VTOL?
                     // Get HeliH object
+                    //
+                    // nearestObject has no range limit, so it will happily answer with a
+                    // pad on the other side of the airfield - or, for a flight line whose
+                    // aircraft stand forty metres apart, with the pad just created for the
+                    // aircraft in the next slot. Every airframe then shares one pad and
+                    // they all try to recover onto the same square of ground. Anything
+                    // further off than a pad's own footprint is not this aircraft's pad.
                     private _helipad = nearestObject [_position, "HeliH"];
-                    if (isNull _helipad) then {
+                    if (isNull _helipad || {(_helipad distance2D _position) > 25}) then {
                         // create an invisble helipad
                         _helipad = "Land_HelipadEmpty_F" createvehicle _position;
                     };
@@ -1941,13 +1948,6 @@ switch(_operation) do {
                 [_logic, "airspace", [_marker]] call MAINCLASS;
             };
 
-            // Ask for the ingress point now, while the mission is still starting, so a
-            // marker name that matches nothing is reported here rather than an hour
-            // later when the commander turns out to have no aircraft. The answer is
-            // deliberately not kept: it is worked out again when the base is decided,
-            // and a single copy shared between the two could only ever go stale.
-            [_logic] call ALiVE_fnc_ATOIngressPos;
-
             // DEBUG -------------------------------------------------------------------------------------
             if(_debug) then {
                 ["----------------------------------------------------------------------------------------"] call ALIVE_fnc_dump;
@@ -2278,7 +2278,16 @@ switch(_operation) do {
 
                 } else {
 
-                    _hqBuilding = ([_baseCluster,"nodes"] call ALiVE_fnc_hashGet) select 0;
+                    // A cluster with no nodes answers nil here, and assigning nil deletes
+                    // the variable rather than emptying it - the read a few lines down
+                    // then throws and takes the rest of startup with it, so the commander
+                    // never gets a base at all. The virtual air base is exactly such a
+                    // cluster: it describes a position and has nothing standing on it.
+                    // Leave the objNull it was initialised with instead.
+                    private _nodes = [_baseCluster,"nodes",[]] call ALiVE_fnc_hashGet;
+                    if (count _nodes > 0) then {
+                        _hqBuilding = _nodes select 0;
+                    };
 
                 };
 
@@ -2942,7 +2951,17 @@ switch(_operation) do {
 
                         private _ingressSide = [_logic, "side"] call MAINCLASS;
                         private _ingressFaction = [_logic, "faction"] call MAINCLASS;
+                        // Which airspace the fleet answers to. The module's own position
+                        // is the synthetic base centre, so ask which marker contains it
+                        // the same way the physical path does; the first marker is only
+                        // the fallback for a base that lies outside all of them.
                         private _ingressAirspace = _airspace select 0;
+                        private _ingressBaseCentre = [([_logic, "currentBase"] call MAINCLASS),"center",position _logic] call ALiVE_fnc_hashGet;
+                        {
+                            if (_ingressBaseCentre inArea _x) exitWith {
+                                _ingressAirspace = _x;
+                            };
+                        } forEach _airspace;
 
                         // Same capability test the adoption gate and the physical
                         // placement path use: an airframe that resolves to no role is no
@@ -5699,7 +5718,7 @@ switch(_operation) do {
                     [_event, "state", "eventComplete"] call ALIVE_fnc_hashSet;
                     [_eventQueue, _eventID, _event] call ALIVE_fnc_hashSet;
 
-                    if (_isPlane) then {
+                    if (_isPlane && !_virtualBase) then {
 
                         private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
 
@@ -6258,7 +6277,7 @@ switch(_operation) do {
                                     [_eventQueue, _eventID, _event] call ALIVE_fnc_hashSet;
 
                                     // unlock runway
-                                    if (_isPlane) then {
+                                    if (_isPlane && !_virtualBase) then {
                                         private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
                                         [_logic, "unlockRunway", _airportID] call MAINCLASS;
                                     };
@@ -6655,7 +6674,7 @@ switch(_operation) do {
 
 
                                 // Unlock runway
-                                if (_vehicleClass iskindof "Plane" && (_isVTOL < 3)) then {
+                                if (_vehicleClass iskindof "Plane" && (_isVTOL < 3) && !_virtualBase) then {
                                     private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
                                     [_logic, "unlockRunway", _airportID] call MAINCLASS;
                                 };
@@ -6698,6 +6717,7 @@ switch(_operation) do {
                 private _isVTOL = [_vehicleClass] call ALiVE_fnc_isVTOL;
                 private _isOnCarrier = [_aircraft,"isOnCarrier",false] call ALiVE_fnc_hashGet;
                 private _launched = [_aircraft,"launched", false] call ALiVE_fnc_hashGet;
+                private _virtualBase = [_aircraft,"virtualBase",false] call ALiVE_fnc_hashGet;
                 private _count = [_logic, "checkEvent", _event] call MAINCLASS;
 
                 if(_count == 0) exitWith {
@@ -6710,8 +6730,10 @@ switch(_operation) do {
                     };
 
                     // Unlock runway
-                    private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
-                    [_logic, "unlockRunway", _airportID] call MAINCLASS;
+                    if !(_virtualBase) then {
+                        private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
+                        [_logic, "unlockRunway", _airportID] call MAINCLASS;
+                    };
 
                     // set state to event complete
                     if(_playerRequested) then {
@@ -6747,7 +6769,7 @@ switch(_operation) do {
                 // If aircraft is airborne, unlock runway once
                 if ( (getposATL _vehicle) select 2 > 50 && (getposASL _vehicle) select 2 > 50 && !_launched) then {
                     // Unlock runway now
-                    if (_vehicleClass iskindof "Plane" && (_isVTOL < 3) ) then {
+                    if (_vehicleClass iskindof "Plane" && (_isVTOL < 3) && !_virtualBase) then {
                         private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
                         [_logic, "unlockRunway", _airportID] call MAINCLASS;
                     };
@@ -6998,6 +7020,7 @@ switch(_operation) do {
                 private _vehicleClass = [_aircraft,"vehicleClass"] call ALiVE_fnc_hashGet;
                 private _isVTOL = [_vehicleClass] call ALiVE_fnc_isVTOL;
                 private _isPlane = _vehicleClass iskindof "Plane" && (_isVTOL < 3);
+                private _virtualBase = [_aircraft,"virtualBase",false] call ALiVE_fnc_hashGet;
 
                 private _count = [_logic, "checkEvent", _event] call MAINCLASS;
                 if(_count == 0) exitWith {
@@ -7012,7 +7035,11 @@ switch(_operation) do {
                     };
 
                     // Unlock runway
-                    if (_isPlane ) then {
+                    // Never for a virtual aircraft: it holds no airport identifier, so
+                    // the default would resolve some real field and release a lock this
+                    // aircraft never took - and on a module flying a mix of virtual and
+                    // delivered airframes, that is another aircraft's lock.
+                    if (_isPlane && !_virtualBase) then {
                         private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
                         [_logic, "unlockRunway", _airportID] call MAINCLASS;
                     };
@@ -7036,7 +7063,12 @@ switch(_operation) do {
                     private _playersInRange = [_startPosition, 1000] call ALiVE_fnc_anyPlayersInRange;
 
                     // If players are around then execute landing
-                    if (_playersInRange > 0) then {
+                    // A virtual aircraft always takes the quick path below, watched or
+                    // not. The landing proper needs an airport to lock, to land at and
+                    // to release afterwards, and the one it would find is a real field
+                    // it has no claim on. The quick path sets the aircraft down at the
+                    // ingress point, which is where it belongs either way.
+                    if (_playersInRange > 0 && !_virtualBase) then {
 
                         if (_isPlane) then {
 
@@ -7157,8 +7189,10 @@ switch(_operation) do {
                     };
 
                     // Unlock runway
-                    private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
-                    [_logic, "unlockRunway", _airportID] call MAINCLASS;
+                    if !(_virtualBase) then {
+                        private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
+                        [_logic, "unlockRunway", _airportID] call MAINCLASS;
+                    };
 
                     // set state to event complete
                     [_event, "state", "eventComplete"] call ALIVE_fnc_hashSet;
@@ -7373,12 +7407,31 @@ switch(_operation) do {
                         // detonating inside its hangar. At an ingress point there is no
                         // hangar to be inside, and often no ground either - a point
                         // offshore resolves to sea level, and that is where the aircraft
-                        // would be put down.
+                        // would be put down. So the move is made here instead.
                         //
-                        // Write the profile back to the ingress point instead. That is
-                        // the position the availability test measures against, so this is
-                        // the step that closes the sortie loop and makes the aircraft
-                        // askable for again.
+                        // It has to be the object that moves. A profile's position is a
+                        // snapshot taken from the aircraft at despawn - the profile
+                        // follows the object, never the other way about - so writing the
+                        // profile alone would be overwritten by the aircraft's real
+                        // position the moment it virtualises, and the aircraft would be
+                        // recorded wherever it happened to be when the sortie ended.
+                        //
+                        // The recall can also fire while the aircraft is still in the
+                        // air, with the engine shut down a few lines above, so without
+                        // this it is left falling.
+                        private _playerAboard = (crew _vehicle) findIf {isPlayer _x};
+                        if (!isNull _vehicle && {alive _vehicle} && {_playerAboard < 0}) then {
+                            _vehicle setDir _startDir;
+                            _vehicle setPosATL [_startPosition select 0, _startPosition select 1, (_startPosition select 2) + 1];
+                            _vehicle setVectorUp [0,0,1];
+                            _vehicle setVelocity [0,0,0];
+                        };
+
+                        // Belt and braces for the case where there is no object to move,
+                        // which is the usual one: the aircraft is recovered virtualized
+                        // with nobody watching. The ingress point is the position the
+                        // availability test measures against, so this is the step that
+                        // closes the sortie loop and makes the aircraft askable for again.
                         [_profile,"position",_startPosition] call ALiVE_fnc_profileVehicle;
                         [_profile,"despawnPosition",_startPosition] call ALiVE_fnc_profileVehicle;
                         [_profile,"direction",_startDir] call ALiVE_fnc_profileVehicle;
@@ -7397,7 +7450,7 @@ switch(_operation) do {
                     // through here and unconditionally unlock, releasing a lock still held by an
                     // OUTBOUND plane waiting at ilsTaxiIn for its pilot - the next tasking then
                     // passed the busy gate and teleported a second airframe onto it.
-                    if (_isPlane && {_vehicle getVariable [QGVAR(LANDINGLOCK), false]}) then {
+                    if (_isPlane && !_virtualBase && {_vehicle getVariable [QGVAR(LANDINGLOCK), false]}) then {
                         private _airportID = [_aircraft,"airportID",[_startPosition] call ALiVE_fnc_getNearestAirportID] call ALiVE_fnc_hashGet;
                         // Mark airport as not busy
                         [_logic, "unlockRunway", _airportID] call MAINCLASS;

--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -6363,7 +6363,22 @@ switch(_operation) do {
 
                     } else {
                         // if parked assign crew to vehicle if necessary, if at home move to ilsTaxiOut position at 300 feet, spawn aircraft at speed
-                        if (_startPosition distance _currentPosition < 15) then {
+                        //
+                        // Measured in plan for an aircraft off the Virtual Air Base, for the
+                        // same reason the selection test is: its home is an XY point, and
+                        // the height it sits at is whatever the despawn snapshot recorded -
+                        // six hundred metres when it was recovered over water. Counting that
+                        // height against it says the aircraft is not at home, and with the
+                        // runway branch already closed to virtual aircraft there is then no
+                        // way out at all: neither launch fires, and the sortie sits holding
+                        // its slot for the rest of the mission.
+                        private _atHome = if (_virtualBase) then {
+                            _startPosition distance2D _currentPosition < 15
+                        } else {
+                            _startPosition distance _currentPosition < 15
+                        };
+
+                        if (_atHome) then {
 
                             private _isPlane = _vehicleClass iskindof "Plane" && (_isVTOL < 3);
                             private _profile = [ALIVE_profileHandler, "getProfile",_profileID] call ALIVE_fnc_profileHandler;

--- a/addons/mil_ato/fnc_ATO.sqf
+++ b/addons/mil_ato/fnc_ATO.sqf
@@ -1038,6 +1038,38 @@ switch(_operation) do {
     case "ingressPos": {
         _result = [_logic,_operation,_args,[]] call ALIVE_fnc_OOsimpleOperation;
     };
+    // The Virtual Air Base roster: one entry per slot, [slot, class, profileID],
+    // in slot order.
+    //
+    // Worked out from the aircraft themselves every time it is asked for, and
+    // never written down. A stored copy would be a second account of the same
+    // thing, and the two would part company the first time an aircraft was lost
+    // and rebuilt. It also means the roster is simply correct after a save is
+    // reloaded, because the aircraft come back carrying their own slot numbers.
+    //
+    // This is the inspection point for a mission maker who wants to see what the
+    // commander is actually holding:
+    //   [<module>, "virtualBaseSlots"] call ALIVE_fnc_ATO
+    case "virtualBaseSlots": {
+        private _slots = [];
+        private _slotAssets = [_logic,"assets"] call MAINCLASS;
+
+        {
+            private _slotAsset = [_slotAssets, _x] call ALiVE_fnc_hashGet;
+
+            if !(isNil "_slotAsset") then {
+                private _slotNumber = [_slotAsset,"vabSlot",0] call ALiVE_fnc_hashGet;
+
+                // Aircraft that never came from the virtual air base carry no slot
+                // at all, and a module can hold both kinds at once.
+                if (_slotNumber isEqualType 0 && {_slotNumber > 0}) then {
+                    _slots pushBack [_slotNumber, [_slotAsset,"vehicleClass",""] call ALiVE_fnc_hashGet, _x];
+                };
+            };
+        } forEach (_slotAssets select 1);
+
+        _result = [_slots, [], {_x select 0}, "ASCEND"] call ALiVE_fnc_SortBy;
+    };
     case "assets": {
         _result = [_logic,_operation,_args,[]] call ALIVE_fnc_OOsimpleOperation;
     };
@@ -2984,9 +3016,15 @@ switch(_operation) do {
                             ["ATO %1 - Warning, virtual air base is active but faction %2 has no aircraft that resolve to a role, so none were created.", _logic, _ingressFaction] call ALiVE_fnc_dumpR;
                         } else {
 
+                            // Slot number, profile and airframe type, one entry per
+                            // slot. The base holds a numbered flight line rather than a
+                            // pool: slot 3 is a particular aircraft of a particular
+                            // type, and it stays that way for the rest of the mission.
                             private _ingressProfiles = [];
 
                             for "_i" from 0 to (_ingressCount - 1) do {
+
+                                private _slotNumber = _i + 1;
 
                                 // Spread along the line rather than stacked on the marker:
                                 // nothing is watching them while they are virtualized, but
@@ -2999,13 +3037,13 @@ switch(_operation) do {
                                     private _tmp = [_vehicleClass,_ingressSide,_ingressFaction,"CAPTAIN",_slotPos,_ingressDir,false,_ingressFaction,false] call ALIVE_fnc_createProfilesCrewedVehicle;
                                     {
                                         if ([_x,"type"] call ALiVE_fnc_hashGet == "entity") then {
-                                            _ingressProfiles pushback ([_x,"profileID"] call ALiVE_fnc_hashGet);
+                                            _ingressProfiles pushback [_slotNumber, [_x,"profileID"] call ALiVE_fnc_hashGet, _vehicleClass];
                                         };
                                     } forEach _tmp;
                                 } else {
                                     private _tmp = [_vehicleClass,_ingressSide,_ingressFaction,_slotPos,_ingressDir,false,_ingressFaction] call ALIVE_fnc_createProfileVehicle;
                                     if !(isNil "_tmp") then {
-                                        _ingressProfiles pushback ([_tmp, "profileID"] call ALIVE_fnc_hashGet);
+                                        _ingressProfiles pushback [_slotNumber, [_tmp, "profileID"] call ALIVE_fnc_hashGet, _vehicleClass];
                                     };
                                 };
                             };
@@ -3014,11 +3052,41 @@ switch(_operation) do {
                             // taxiway to be clear of, and the whole point of the ingress
                             // point is that the aircraft stay exactly where it is.
                             {
-                                private _profileID = _x;
+                                _x params ["_slotNumber","_profileID","_slotClass"];
                                 private _profile = [ALIVE_profileHandler, "getProfile",_profileID] call ALIVE_fnc_profileHandler;
 
                                 if !(isnil "_profile") then {
                                     [_logic,"registerProfile",[_profileID,_ingressAirspace]] call MAINCLASS;
+
+                                    // Mark whatever registration actually took on. A
+                                    // crewed helicopter is handed over as its entity, and
+                                    // the aircraft that ends up on the roster is the one
+                                    // underneath it, so the identifier offered here is not
+                                    // necessarily the one the asset is filed against.
+                                    //
+                                    // An airframe registration turned away - no role it
+                                    // could be given - leaves no asset to mark, and so
+                                    // goes unreported below. That is the intended
+                                    // reading: the slot was not filled.
+                                    private _slotVehicleIDs = [_profileID];
+                                    if (([_profile,"type"] call ALiVE_fnc_hashGet) == "entity") then {
+                                        _slotVehicleIDs = [_profile,"vehiclesInCommandOf",[]] call ALiVE_fnc_hashGet;
+                                    };
+
+                                    private _registered = [_logic,"assets"] call MAINCLASS;
+
+                                    {
+                                        private _slotAsset = [_registered, _x] call ALiVE_fnc_hashGet;
+                                        if !(isNil "_slotAsset") then {
+                                            [_slotAsset,"vabSlot",_slotNumber] call ALiVE_fnc_hashSet;
+
+                                            // Logged whether or not debug is on. This is
+                                            // the record of what the commander was given,
+                                            // and it is the only account of it that exists
+                                            // before the first sortie is flown.
+                                            ["ATO %1 - Virtual Air Base slot %2: %3 (%4)", _logic, _slotNumber, _slotClass, _x] call ALiVE_fnc_dumpR;
+                                        };
+                                    } forEach _slotVehicleIDs;
                                 };
                             } forEach _ingressProfiles;
 
@@ -4563,6 +4631,22 @@ switch(_operation) do {
                             // Add aircraft to maintenance
                             if !(_aircraft isEqualType "") then {
                                 [_aircraft,"maintenance",time] call ALiVE_fnc_hashSet;
+                            };
+
+                            // The replacement inherits the lost aircraft's slot. A
+                            // Virtual Air Base slot is a particular airframe rather than
+                            // a space in a pool, and the rebuild above is made from the
+                            // lost aircraft's own class, so the type in a slot holds
+                            // steady however many times it is shot down.
+                            //
+                            // This is the only place the mark has to be reapplied: the
+                            // logistics commander is not offered virtual aircraft at all,
+                            // so every one of them is rebuilt here. Aircraft that came
+                            // from a real airfield carry no slot and fall straight past.
+                            private _lostSlot = [_asset,"vabSlot",0] call ALiVE_fnc_hashGet;
+                            if (_lostSlot isEqualType 0 && {_lostSlot > 0} && {!(_aircraft isEqualType "")}) then {
+                                [_aircraft,"vabSlot",_lostSlot] call ALiVE_fnc_hashSet;
+                                ["ATO %1 - Virtual Air Base slot %2 rebuilt: %3", _logic, _lostSlot, _vehicleClass] call ALiVE_fnc_dumpR;
                             };
 
                             if (_debug) then {

--- a/addons/mil_ato/stringtable.xml
+++ b/addons/mil_ato/stringtable.xml
@@ -68,6 +68,9 @@
 <Key ID="STR_ALIVE_ATO_PILOTBUILDING_COMMENT">
     <English>Classname of a building within 50 m of this module where replacement aircrew appear, for example Land_Cargo_House_V3_F. Leave blank to pick a nearby building automatically. A classname that matches nothing within 50 m puts the crew out in the open at the module's own position, which is worse than leaving it blank.</English>
 </Key>
+<Key ID="STR_ALIVE_ATO_INGRESS_HDR">
+    <English>VIRTUAL AIR BASE</English>
+</Key>
 <Key ID="STR_ALIVE_ATO_INGRESS_MODE">
     <English>Virtual Air Base:</English>
 </Key>
@@ -78,7 +81,7 @@
     <English>Ingress Point Marker:</English>
 </Key>
 <Key ID="STR_ALIVE_ATO_INGRESS_MARKER_COMMENT">
-    <English>Name of a map marker the fleet flies from and returns to. It does not have to sit inside the airspace marker - putting it offshore or over the border reads as aircraft arriving from a base elsewhere. Only used when Virtual Air Base is set to Fallback and no usable airfield was found. A name that matches no marker is reported at mission start and the fallback stays off.</English>
+    <English>Name of a map marker the fleet flies from and returns to. It does not have to sit inside the airspace marker - putting it offshore or over the border reads as aircraft arriving from a base elsewhere. Only used when Virtual Air Base is set to Fallback and no usable airfield was found. A name that matches no marker is reported at mission start and the fallback stays off. Pick open ground: a marker placed on or beside a real airfield elsewhere on the map will park the fleet on that apron, while it still operates virtually and ignores the runway beside it.</English>
 </Key>
 <Key ID="STR_ALIVE_ATO_INGRESS_COUNT">
     <English>Ingress Fleet Size:</English>

--- a/addons/mil_ato/stringtable.xml
+++ b/addons/mil_ato/stringtable.xml
@@ -68,6 +68,24 @@
 <Key ID="STR_ALIVE_ATO_PILOTBUILDING_COMMENT">
     <English>Classname of a building within 50 m of this module where replacement aircrew appear, for example Land_Cargo_House_V3_F. Leave blank to pick a nearby building automatically. A classname that matches nothing within 50 m puts the crew out in the open at the module's own position, which is worse than leaving it blank.</English>
 </Key>
+<Key ID="STR_ALIVE_ATO_INGRESS_MODE">
+    <English>Virtual Air Base:</English>
+</Key>
+<Key ID="STR_ALIVE_ATO_INGRESS_MODE_COMMENT">
+    <English>Lets this commander operate without an airfield. Fallback takes effect only when no usable airfield is found inside the airspace - with a field available it changes nothing. Its aircraft then wait virtualized at the ingress point, launch already airborne and return there, so no runway, taxiway or hangar is needed anywhere on the map.</English>
+</Key>
+<Key ID="STR_ALIVE_ATO_INGRESS_MARKER">
+    <English>Ingress Point Marker:</English>
+</Key>
+<Key ID="STR_ALIVE_ATO_INGRESS_MARKER_COMMENT">
+    <English>Name of a map marker the fleet flies from and returns to. It does not have to sit inside the airspace marker - putting it offshore or over the border reads as aircraft arriving from a base elsewhere. Only used when Virtual Air Base is set to Fallback and no usable airfield was found. A name that matches no marker is reported at mission start and the fallback stays off.</English>
+</Key>
+<Key ID="STR_ALIVE_ATO_INGRESS_COUNT">
+    <English>Ingress Fleet Size:</English>
+</Key>
+<Key ID="STR_ALIVE_ATO_INGRESS_COUNT_COMMENT">
+    <English>How many aircraft the ingress point holds, from 1 to 12. Six by default rather than one or two, because Minimum Aircraft For Offensive Missions (2 by default) suspends offensive tasking once the fleet has shrunk to that size - a small fleet degrades to defensive patrols after a couple of losses and never recovers.</English>
+</Key>
 <Key ID="STR_ALIVE_ATO_RUNWAYSTARTPOS">
     <English>Runway start position:</English>
     <Chinesesimp>跑道起始位置:</Chinesesimp>

--- a/addons/mil_ato/stringtable.xml
+++ b/addons/mil_ato/stringtable.xml
@@ -75,19 +75,19 @@
     <English>Virtual Air Base:</English>
 </Key>
 <Key ID="STR_ALIVE_ATO_INGRESS_MODE_COMMENT">
-    <English>Lets this commander operate without an airfield. Fallback takes effect only when no usable airfield is found inside the airspace - with a field available it changes nothing. Its aircraft then wait virtualized at the ingress point, launch already airborne and return there, so no runway, taxiway or hangar is needed anywhere on the map.</English>
+    <English>Lets this air commander operate without an airfield on the map. Its aircraft fly in from a virtual air base off the map: they launch already airborne from the ingress marker and return there. Fallback takes effect only when no usable airfield is found inside the airspace - with a real airfield available it changes nothing.</English>
 </Key>
 <Key ID="STR_ALIVE_ATO_INGRESS_MARKER">
-    <English>Ingress Point Marker:</English>
+    <English>Virtual Air Base Ingress Marker:</English>
 </Key>
 <Key ID="STR_ALIVE_ATO_INGRESS_MARKER_COMMENT">
-    <English>Name of a map marker the fleet flies from and returns to. It does not have to sit inside the airspace marker - putting it offshore or over the border reads as aircraft arriving from a base elsewhere. Only used when Virtual Air Base is set to Fallback and no usable airfield was found. A name that matches no marker is reported at mission start and the fallback stays off. Pick open ground: a marker placed on or beside a real airfield elsewhere on the map will park the fleet on that apron, while it still operates virtually and ignores the runway beside it.</English>
+    <English>Where aircraft from the off-map base enter and leave the map. Name a marker here. It does not have to sit inside the airspace marker - putting it offshore or over the border reads as aircraft arriving from a base elsewhere. Only used when Virtual Air Base is set to Fallback and no usable airfield was found. A name that matches no marker is reported at mission start and the fallback stays off. Pick open ground: a marker placed on or beside a real airfield elsewhere on the map will park the fleet on that apron, while it still operates virtually and ignores the runway beside it.</English>
 </Key>
 <Key ID="STR_ALIVE_ATO_INGRESS_COUNT">
-    <English>Ingress Fleet Size:</English>
+    <English>Virtual Air Base Slots:</English>
 </Key>
 <Key ID="STR_ALIVE_ATO_INGRESS_COUNT_COMMENT">
-    <English>How many aircraft the ingress point holds, from 1 to 12. Six by default rather than one or two, because Minimum Aircraft For Offensive Missions (2 by default) suspends offensive tasking once the fleet has shrunk to that size - a small fleet degrades to defensive patrols after a couple of losses and never recovers.</English>
+    <English>How many aircraft sit on the off-map airfield, from 1 to 12. Each slot holds a specific airframe, and an aircraft lost on operations is rebuilt into its own slot as the same type. Six by default rather than one or two, because Minimum Aircraft For Offensive Missions (2 by default) suspends offensive tasking once the fleet has shrunk to that size - a small fleet degrades to defensive patrols after a couple of losses and never recovers.</English>
 </Key>
 <Key ID="STR_ALIVE_ATO_RUNWAYSTARTPOS">
     <English>Runway start position:</English>


### PR DESCRIPTION
Implements the fallback case from #961.

At the moment the MACC exits at startup if it can't find any usable military buildings inside its airspace, and on a map with no airfield that means the faction simply has no air arm. This adds a way through: a Virtual Air Base. Set the new module option to Fallback, name a map marker, and when (and only when) no usable airfield is found the commander synthesises a base and operates its fleet from that marker instead of an apron.

The aircraft are ordinary profiles in every respect. They sit virtualized at the marker between sorties, launch through the flying-start branch the module already uses when nobody is watching a parked aircraft (engine-on profile spawn, so planes get the 300m altitude floor and the 200 m/s push from sys_profile, 600m over water), and recover through the existing quick-land path. So there's no new flight logic to maintain. Most of the diff is guarding the code paths that assume an airfield exists: airside clearance, airportID derivation and runway locks, the ilsTaxiOff / ilsTaxiIn repositions, pilot building crew placement, and the safe reposition on recovery (a virtual airframe is flown home by moving the object and letting the profile follow it, since the profile position is a snapshot taken at despawn).

**Module options (default off, existing behaviour unchanged):**
- **Virtual Air Base:** Off / Fallback. Fallback only takes effect when no usable airfield is found.
- **Virtual Air Base Ingress Marker:** where the fleet enters and leaves the map. Doesn't have to be inside the airspace marker; offshore reads well as aircraft arriving from a distant base.
- **Virtual Air Base Slots:** total aircraft held at the off-map base (1-12, default 6). Each slot is a specific airframe of a specific class, logged at startup ("Virtual Air Base slot 3: B_Plane_CAS_01_F"), and a shot-down aircraft is rebuilt into its own slot as the same type. `[<module>, "virtualBaseSlots"] call ALIVE_fnc_ATO` returns the roster for inspection.

**Attrition:** the LOGCOM replacement path is gated off for virtual aircraft (there's no airfield to deliver to); the existing self-create fallback rebuilds them at the marker with the usual maintenance delay. Carriers veto the fallback, so it can't fight with the deck logic. Persistence needs no schema changes; the slot marks ride the asset hashes through save and load.

**Out of scope here:** migrating to a real airfield once one is captured (the fall-forward half of #961). That needs re-entrant base setup and is a separate piece of work.

**Testing:** sqf and config validators pass (baseline identical), and the full sortie cycle, attrition, persistence and bad-marker cases have been desk-checked line by line. My PBO tooling is down at the moment so it hasn't flown in game yet; I'll run the flight tests as soon as it's back. If anyone loads it sooner, the interesting cases are a second sortie from the same airframe, and a player standing near the marker during launch and recovery (especially an offshore marker).

Closes #961 (fallback case).
