### PR TITLE
[AMB_CIV_POPULATION] Scale Civilian Interaction button text with interface size

### DIFF
--- a/addons/amb_civ_population/data/ui/common.hpp
+++ b/addons/amb_civ_population/data/ui/common.hpp
@@ -368,7 +368,7 @@ class CivInteract_RscButton
 	h = 0.039216;
 	shadow = 2;
 	font = "PuristaMedium";
-	sizeEx = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 1)";
+	sizeEx = "0.024 * safezoneH";
 	offsetX = 0.003;
 	offsetY = 0.003;
 	offsetPressedX = 0.000;

--- a/addons/amb_civ_population/data/ui/main.hpp
+++ b/addons/amb_civ_population/data/ui/main.hpp
@@ -139,6 +139,7 @@ class ALiVE_CivilianInteraction {
             y = 0.7916 * safezoneH + safezoneY;
             w = 0.0525 * safezoneW;
             h = 0.028 * safezoneH;
+            sizeEx = "0.021 * safezoneH";
 			colorBackground[] = {0,0,0,0.5};
 			colorActive[] = {0,0,0,0.5};
 		};
@@ -151,6 +152,7 @@ class ALiVE_CivilianInteraction {
             y = 0.7916 * safezoneH + safezoneY;
             w = 0.0525 * safezoneW;
             h = 0.028 * safezoneH;
+            sizeEx = "0.021 * safezoneH";
 			colorBackground[] = {0,0,0,0.5};
 			colorActive[] = {0,0,0,0.5};
 		};
@@ -163,6 +165,7 @@ class ALiVE_CivilianInteraction {
             y = 0.7916 * safezoneH + safezoneY;
             w = 0.0525 * safezoneW;
             h = 0.028 * safezoneH;
+            sizeEx = "0.021 * safezoneH";
 			colorBackground[] = {0,0,0,0.5};
 			colorActive[] = {0,0,0,0.5};
 		};
@@ -175,6 +178,7 @@ class ALiVE_CivilianInteraction {
             y = 0.7916 * safezoneH + safezoneY;
             w = 0.0525 * safezoneW;
             h = 0.028 * safezoneH;
+            sizeEx = "0.021 * safezoneH";
 			colorBackground[] = {0,0,0,0.5};
 			colorActive[] = {0,0,0,0.5};
 		};
@@ -187,6 +191,7 @@ class ALiVE_CivilianInteraction {
             y = 0.7916 * safezoneH + safezoneY;
             w = 0.0525 * safezoneW;
             h = 0.028 * safezoneH;
+            sizeEx = "0.021 * safezoneH";
 			colorBackground[] = {0,0,0,0.5};
 			colorActive[] = {0,0,0,0.5};
 		};
@@ -199,6 +204,7 @@ class ALiVE_CivilianInteraction {
             y = 0.7916 * safezoneH + safezoneY;
             w = 0.0525 * safezoneW;
             h = 0.028 * safezoneH;
+            sizeEx = "0.021 * safezoneH";
 			colorBackground[] = {0,0,0,0.5};
 			colorActive[] = {0,0,0,0.5};
 		};
@@ -211,6 +217,7 @@ class ALiVE_CivilianInteraction {
             y = 0.7916 * safezoneH + safezoneY;
             w = 0.0525 * safezoneW;
             h = 0.028 * safezoneH;
+            sizeEx = "0.021 * safezoneH";
 			colorBackground[] = {0,0,0,0.5};
 			colorActive[] = {0,0,0,0.5};
 		};
@@ -223,6 +230,7 @@ class ALiVE_CivilianInteraction {
             y = 0.7916 * safezoneH + safezoneY;
             w = 0.0525 * safezoneW;
             h = 0.028 * safezoneH;
+            sizeEx = "0.021 * safezoneH";
 			colorBackground[] = {0,0,0,0.5};
 			colorActive[] = {0,0,0,0.5};
 		};


### PR DESCRIPTION
The Civilian Interaction buttons size their text with a formula that resolves to a constant 0.04 UI units on 16:9 displays, while the buttons themselves are a fixed fraction of the screen. As Interface Size goes up the text outgrows the buttons, which is what cuts off Go Home, Hands Up, Calm Down, Negotiate, Give Ration, Give Water and Gather Intel in the report.

This ties the base button font to button height instead (0.024 * safezoneH, about 85% of the button), with a smaller 0.021 * safezoneH on the eight narrow bottom-row buttons to make room for their longer captions. Text keeps the same proportion of the button at every interface size and resolution.

I measured the worst captions against the screenshot in the report to check the new sizes fit the button widths before changing anything; the widest ones (Calm Down, Gather Intel) clear with a few pixels to spare. Worth an in-game look at 1440p / Interface Large to confirm, which is the setup from the report.

Fixes #956