### PR TITLE
[SUP_COMMAND] Player-designated OPCOM objectives in the Operations tablet view (#969)

### DIFF
--- a/addons/mil_c2istar/CfgVehicles.hpp
+++ b/addons/mil_c2istar/CfgVehicles.hpp
@@ -445,6 +445,34 @@ class CfgVehicles {
                                     class Yes { name = "Yes"; value = "true"; };
                             };
                     };
+                    class scomOpsAllowPlayerObjectives : Combo
+                    {
+                            property = "ALiVE_MIL_C2ISTAR_scomOpsAllowPlayerObjectives";
+                            displayName = "$STR_ALIVE_C2ISTAR_SCOM_OPS_ALLOW_PLAYER_OBJECTIVES";
+                            tooltip = "$STR_ALIVE_C2ISTAR_SCOM_OPS_ALLOW_PLAYER_OBJECTIVES_COMMENT";
+                            defaultValue = """false""";
+                            class Values
+                            {
+                                    class No  { name = "No";  value = "false"; };
+                                    class Yes { name = "Yes"; value = "true"; };
+                            };
+                    };
+                    class scomOpsObjectiveCooldown : Edit
+                    {
+                            property = "ALiVE_MIL_C2ISTAR_scomOpsObjectiveCooldown";
+                            displayName = "$STR_ALIVE_C2ISTAR_SCOM_OPS_OBJECTIVE_COOLDOWN";
+                            tooltip = "$STR_ALIVE_C2ISTAR_SCOM_OPS_OBJECTIVE_COOLDOWN_COMMENT";
+                            defaultValue = """300""";
+                            typeName = "NUMBER";
+                    };
+                    class scomOpsMaxPlayerObjectives : Edit
+                    {
+                            property = "ALiVE_MIL_C2ISTAR_scomOpsMaxPlayerObjectives";
+                            displayName = "$STR_ALIVE_C2ISTAR_SCOM_OPS_MAX_PLAYER_OBJECTIVES";
+                            tooltip = "$STR_ALIVE_C2ISTAR_SCOM_OPS_MAX_PLAYER_OBJECTIVES_COMMENT";
+                            defaultValue = """3""";
+                            typeName = "NUMBER";
+                    };
 
                     class SPACER_ROLE_INTEL : ALiVE_ModuleSubTitle { property = "ALiVE_mil_c2istar_SPACER_ROLE_INTEL"; displayName = " "; };
                     class scomIntelLimit : Combo

--- a/addons/mil_c2istar/fnc_C2ISTAR.sqf
+++ b/addons/mil_c2istar/fnc_C2ISTAR.sqf
@@ -395,6 +395,48 @@ switch(_operation) do {
 
         _result = _args;
     };
+    case "scomOpsAllowPlayerObjectives": {
+        if (typeName _args == "BOOL") then {
+            _logic setVariable ["scomOpsAllowPlayerObjectives", _args];
+        } else {
+            _args = _logic getVariable ["scomOpsAllowPlayerObjectives", false];
+        };
+        if (typeName _args == "STRING") then {
+                if(_args == "true") then {_args = true;} else {_args = false;};
+                _logic setVariable ["scomOpsAllowPlayerObjectives", _args];
+        };
+        ASSERT_TRUE(typeName _args == "BOOL",str _args);
+
+        _result = _args;
+    };
+    case "scomOpsObjectiveCooldown": {
+        if (typeName _args == "SCALAR") then {
+            _logic setVariable ["scomOpsObjectiveCooldown", _args];
+        } else {
+            _args = _logic getVariable ["scomOpsObjectiveCooldown", 300];
+        };
+        if (typeName _args == "STRING") then {
+                _args = parseNumber _args;
+                _logic setVariable ["scomOpsObjectiveCooldown", _args];
+        };
+        ASSERT_TRUE(typeName _args == "SCALAR",str _args);
+
+        _result = _args;
+    };
+    case "scomOpsMaxPlayerObjectives": {
+        if (typeName _args == "SCALAR") then {
+            _logic setVariable ["scomOpsMaxPlayerObjectives", _args];
+        } else {
+            _args = _logic getVariable ["scomOpsMaxPlayerObjectives", 3];
+        };
+        if (typeName _args == "STRING") then {
+                _args = parseNumber _args;
+                _logic setVariable ["scomOpsMaxPlayerObjectives", _args];
+        };
+        ASSERT_TRUE(typeName _args == "SCALAR",str _args);
+
+        _result = _args;
+    };
     case "scomIntelLimit": {
         _result = [_logic,_operation,_args,DEFAULT_SCOM_LIMIT,["SIDE","FACTION","ALL"]] call ALIVE_fnc_OOsimpleOperation;
     };
@@ -1127,13 +1169,16 @@ switch(_operation) do {
         [_gm, "debug", _debug] call ALIVE_fnc_GM;
         [_gm, "init",[]] call ALIVE_fnc_GM;
 
-        private["_scomOpsLimit","_scomIntelLimit","_scomOpsAllowSpectate","_scomOpsAllowJoin","_scomOpsAllowImageIntelligence","_scom"];
+        private["_scomOpsLimit","_scomIntelLimit","_scomOpsAllowSpectate","_scomOpsAllowJoin","_scomOpsAllowImageIntelligence","_scomOpsAllowPlayerObjectives","_scomOpsObjectiveCooldown","_scomOpsMaxPlayerObjectives","_scom"];
 
         _scomOpsLimit = [_logic, "scomOpsLimit"] call MAINCLASS;
         _scomIntelLimit = [_logic, "scomIntelLimit"] call MAINCLASS;
         _scomOpsAllowSpectate = [_logic, "scomOpsAllowSpectate"] call MAINCLASS;
         _scomOpsAllowJoin = [_logic, "scomOpsAllowInstantJoin"] call MAINCLASS;
         _scomOpsAllowImageIntelligence = [_logic, "scomOpsAllowImageIntelligence"] call MAINCLASS;
+        _scomOpsAllowPlayerObjectives = [_logic, "scomOpsAllowPlayerObjectives"] call MAINCLASS;
+        _scomOpsObjectiveCooldown = [_logic, "scomOpsObjectiveCooldown"] call MAINCLASS;
+        _scomOpsMaxPlayerObjectives = [_logic, "scomOpsMaxPlayerObjectives"] call MAINCLASS;
 
         _scom = [nil, "create"] call ALIVE_fnc_SCOM;
         [_scom, "opsLimit", _scomOpsLimit] call ALIVE_fnc_SCOM;
@@ -1141,6 +1186,9 @@ switch(_operation) do {
         [_scom, "scomOpsAllowSpectate", _scomOpsAllowSpectate] call ALIVE_fnc_SCOM;
         [_scom, "scomOpsAllowInstantJoin", _scomOpsAllowJoin] call ALIVE_fnc_SCOM;
         [_scom, "scomOpsAllowImageIntelligence", _scomOpsAllowImageIntelligence] call ALIVE_fnc_SCOM;
+        [_scom, "scomOpsAllowPlayerObjectives", _scomOpsAllowPlayerObjectives] call ALIVE_fnc_SCOM;
+        [_scom, "scomOpsObjectiveCooldown", _scomOpsObjectiveCooldown] call ALIVE_fnc_SCOM;
+        [_scom, "scomOpsMaxPlayerObjectives", _scomOpsMaxPlayerObjectives] call ALIVE_fnc_SCOM;
         [_scom, "debug", _debug] call ALIVE_fnc_SCOM;
         [_scom, "init",[]] call ALIVE_fnc_SCOM;
 

--- a/addons/mil_c2istar/stringtable.xml
+++ b/addons/mil_c2istar/stringtable.xml
@@ -452,6 +452,24 @@
     <Portuguese>Permite que comandantes visualizem transmissão ao vivo de unidades aéreas amigas</Portuguese>
     <Russian>Разрешает командирам просматривать прямую трансляцию с дружественных воздушных подразделений</Russian>
 </Key>
+<Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_ALLOW_PLAYER_OBJECTIVES">
+    <English>Allow Player Objectives:</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_ALLOW_PLAYER_OBJECTIVES_COMMENT">
+    <English>Allow players to designate, cancel and reprioritise commander objectives from the Operations tablet view</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_OBJECTIVE_COOLDOWN">
+    <English>Player Objective Cooldown:</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_OBJECTIVE_COOLDOWN_COMMENT">
+    <English>Seconds a player must wait between designating objectives</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_MAX_PLAYER_OBJECTIVES">
+    <English>Max Player Objectives:</English>
+</Key>
+<Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_MAX_PLAYER_OBJECTIVES_COMMENT">
+    <English>Maximum simultaneous player-designated objectives per side</English>
+</Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_C2ISTAR_SCOM_INTEL_LIMIT">
     <English>Limit Intel:</English>

--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -1782,6 +1782,31 @@ switch (_operation) do {
         };
     };
 
+    case "reorderObjective": {
+        if !(isServer) exitwith {[_logic,_operation,_args] remoteExec ["ALiVE_fnc_OPCOM",2]};
+
+        _args params [
+            ["_objectiveID", "", [""]],
+            ["_newIndex", 0, [0]]
+        ];
+
+        private _objectives = [_logic,"objectives", []] call ALiVE_fnc_HashGet;
+        private _objectiveIndex = _objectives findIf { ([_x,"objectiveID",""] call ALiVE_fnc_HashGet) == _objectiveID };
+
+        if (_objectiveIndex != -1) then {
+            _newIndex = 0 max _newIndex min (count _objectives - 1);
+
+            // in-place move on the live array reference. Array position is the
+            // commander's de-facto priority queue (selectordersbystate picks the
+            // first match per state), and every async consumer resolves
+            // objectives by ID or hash reference, so reordering is safe mid-run.
+            private _objective = _objectives deleteAt _objectiveIndex;
+            _objectives insert [_newIndex, [_objective]];
+        };
+
+        _result = _objectives;
+    };
+
     case "findReinforcementBase": {
             _AO = [];
             _FOB = [];
@@ -2488,7 +2513,8 @@ switch (_operation) do {
                 _objectivesGlobal = [];
                 {
                     if ([_x,"persistent",false] call ALIVE_fnc_HashGet) then {
-                        _objectivesGlobal = _objectivesGlobal + ([_x, "objectives",[]] call ALiVE_fnc_HashGet);
+                        // player-designated objectives are session-only by design
+                        _objectivesGlobal = _objectivesGlobal + (([_x, "objectives",[]] call ALiVE_fnc_HashGet) select {!([_x,"playerCreated",false] call ALiVE_fnc_HashGet)});
                     };
                 } foreach OPCOM_INSTANCES;
 
@@ -2863,9 +2889,13 @@ switch (_operation) do {
             ["_priority", 100, [-1]],
             ["_opcomState", "unassigned", [""]],
             ["_clusterID", "none", [""]],
-            ["_opcomID", [_logic,"opcomID", ""] call ALiVE_fnc_HashGet, [""]]
+            ["_opcomID", [_logic,"opcomID", ""] call ALiVE_fnc_HashGet, [""]],
+            ["_playerCreated", false, [false]],
+            ["_insertAtFront", false, [false]]
         ];
 
+        // playerCreated must stay AFTER _rev - opcom.fsm reads opcom_state
+        // positionally (_x select 2 select 5), so the first ten keys are fixed
         private _objective = [[
             ["objectiveID", _id],
             ["center", _pos],
@@ -2876,7 +2906,8 @@ switch (_operation) do {
             ["clusterID", _clusterID],
             ["opcomID", _opcomID],
             ["deleted", false],
-            ["_rev", ""]
+            ["_rev", ""],
+            ["playerCreated", _playerCreated]
         ]] call ALIVE_fnc_hashCreate;
 
         if (_debug) then {
@@ -2884,7 +2915,16 @@ switch (_operation) do {
         };
 
         private _objectives = [_logic,"objectives"] call ALiVE_fnc_HashGet;
-        _objectives pushback _objective;
+
+        // hashGet returns the live array reference, so mutating in place is
+        // visible to the FSMs without a HashSet. Front insertion puts the
+        // objective first in its opcom_state bucket (selectordersbystate takes
+        // the first array-order match), making it the commander's top priority.
+        if (_insertAtFront) then {
+            _objectives insert [0, [_objective]];
+        } else {
+            _objectives pushback _objective;
+        };
 
         _result = _objective;
     };

--- a/addons/sup_command/fnc_SCOM.sqf
+++ b/addons/sup_command/fnc_SCOM.sqf
@@ -1644,6 +1644,11 @@ switch (_operation) do {
 
                     [_logic,"commandState",_commandState] call MAINCLASS;
 
+                    // disarm the group view's map click for the round-trip
+
+                    private _editMap = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+                    _editMap ctrlSetEventHandler ["MouseButtonDown", "['OP_MAP_CLICK_NULL',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
                     private _editList = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditList);
                     lbClear _editList;
 

--- a/addons/sup_command/fnc_SCOM.sqf
+++ b/addons/sup_command/fnc_SCOM.sqf
@@ -271,6 +271,26 @@ switch (_operation) do {
 
     };
 
+    case "objMarkers": {
+
+        // objectives-layer markers get their own slot - "marker" is a single
+        // list shared by the intel and ops views and its cleanup loops never
+        // reset it, so sharing it would clobber the group markers
+
+        _result = [_logic,_operation,_args,DEFAULT_MARKER] call ALIVE_fnc_OOsimpleOperation;
+
+    };
+
+    case "clearObjMarkers": {
+
+        {
+            deleteMarkerLocal _x;
+        } foreach ([_logic,"objMarkers"] call MAINCLASS);
+
+        [_logic,"objMarkers",[]] call MAINCLASS;
+
+    };
+
     case "init": {
 
         //Only one init per instance is allowed
@@ -404,6 +424,12 @@ switch (_operation) do {
             [_commandState,"opsGroupWaypointsSelectedValues",[]] call ALIVE_fnc_hashSet;
             [_commandState,"opsGroupWaypointsSelectedIndex",DEFAULT_SELECTED_INDEX] call ALIVE_fnc_hashSet;
             [_commandState,"opsGroupWaypointsSelectedValue",DEFAULT_SELECTED_VALUE] call ALIVE_fnc_hashSet;
+
+            [_commandState,"opsViewMode","GROUPS"] call ALIVE_fnc_hashSet;
+            [_commandState,"opsObjectivesData",[]] call ALIVE_fnc_hashSet;
+            [_commandState,"opsObjectivesMeta",[]] call ALIVE_fnc_hashSet;
+            [_commandState,"opsObjectivesSelectedID",""] call ALIVE_fnc_hashSet;
+            [_commandState,"opsObjectiveDesignatePos",[]] call ALIVE_fnc_hashSet;
 
             [_commandState,"opsWPProfiledTypeOptions",["Move","Cycle"]] call ALIVE_fnc_hashSet;
             [_commandState,"opsWPProfiledTypeValues",["MOVE","CYCLE"]] call ALIVE_fnc_hashSet;
@@ -562,6 +588,12 @@ switch (_operation) do {
 
                 };
 
+                case "OPS_OBJECTIVES": {
+
+                    [_logic,"enableOpsObjectives", _data] call MAINCLASS;
+
+                };
+
                 default {
 
                     [_logic,_type, _data] call MAINCLASS;
@@ -661,8 +693,13 @@ switch (_operation) do {
                 deleteMarkerLocal _x;
             } foreach _markers;
 
+            [_logic,"clearObjMarkers"] call MAINCLASS;
+
             [_commandState,"opsGroupWaypoints", []] call ALIVE_fnc_hashSet;
             [_commandState,"opsGroupPlannedWaypoints", []] call ALIVE_fnc_hashSet;
+            [_commandState,"opsViewMode","GROUPS"] call ALIVE_fnc_hashSet;
+            [_commandState,"opsObjectivesSelectedID",""] call ALIVE_fnc_hashSet;
+            [_commandState,"opsObjectiveDesignatePos",[]] call ALIVE_fnc_hashSet;
 
         };
 
@@ -1591,6 +1628,228 @@ switch (_operation) do {
 
                     // map click on reset
                     // do nothing
+
+                };
+
+                case "OPS_VIEW_OBJECTIVES": {
+
+                    // switch the ops view to the selected commander's
+                    // objectives - request a fresh snapshot from the server
+
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+                    [_commandState,"opsViewMode","OBJECTIVES"] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsObjectivesSelectedID",""] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsObjectiveDesignatePos",[]] call ALIVE_fnc_hashSet;
+
+                    [_logic,"commandState",_commandState] call MAINCLASS;
+
+                    private _editList = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditList);
+                    lbClear _editList;
+
+                    [_logic,"enableOpsWaiting", true] call MAINCLASS;
+
+                    private _selOpcom = [_commandState,"opsOPCOMSelectedValue"] call ALIVE_fnc_hashGet;
+                    private _playerID = getPlayerUID player;
+
+                    ["OPS_GET_OBJECTIVES", [_playerID,_selOpcom]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer", 2];
+
+                };
+
+                case "OPS_VIEW_GROUPS": {
+
+                    // back to the group command view
+
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+                    [_commandState,"opsViewMode","GROUPS"] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsObjectivesSelectedID",""] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsObjectiveDesignatePos",[]] call ALIVE_fnc_hashSet;
+
+                    [_logic,"commandState",_commandState] call MAINCLASS;
+
+                    [_logic,"clearObjMarkers"] call MAINCLASS;
+
+                    {
+                        private _button = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,_x);
+                        _button ctrlShow false;
+                    } foreach [SCOMTablet_CTRL_BL1,SCOMTablet_CTRL_BL2,SCOMTablet_CTRL_BL3,SCOMTablet_CTRL_BR1,SCOMTablet_CTRL_BR2,SCOMTablet_CTRL_BR3];
+
+                    private _editMap = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+                    _editMap ctrlSetEventHandler ["MouseButtonDown", "['OP_MAP_CLICK_NULL',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+                    private _editList = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditList);
+                    lbClear _editList;
+
+                    [_logic,"enableOpsWaiting", true] call MAINCLASS;
+
+                    // re-enter the group flow through the existing server path
+
+                    private _selOpcom = [_commandState,"opsOPCOMSelectedValue"] call ALIVE_fnc_hashGet;
+                    private _playerID = getPlayerUID player;
+
+                    ["OPS_OPCOM_SELECT", [_playerID,_selOpcom]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer", 2];
+
+                };
+
+                case "OPS_OBJECTIVE_LIST_SELECT": {
+
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+                    private _selectedIndex = _args select 0 select 1;
+                    private _objectiveData = [_commandState,"opsObjectivesData"] call ALIVE_fnc_hashGet;
+
+                    if (_selectedIndex >= 0 && {_selectedIndex < count _objectiveData}) then {
+
+                        private _objective = _objectiveData select _selectedIndex;
+
+                        [_commandState,"opsObjectivesSelectedID",_objective select 0] call ALIVE_fnc_hashSet;
+                        [_logic,"commandState",_commandState] call MAINCLASS;
+
+                        private _map = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+
+                        ctrlMapAnimClear _map;
+                        _map ctrlMapAnimAdd [0.5, ctrlMapScale _map, _objective select 1];
+                        ctrlMapAnimCommit _map;
+
+                        [_logic,"enableOpsObjectiveActions"] call MAINCLASS;
+
+                    };
+
+                };
+
+                case "OPS_OBJECTIVE_DESIGNATE": {
+
+                    // arm the map for placement
+
+                    private _editMap = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+                    _editMap ctrlSetEventHandler ["MouseButtonDown", "['OP_OBJECTIVE_MAP_CLICK',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+                    [_logic,"setOpsStatus", "Click map to place objective"] call MAINCLASS;
+
+                    private _buttonR1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR1);
+                    _buttonR1 ctrlSetText "Confirm Position";
+                    _buttonR1 ctrlEnable false;
+                    _buttonR1 ctrlSetEventHandler ["MouseButtonClick", "['OPS_OBJECTIVE_CONFIRM',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+                    private _buttonR2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR2);
+                    _buttonR2 ctrlSetText "Cancel Designation";
+                    _buttonR2 ctrlSetEventHandler ["MouseButtonClick", "['OPS_OBJECTIVE_DESIGNATE_CANCEL',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+                };
+
+                case "OP_OBJECTIVE_MAP_CLICK": {
+
+                    private _button = _args select 0 select 1;
+                    private _posX = _args select 0 select 2;
+                    private _posY = _args select 0 select 3;
+
+                    if (_button == 0) then {
+
+                        private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+                        private _map = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+                        private _position = _map ctrlMapScreenToWorld [_posX, _posY];
+
+                        [_commandState,"opsObjectiveDesignatePos",_position] call ALIVE_fnc_hashSet;
+                        [_logic,"commandState",_commandState] call MAINCLASS;
+
+                        // re-clicking moves the placement marker
+
+                        deleteMarkerLocal "ALiVE_SCOM_OBJ_DESIGNATE";
+
+                        private _m = createMarkerLocal ["ALiVE_SCOM_OBJ_DESIGNATE", _position];
+                        _m setMarkerShapeLocal "ICON";
+                        _m setMarkerTypeLocal "mil_objective";
+                        _m setMarkerColorLocal "ColorOrange";
+                        _m setMarkerTextLocal "New Objective";
+
+                        private _objMarkers = [_logic,"objMarkers"] call MAINCLASS;
+                        if !(_m in _objMarkers) then {
+                            _objMarkers pushback _m;
+                            [_logic,"objMarkers",_objMarkers] call MAINCLASS;
+                        };
+
+                        [_logic,"setOpsStatus", "Confirm to designate objective"] call MAINCLASS;
+
+                        private _buttonR1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR1);
+                        _buttonR1 ctrlEnable true;
+
+                    };
+
+                };
+
+                case "OPS_OBJECTIVE_CONFIRM": {
+
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+                    private _position = [_commandState,"opsObjectiveDesignatePos"] call ALIVE_fnc_hashGet;
+
+                    if (_position isEqualTo []) exitwith {};
+
+                    [_commandState,"opsObjectiveDesignatePos",[]] call ALIVE_fnc_hashSet;
+                    [_logic,"commandState",_commandState] call MAINCLASS;
+
+                    private _editMap = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+                    _editMap ctrlSetEventHandler ["MouseButtonDown", "['OP_MAP_CLICK_NULL',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+                    [_logic,"enableOpsWaiting", true] call MAINCLASS;
+
+                    private _selOpcom = [_commandState,"opsOPCOMSelectedValue"] call ALIVE_fnc_hashGet;
+                    private _playerID = getPlayerUID player;
+
+                    ["OPS_ADD_OBJECTIVE", [_playerID,_selOpcom,_position]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer", 2];
+
+                };
+
+                case "OPS_OBJECTIVE_DESIGNATE_CANCEL": {
+
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+                    [_commandState,"opsObjectiveDesignatePos",[]] call ALIVE_fnc_hashSet;
+                    [_logic,"commandState",_commandState] call MAINCLASS;
+
+                    private _editMap = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+                    _editMap ctrlSetEventHandler ["MouseButtonDown", "['OP_MAP_CLICK_NULL',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+                    // re-render from the cached snapshot
+
+                    [_logic,"renderOpsObjectives"] call MAINCLASS;
+
+                };
+
+                case "OPS_OBJECTIVE_CANCEL": {
+
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+                    private _selectedID = [_commandState,"opsObjectivesSelectedID"] call ALIVE_fnc_hashGet;
+
+                    if (_selectedID == "") exitwith {};
+
+                    [_logic,"enableOpsWaiting", true] call MAINCLASS;
+
+                    private _selOpcom = [_commandState,"opsOPCOMSelectedValue"] call ALIVE_fnc_hashGet;
+                    private _playerID = getPlayerUID player;
+
+                    ["OPS_CANCEL_OBJECTIVE", [_playerID,_selOpcom,_selectedID]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer", 2];
+
+                };
+
+                case "OPS_OBJECTIVE_MOVE_UP";
+                case "OPS_OBJECTIVE_MOVE_DOWN": {
+
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+                    private _selectedID = [_commandState,"opsObjectivesSelectedID"] call ALIVE_fnc_hashGet;
+
+                    if (_selectedID == "") exitwith {};
+
+                    private _direction = if (_action == "OPS_OBJECTIVE_MOVE_UP") then {-1} else {1};
+
+                    private _selOpcom = [_commandState,"opsOPCOMSelectedValue"] call ALIVE_fnc_hashGet;
+                    private _playerID = getPlayerUID player;
+
+                    ["OPS_MOVE_OBJECTIVE", [_playerID,_selOpcom,_selectedID,_direction]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer", 2];
 
                 };
 
@@ -2906,6 +3165,8 @@ switch (_operation) do {
             deleteMarkerLocal _x;
         } foreach _markers;
 
+        [_logic,"clearObjMarkers"] call MAINCLASS;
+
         // call reset
 
         if!(_isInstantJoinMode || _isSpectateMode) then {
@@ -2914,11 +3175,19 @@ switch (_operation) do {
 
         };
 
-        // add map draw eh
+        // add map draw eh - remove any previous one first, this runs on every
+        // tablet open and ctrlAddEventHandler stacks otherwise
 
-        _editMap ctrlAddEventHandler ["Draw",{
+        private _drawEH = _editMap getVariable ["SCOM_opsDrawEH", -1];
+        if (_drawEH != -1) then {
+            _editMap ctrlRemoveEventHandler ["Draw", _drawEH];
+        };
+
+        _drawEH = _editMap ctrlAddEventHandler ["Draw",{
             [ALiVE_SUP_COMMAND,"opsDrawWaypoints", _this] call ALiVE_fnc_SCOM;
         }];
+
+        _editMap setVariable ["SCOM_opsDrawEH", _drawEH];
     };
 
     case "resetOps": {
@@ -2933,6 +3202,14 @@ switch (_operation) do {
         [_commandState,"opsGroupWaypoints",[]] call ALIVE_fnc_hashSet;
         [_commandState,"opsGroupPlannedWaypoints",[]] call ALIVE_fnc_hashSet;
         [_commandState,"opsGroupWaypointsPlanned",false] call ALIVE_fnc_hashSet;
+
+        // reset the objectives view
+
+        [_commandState,"opsViewMode","GROUPS"] call ALIVE_fnc_hashSet;
+        [_commandState,"opsObjectivesData",[]] call ALIVE_fnc_hashSet;
+        [_commandState,"opsObjectivesMeta",[]] call ALIVE_fnc_hashSet;
+        [_commandState,"opsObjectivesSelectedID",""] call ALIVE_fnc_hashSet;
+        [_commandState,"opsObjectiveDesignatePos",[]] call ALIVE_fnc_hashSet;
 
 
         //[_logic,"commandState",_commandState] call MAINCLASS;
@@ -3342,6 +3619,212 @@ switch (_operation) do {
 
             };
 
+            // objectives entry point - offered whether or not this commander
+            // has free groups, gated by the mission-maker toggle
+
+            if ([_logic,"scomOpsAllowPlayerObjectives"] call MAINCLASS) then {
+                private _buttonR3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR3);
+                _buttonR3 ctrlShow true;
+                _buttonR3 ctrlSetText "View Objectives";
+                _buttonR3 ctrlSetEventHandler ["MouseButtonClick", "['OPS_VIEW_OBJECTIVES',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+            };
+
+        };
+
+    };
+
+    case "enableOpsObjectives": {
+
+        // server snapshot of the selected commander's objectives has arrived
+
+        if (_args isEqualType []) then {
+
+            private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+            // drop stale replies if the player already switched back to groups
+
+            if (([_commandState,"opsViewMode",""] call ALIVE_fnc_hashGet) != "OBJECTIVES") exitwith {};
+
+            (_args select 1) params ["_selOpcom","_objectiveData","_meta"];
+
+            [_commandState,"opsObjectivesData",_objectiveData] call ALIVE_fnc_hashSet;
+            [_commandState,"opsObjectivesMeta",_meta] call ALIVE_fnc_hashSet;
+
+            [_logic,"commandState",_commandState] call MAINCLASS;
+
+            [_logic,"renderOpsObjectives"] call MAINCLASS;
+
+        };
+
+    };
+
+    case "renderOpsObjectives": {
+
+        // draw the objectives list + map overlay from the cached snapshot.
+        // list order = array order = the commander's priority queue
+
+        private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+        private _objectiveData = [_commandState,"opsObjectivesData"] call ALIVE_fnc_hashGet;
+        private _meta = [_commandState,"opsObjectivesMeta"] call ALIVE_fnc_hashGet;
+        private _selectedID = [_commandState,"opsObjectivesSelectedID"] call ALIVE_fnc_hashGet;
+
+        if (_meta isEqualTo []) then {_meta = [false,0,false,""]};
+        _meta params ["_playerObjectivesEnabled","_cooldownRemaining","_maxReached","_statusText"];
+
+        // markers
+
+        [_logic,"clearObjMarkers"] call MAINCLASS;
+
+        private _objMarkers = [];
+
+        {
+            _x params ["_objectiveID","_center","_size","_opcom_state","_objectiveType","_playerCreated"];
+
+            private _opcomColor = switch (_opcom_state) do {
+                case "unassigned": {"ColorWhite"};
+                case "idle": {"ColorYellow"};
+                case "reserve";
+                case "reserving": {"ColorGreen"};
+                case "defend";
+                case "defending": {"ColorBlue"};
+                case "attack";
+                case "attacking": {"ColorRed"};
+                default {"ColorWhite"};
+            };
+
+            private _m = createMarkerLocal [format["ALiVE_SCOM_OBJ_%1",_forEachIndex], _center];
+            _m setMarkerShapeLocal "Ellipse";
+            _m setMarkerBrushLocal (if (_playerCreated) then {"Cross"} else {"FDiagonal"});
+            _m setMarkerSizeLocal [_size, _size];
+            _m setMarkerColorLocal _opcomColor;
+            _m setMarkerAlphaLocal 1;
+
+            _objMarkers pushback _m;
+
+            private _icon = createMarkerLocal [format["ALiVE_SCOM_OBJ_%1_icon",_forEachIndex], _center];
+            _icon setMarkerShapeLocal "ICON";
+            _icon setMarkerTypeLocal "mil_objective";
+            _icon setMarkerColorLocal (if (_playerCreated) then {"ColorOrange"} else {_opcomColor});
+            _icon setMarkerSizeLocal [0.7,0.7];
+            _icon setMarkerTextLocal (format["%1%2", _forEachIndex + 1, if (_playerCreated) then {" P"} else {""}]);
+
+            _objMarkers pushback _icon;
+
+        } foreach _objectiveData;
+
+        [_logic,"objMarkers",_objMarkers] call MAINCLASS;
+
+        // list
+
+        private _editList = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditList);
+        lbClear _editList;
+
+        {
+            _x params ["_objectiveID","_center","_size","_opcom_state","_objectiveType","_playerCreated"];
+
+            _editList lbAdd format["%1. %2 [%3]%4", _forEachIndex + 1, _objectiveType, toUpper _opcom_state, if (_playerCreated) then {" *PLAYER*"} else {""}];
+        } foreach _objectiveData;
+
+        _editList ctrlSetEventHandler ["LBSelChanged", "['OPS_OBJECTIVE_LIST_SELECT',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+        // neutral map click while not designating
+
+        private _editMap = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+        _editMap ctrlSetEventHandler ["MouseButtonDown", "['OP_MAP_CLICK_NULL',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+        // buttons
+
+        private _buttonR1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR1);
+        _buttonR1 ctrlShow true;
+        _buttonR1 ctrlSetText "Designate Objective";
+        _buttonR1 ctrlSetEventHandler ["MouseButtonClick", "['OPS_OBJECTIVE_DESIGNATE',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+        _buttonR1 ctrlEnable (_playerObjectivesEnabled && {!_maxReached} && {_cooldownRemaining <= 0});
+
+        private _buttonR2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR2);
+        _buttonR2 ctrlShow true;
+        _buttonR2 ctrlEnable true;
+        _buttonR2 ctrlSetText "Refresh";
+        _buttonR2 ctrlSetEventHandler ["MouseButtonClick", "['OPS_VIEW_OBJECTIVES',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+        private _buttonR3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR3);
+        _buttonR3 ctrlShow true;
+        _buttonR3 ctrlSetText "View Groups";
+        _buttonR3 ctrlSetEventHandler ["MouseButtonClick", "['OPS_VIEW_GROUPS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+        {
+            private _button = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,_x);
+            _button ctrlShow false;
+        } foreach [SCOMTablet_CTRL_BL1,SCOMTablet_CTRL_BL2,SCOMTablet_CTRL_BL3];
+
+        // status - explicit server message wins, otherwise show why
+        // designation is unavailable
+
+        if (_statusText == "") then {
+            if (_cooldownRemaining > 0) then {
+                _statusText = format["Objective cooldown: %1s", ceil _cooldownRemaining];
+            } else {
+                if (_maxReached) then {_statusText = "Maximum player objectives reached"};
+            };
+        };
+
+        [_logic,"setOpsStatus", _statusText] call MAINCLASS;
+
+        // restore selection by ID - the array may have shifted since
+
+        if (_selectedID != "") then {
+            private _selectedIndex = _objectiveData findIf { (_x select 0) == _selectedID };
+
+            if (_selectedIndex != -1) then {
+                _editList lbSetCurSel _selectedIndex;
+            } else {
+                [_commandState,"opsObjectivesSelectedID",""] call ALIVE_fnc_hashSet;
+                [_logic,"commandState",_commandState] call MAINCLASS;
+            };
+        };
+
+    };
+
+    case "enableOpsObjectiveActions": {
+
+        // context buttons for the selected objective
+
+        private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+        private _objectiveData = [_commandState,"opsObjectivesData"] call ALIVE_fnc_hashGet;
+        private _selectedID = [_commandState,"opsObjectivesSelectedID"] call ALIVE_fnc_hashGet;
+
+        private _selectedIndex = _objectiveData findIf { (_x select 0) == _selectedID };
+
+        if (_selectedIndex == -1) exitwith {
+            {
+                private _button = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,_x);
+                _button ctrlShow false;
+            } foreach [SCOMTablet_CTRL_BL1,SCOMTablet_CTRL_BL2,SCOMTablet_CTRL_BL3];
+        };
+
+        private _playerCreated = (_objectiveData select _selectedIndex) select 5;
+
+        private _buttonL1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL1);
+        _buttonL1 ctrlShow true;
+        _buttonL1 ctrlSetText "Move Priority Up";
+        _buttonL1 ctrlSetEventHandler ["MouseButtonClick", "['OPS_OBJECTIVE_MOVE_UP',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+        _buttonL1 ctrlEnable (_selectedIndex > 0);
+
+        private _buttonL2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL2);
+        _buttonL2 ctrlShow true;
+        _buttonL2 ctrlSetText "Move Priority Down";
+        _buttonL2 ctrlSetEventHandler ["MouseButtonClick", "['OPS_OBJECTIVE_MOVE_DOWN',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+        _buttonL2 ctrlEnable (_selectedIndex < (count _objectiveData - 1));
+
+        private _buttonL3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL3);
+
+        if (_playerCreated) then {
+            _buttonL3 ctrlShow true;
+            _buttonL3 ctrlSetText "Cancel Objective";
+            _buttonL3 ctrlSetEventHandler ["MouseButtonClick", "['OPS_OBJECTIVE_CANCEL',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+        } else {
+            _buttonL3 ctrlShow false;
         };
 
     };

--- a/addons/sup_command/fnc_SCOM.sqf
+++ b/addons/sup_command/fnc_SCOM.sqf
@@ -184,6 +184,57 @@ switch (_operation) do {
 
     };
 
+    case "scomOpsAllowPlayerObjectives": {
+
+        if (typeName _args == "BOOL") then {
+            _logic setVariable ["scomOpsAllowPlayerObjectives", _args];
+        } else {
+            _args = _logic getVariable ["scomOpsAllowPlayerObjectives", false];
+        };
+        if (typeName _args == "STRING") then {
+                if(_args == "true") then {_args = true;} else {_args = false;};
+                _logic setVariable ["scomOpsAllowPlayerObjectives", _args];
+        };
+        ASSERT_TRUE(typeName _args == "BOOL",str _args);
+
+        _result = _args;
+
+    };
+
+    case "scomOpsObjectiveCooldown": {
+
+        if (typeName _args == "SCALAR") then {
+            _logic setVariable ["scomOpsObjectiveCooldown", _args];
+        } else {
+            _args = _logic getVariable ["scomOpsObjectiveCooldown", 300];
+        };
+        if (typeName _args == "STRING") then {
+                _args = parseNumber _args;
+                _logic setVariable ["scomOpsObjectiveCooldown", _args];
+        };
+        ASSERT_TRUE(typeName _args == "SCALAR",str _args);
+
+        _result = _args;
+
+    };
+
+    case "scomOpsMaxPlayerObjectives": {
+
+        if (typeName _args == "SCALAR") then {
+            _logic setVariable ["scomOpsMaxPlayerObjectives", _args];
+        } else {
+            _args = _logic getVariable ["scomOpsMaxPlayerObjectives", 3];
+        };
+        if (typeName _args == "STRING") then {
+                _args = parseNumber _args;
+                _logic setVariable ["scomOpsMaxPlayerObjectives", _args];
+        };
+        ASSERT_TRUE(typeName _args == "SCALAR",str _args);
+
+        _result = _args;
+
+    };
+
     case "intelLimit": {
 
         _result = [_logic,_operation,_args,DEFAULT_SCOM_LIMIT,["SIDE","FACTION","ALL"]] call ALIVE_fnc_OOsimpleOperation;
@@ -245,6 +296,12 @@ switch (_operation) do {
             ALIVE_commandHandler = [nil,"create"] call ALIVE_fnc_commandHandler;
             [ALIVE_commandHandler, "init"] call ALIVE_fnc_commandHandler;
             [ALIVE_commandHandler, "debug", _debug] call ALIVE_fnc_commandHandler;
+
+            // player-objectives config + per-player cooldown registry
+            [ALIVE_commandHandler, "playerObjectivesEnabled", [_logic,"scomOpsAllowPlayerObjectives"] call MAINCLASS] call ALiVE_fnc_hashSet;
+            [ALIVE_commandHandler, "playerObjectiveCooldown", [_logic,"scomOpsObjectiveCooldown"] call MAINCLASS] call ALiVE_fnc_hashSet;
+            [ALIVE_commandHandler, "maxPlayerObjectives", [_logic,"scomOpsMaxPlayerObjectives"] call MAINCLASS] call ALiVE_fnc_hashSet;
+            [ALIVE_commandHandler, "playerObjectiveCooldowns", [] call ALIVE_fnc_hashCreate] call ALiVE_fnc_hashSet;
 
         };
 

--- a/addons/sup_command/fnc_commandHandler.sqf
+++ b/addons/sup_command/fnc_commandHandler.sqf
@@ -1103,8 +1103,14 @@ switch(_operation) do {
             // analysis cycle, and front array position makes it the first
             // pick within its state bucket
 
+            // monotonic counter keeps IDs unique even when two designations
+            // drain from the remoteExec queue in the same server frame
+
+            private _counter = ([_logic,"playerObjectiveCounter",0] call ALiVE_fnc_hashGet) + 1;
+            [_logic,"playerObjectiveCounter",_counter] call ALiVE_fnc_hashSet;
+
             private _opcomID = [_opcom,"opcomID",""] call ALiVE_fnc_hashGet;
-            private _objectiveID = format ["%1_player_obj_%2", _opcomID, floor (diag_tickTime * 1000)];
+            private _objectiveID = format ["%1_player_obj_%2", _opcomID, _counter];
 
             [_opcom,"addObjective",[_objectiveID,_pos,100,"custom",100,"unassigned","none",_opcomID,true,true]] call ALiVE_fnc_OPCOM;
             [_cooldowns,_playerID,time] call ALiVE_fnc_hashSet;
@@ -1120,6 +1126,13 @@ switch(_operation) do {
         if (_args isEqualType []) then {
 
             _args params ["_playerID","_selOpcom","_objectiveID"];
+
+            // same server-side gate as opsAddObjective - the tablet UI is not
+            // the only way to reach this op
+
+            if !([_logic,"playerObjectivesEnabled",false] call ALiVE_fnc_hashGet) exitwith {
+                [_logic,"opsSendObjectives",[_playerID,_selOpcom,"Player objectives are disabled"]] call MAINCLASS;
+            };
 
             private _opcom = [_logic,"opsFindOPCOM", _selOpcom select 0] call MAINCLASS;
 
@@ -1152,6 +1165,13 @@ switch(_operation) do {
         if (_args isEqualType []) then {
 
             _args params ["_playerID","_selOpcom","_objectiveID","_direction"];
+
+            // same server-side gate as opsAddObjective - reordering the
+            // commander's priority queue is exactly what the toggle gates
+
+            if !([_logic,"playerObjectivesEnabled",false] call ALiVE_fnc_hashGet) exitwith {
+                [_logic,"opsSendObjectives",[_playerID,_selOpcom,"Player objectives are disabled"]] call MAINCLASS;
+            };
 
             private _opcom = [_logic,"opsFindOPCOM", _selOpcom select 0] call MAINCLASS;
 

--- a/addons/sup_command/fnc_commandHandler.sqf
+++ b/addons/sup_command/fnc_commandHandler.sqf
@@ -181,6 +181,30 @@ switch(_operation) do {
 
                 };
 
+                case "OPS_GET_OBJECTIVES": {
+
+                    [_logic,"opsGetObjectives", _data] call MAINCLASS;
+
+                };
+
+                case "OPS_ADD_OBJECTIVE": {
+
+                    [_logic,"opsAddObjective", _data] call MAINCLASS;
+
+                };
+
+                case "OPS_CANCEL_OBJECTIVE": {
+
+                    [_logic,"opsCancelObjective", _data] call MAINCLASS;
+
+                };
+
+                case "OPS_MOVE_OBJECTIVE": {
+
+                    [_logic,"opsMoveObjective", _data] call MAINCLASS;
+
+                };
+
                 default {
 
                     [_logic,_type, _data] call MAINCLASS;
@@ -936,6 +960,221 @@ switch(_operation) do {
             ["OPCOM_OBJECTIVES", [_playerID,_objectiveData]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
 
         };
+    };
+
+    case "opsFindOPCOM": {
+
+        // resolve a selected-opcom ID to its live OPCOM handler, nil if gone
+
+        private _selOpcomID = _args;
+
+        if (!isnil "OPCOM_instances") then {
+            private _index = OPCOM_instances findIf { ([_x,"opcomID",""] call ALiVE_fnc_hashGet) == _selOpcomID };
+            if (_index != -1) then {
+                _result = OPCOM_instances select _index;
+            };
+        };
+
+    };
+
+    case "opsSendObjectives": {
+
+        // pack the selected commander's objectives IN ARRAY ORDER (array order
+        // is the commander's priority queue) and reply with a full snapshot -
+        // every mutation op ends here so the client never tracks indices
+
+        if (_args isEqualType []) then {
+
+            _args params ["_playerID","_selOpcom",["_statusText","",[""]]];
+
+            private _selOpcomID = _selOpcom select 0;
+            private _opcom = [_logic,"opsFindOPCOM", _selOpcomID] call MAINCLASS;
+
+            private _objectiveData = [];
+
+            if (isnil "_opcom") then {
+                if (_statusText == "") then {_statusText = "Commander no longer available"};
+            } else {
+                if (([_opcom,"controltype",""] call ALiVE_fnc_hashGet) == "asymmetric") then {
+                    if (_statusText == "") then {_statusText = "Objectives view not available for asymmetric commanders"};
+                } else {
+                    {
+                        _objectiveData pushBack [
+                            [_x,"objectiveID",""] call ALiVE_fnc_hashGet,
+                            [_x,"center",[]] call ALiVE_fnc_hashGet,
+                            [_x,"size",150] call ALiVE_fnc_hashGet,
+                            [_x,"opcom_state","unassigned"] call ALiVE_fnc_hashGet,
+                            [_x,"objectiveType","unknown"] call ALiVE_fnc_hashGet,
+                            [_x,"playerCreated",false] call ALiVE_fnc_hashGet
+                        ];
+                    } foreach ([_opcom,"objectives",[]] call ALiVE_fnc_HashGet);
+                };
+            };
+
+            private _enabled = [_logic,"playerObjectivesEnabled",false] call ALiVE_fnc_hashGet;
+            private _cooldown = [_logic,"playerObjectiveCooldown",300] call ALiVE_fnc_hashGet;
+            private _maxObjectives = [_logic,"maxPlayerObjectives",3] call ALiVE_fnc_hashGet;
+            private _cooldowns = [_logic,"playerObjectiveCooldowns"] call ALiVE_fnc_hashGet;
+
+            private _cooldownRemaining = 0;
+            if (!isnil "_cooldowns") then {
+                private _lastDesignation = [_cooldowns,_playerID,-999999] call ALiVE_fnc_hashGet;
+                _cooldownRemaining = 0 max (_cooldown - (time - _lastDesignation));
+            };
+
+            private _playerObjectiveCount = [_logic,"opsCountPlayerObjectives", _selOpcom select 2] call MAINCLASS;
+            private _maxReached = _playerObjectiveCount >= _maxObjectives;
+
+            private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
+            ["OPS_OBJECTIVES", [_playerID,[_selOpcom,_objectiveData,[_enabled,_cooldownRemaining,_maxReached,_statusText]]]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
+
+        };
+
+    };
+
+    case "opsCountPlayerObjectives": {
+
+        // player-designated objectives currently active across all commanders
+        // of the given side
+
+        private _side = _args;
+        private _count = 0;
+
+        if (!isnil "OPCOM_instances") then {
+            {
+                if (([_x,"side",""] call ALiVE_fnc_hashGet) == _side) then {
+                    _count = _count + ({[_x,"playerCreated",false] call ALiVE_fnc_hashGet} count ([_x,"objectives",[]] call ALiVE_fnc_HashGet));
+                };
+            } foreach OPCOM_instances;
+        };
+
+        _result = _count;
+
+    };
+
+    case "opsGetObjectives": {
+
+        if (_args isEqualType []) then {
+
+            _args params ["_playerID","_selOpcom"];
+
+            [_logic,"opsSendObjectives",[_playerID,_selOpcom,""]] call MAINCLASS;
+
+        };
+
+    };
+
+    case "opsAddObjective": {
+
+        if (_args isEqualType []) then {
+
+            _args params ["_playerID","_selOpcom","_pos"];
+
+            // server-side enforcement - the client greying is cosmetic only
+
+            private _enabled = [_logic,"playerObjectivesEnabled",false] call ALiVE_fnc_hashGet;
+            if !(_enabled) exitwith {
+                [_logic,"opsSendObjectives",[_playerID,_selOpcom,"Player objectives are disabled"]] call MAINCLASS;
+            };
+
+            private _cooldown = [_logic,"playerObjectiveCooldown",300] call ALiVE_fnc_hashGet;
+            private _cooldowns = [_logic,"playerObjectiveCooldowns"] call ALiVE_fnc_hashGet;
+            private _lastDesignation = [_cooldowns,_playerID,-999999] call ALiVE_fnc_hashGet;
+
+            if (time - _lastDesignation < _cooldown) exitwith {
+                private _remaining = ceil (_cooldown - (time - _lastDesignation));
+                [_logic,"opsSendObjectives",[_playerID,_selOpcom,format ["Objective cooldown: %1s remaining", _remaining]]] call MAINCLASS;
+            };
+
+            private _maxObjectives = [_logic,"maxPlayerObjectives",3] call ALiVE_fnc_hashGet;
+            private _playerObjectiveCount = [_logic,"opsCountPlayerObjectives", _selOpcom select 2] call MAINCLASS;
+
+            if (_playerObjectiveCount >= _maxObjectives) exitwith {
+                [_logic,"opsSendObjectives",[_playerID,_selOpcom,"Maximum player objectives reached"]] call MAINCLASS;
+            };
+
+            private _opcom = [_logic,"opsFindOPCOM", _selOpcom select 0] call MAINCLASS;
+
+            if (isnil "_opcom" || {([_opcom,"controltype",""] call ALiVE_fnc_hashGet) == "asymmetric"}) exitwith {
+                [_logic,"opsSendObjectives",[_playerID,_selOpcom,""]] call MAINCLASS;
+            };
+
+            // front-insert as unassigned - OPCOM classifies it on the next
+            // analysis cycle, and front array position makes it the first
+            // pick within its state bucket
+
+            private _opcomID = [_opcom,"opcomID",""] call ALiVE_fnc_hashGet;
+            private _objectiveID = format ["%1_player_obj_%2", _opcomID, floor (diag_tickTime * 1000)];
+
+            [_opcom,"addObjective",[_objectiveID,_pos,100,"custom",100,"unassigned","none",_opcomID,true,true]] call ALiVE_fnc_OPCOM;
+            [_cooldowns,_playerID,time] call ALiVE_fnc_hashSet;
+
+            [_logic,"opsSendObjectives",[_playerID,_selOpcom,"Objective designated"]] call MAINCLASS;
+
+        };
+
+    };
+
+    case "opsCancelObjective": {
+
+        if (_args isEqualType []) then {
+
+            _args params ["_playerID","_selOpcom","_objectiveID"];
+
+            private _opcom = [_logic,"opsFindOPCOM", _selOpcom select 0] call MAINCLASS;
+
+            if (isnil "_opcom") exitwith {
+                [_logic,"opsSendObjectives",[_playerID,_selOpcom,""]] call MAINCLASS;
+            };
+
+            private _objective = [_opcom,"getObjectiveByID",_objectiveID] call ALiVE_fnc_OPCOM;
+
+            if (isnil "_objective") exitwith {
+                [_logic,"opsSendObjectives",[_playerID,_selOpcom,"Objective no longer exists"]] call MAINCLASS;
+            };
+
+            // only player-designated objectives may be cancelled
+
+            if !([_objective,"playerCreated",false] call ALiVE_fnc_hashGet) exitwith {
+                [_logic,"opsSendObjectives",[_playerID,_selOpcom,"Only player-designated objectives can be cancelled"]] call MAINCLASS;
+            };
+
+            [_opcom,"removeObjective",_objectiveID] call ALiVE_fnc_OPCOM;
+
+            [_logic,"opsSendObjectives",[_playerID,_selOpcom,"Objective cancelled"]] call MAINCLASS;
+
+        };
+
+    };
+
+    case "opsMoveObjective": {
+
+        if (_args isEqualType []) then {
+
+            _args params ["_playerID","_selOpcom","_objectiveID","_direction"];
+
+            private _opcom = [_logic,"opsFindOPCOM", _selOpcom select 0] call MAINCLASS;
+
+            if (isnil "_opcom") exitwith {
+                [_logic,"opsSendObjectives",[_playerID,_selOpcom,""]] call MAINCLASS;
+            };
+
+            // recompute the index server-side - the FSM churns the array, a
+            // client-held index may be stale by the time the event arrives
+
+            private _objectives = [_opcom,"objectives",[]] call ALiVE_fnc_HashGet;
+            private _index = _objectives findIf { ([_x,"objectiveID",""] call ALiVE_fnc_hashGet) == _objectiveID };
+
+            if (_index == -1) exitwith {
+                [_logic,"opsSendObjectives",[_playerID,_selOpcom,"Objective no longer exists"]] call MAINCLASS;
+            };
+
+            [_opcom,"reorderObjective",[_objectiveID,_index + _direction]] call ALiVE_fnc_OPCOM;
+
+            [_logic,"opsSendObjectives",[_playerID,_selOpcom,""]] call MAINCLASS;
+
+        };
+
     };
 
     default {


### PR DESCRIPTION
Implements #969 (player-designated OPCOM objectives), built as an extension of the existing SCOM Operations tablet view rather than a new interface, plus one extra lever that fell out of the research: reordering objective priority.

## What players get

With the new C2ISTAR attribute enabled, the Operations screen (after selecting a commander) gains a "View Objectives" mode:

- The commander's objectives listed in priority order, with state and map overlay (state colours matching the intel view; player objectives marked distinctly)
- Designate: click the map, confirm, and the commander receives a new high-priority objective (front of queue, state "unassigned" so invasion/occupation planning classifies it naturally)
- Cancel: player-designated objectives only
- Move Priority Up / Down on any objective

## Why front-insert and reorder instead of the priority field

While scoping the spike suggested in #969 we found that the objective "priority" field is not consulted at selection time: selectordersbystate picks the first array-order match within each state bucket, and nothing re-sorts after init. Array position is the de facto priority queue. A pinned opcom_state also does not survive (analyzeclusteroccupation resets sectionless objectives every cycle), so array position is the one durable lever a player designation can use. Hence: addObjective gains an insertAtFront option, and a small reorderObjective operation moves an objective to a given index by ID. Reordering is safe mid-run because every async consumer (TACOM, skip lists, resets) resolves objectives by ID or hash reference, never by index.

## Scope and guardrails

- Default OFF via a new C2ISTAR Eden attribute (scomOpsAllowPlayerObjectives); existing missions unchanged
- Per-player cooldown and per-side max, both Eden-tunable and enforced server-side (the toggle is also enforced server-side on every mutation op, not just in the UI)
- Invasion and occupation commanders only; asymmetric excluded
- Player objectives are session-only: filtered out of OPCOM saveData so they never reach persistence
- The playerCreated hash key is appended after _rev, keeping the FSM's positional opcom_state read (select 2 select 5) intact
- Objectives markers use their own slot rather than the shared "marker" list, so intel/ops marker cleanup is unaffected

## Plumbing

Follows the existing SCOM patterns end to end: four new events on the tablet bus (OPS_GET_OBJECTIVES / OPS_ADD_OBJECTIVE / OPS_CANCEL_OBJECTIVE / OPS_MOVE_OBJECTIVE), server ops in commandHandler that reply with a full ordered snapshot after every action (no client-side index bookkeeping), and the standard 5-file Eden attribute chain. No new dialog controls; the objectives view reuses the existing list, map and button slots. In passing, the ops map Draw event handler no longer stacks on repeated tablet opens.

## Test status

sqf_validator and config_validator both pass at the master baseline. In-game testing so far is editor-level; a dedicated-server soak on our test box is next, and I will report findings here. Known behaviour worth calling out for review: under an occupation commander a fresh unassigned objective sits in the last-priority bucket until enemy contact flips it to attack (front position then wins within the bucket); under invasion it is serviced second only to reserve. Happy to adjust any of the above, split the reorder feature out, or hold the PR until soak results are in if preferred.
