### PR TITLE
[SYS_ORBATCREATOR] Use engine rank identifiers instead of localized names

### DIFF
--- a/addons/sys_orbatcreator/fnc_orbatCreator.sqf
+++ b/addons/sys_orbatcreator/fnc_orbatCreator.sqf
@@ -1124,12 +1124,14 @@ switch(_operation) do {
                 // process in reverse order to have higher ranks higher in the list
                 for "_i" from (count _cfgRanks - 1) to 0 step -1 do {
                     _rank = _cfgRanks select _i;
+                    // class name is the engine rank identifier (locale-independent), displayName is localized
+                    _rankName = toUpper (configName _rank);
                     _rankDisplayName = getText (_rank >> "displayName");
                     _rankImage = getText (_rank >> "texture");
 
-                    if (_rankDisplayName != "General") then {
+                    if (_rankName != "GENERAL") then {
                         _index = _selectedGroupUnitRank lbAdd _rankDisplayName;
-                        _selectedGroupUnitRank lbSetData [_index,toUpper _rankDisplayName];
+                        _selectedGroupUnitRank lbSetData [_index,_rankName];
                         _selectedGroupUnitRank lbSetPicture [_index,_rankImage];
                     };
                 };


### PR DESCRIPTION
When the game runs in a non-English locale, the ORBAT group editor rank combo stores localized display names, so the rank lookup for existing factions comes up empty and exported group configs carry localized rank strings the engine won't accept.

The combo now keeps the canonical CfgRanks class name (PRIVATE through COLONEL) in lbData and only uses the localized string for display. Selection restore, rank changes and the config export all round-trip on the identifier, so it works the same in any language and exports are always valid. On English clients nothing changes, since the vanilla class names match the English display names.

One known leftover: rank strings saved to profileNamespace by an older non-English session won't match the new identifiers and show as an empty selection until re-picked. No crash, and re-saving fixes it.

Fixes #772