### PR TITLE
[UI/SUP_COMMAND] Improve tablet UX, scaling, and multiplayer Instant Join

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__/
 /addons/missions/MPScenarios/ALiVE_Operation_Cobra.SPE_Normandy/ALiVE Operation Cobra v.1.00.4.txt
 /addons/missions/MPScenarios/ALiVE_Operation_Cobra.SPE_Normandy/ALiVE Operation Cobra v.1.00.5.txt
 /addons/alive.lnk
+utils/tools/ALIVE_push_to_game.ps1

--- a/addons/main/XEH_preInit.sqf
+++ b/addons/main/XEH_preInit.sqf
@@ -49,13 +49,15 @@ if (is3DEN) then {
     // events into one run.
     // CfgFunctions may not be compiled in pure-Eden mode (no scenario
     // = no mission preInit = BI's own CfgFunctions phase may be skipped).
-    // Inline-compile the validator here via compile preprocessFileLineNumbers
-    // so it's guaranteed available when the EHs fire. CfgFunctions entry
-    // still registered for completeness / runtime callers.
+    // Inline-compile the validators that use editor-local names, and only fill
+    // missing CfgFunctions globals. In normal mission contexts those globals
+    // are compileFinal and must not be overwritten.
     ALiVE_edenFactionValidator = compile preprocessFileLineNumbers "\x\alive\addons\main\fnc_edenValidateOpcomFactions.sqf";
     ALiVE_edenValidateFactionCompilerSync = compile preprocessFileLineNumbers "\x\alive\addons\main\fnc_edenValidateFactionCompilerSync.sqf";
     // leaf function (config reads + get3DENAttribute only, no ALiVE deps)
-    ALIVE_fnc_edenArtilleryDependencyCheck = compile preprocessFileLineNumbers "\x\alive\addons\main\fnc_edenArtilleryDependencyCheck.sqf";
+    if (isNil "ALIVE_fnc_edenArtilleryDependencyCheck") then {
+        ALIVE_fnc_edenArtilleryDependencyCheck = compile preprocessFileLineNumbers "\x\alive\addons\main\fnc_edenArtilleryDependencyCheck.sqf";
+    };
 
     // Viability Eden chain. Inline-compile the helper functions
     // the assessor reaches transitively, plus the assessor itself,
@@ -69,12 +71,12 @@ if (is3DEN) then {
     // assessor itself. All are leaf functions (no further ALiVE
     // deps) -- verified by grepping ALI(V|v)E_fnc_ across their
     // sources.
-    ALIVE_fnc_hashCreate              = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\data\fnc_hashCreate.sqf";
-    ALIVE_fnc_hashSet                 = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\data\fnc_hashSet.sqf";
-    ALIVE_fnc_hashGet                 = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\data\fnc_hashGet.sqf";
-    ALIVE_fnc_dump                    = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\logging\fnc_dump.sqf";
-    ALIVE_fnc_assessIndexViability    = compile preprocessFileLineNumbers "\x\alive\addons\fnc_analysis\fnc_assessIndexViability.sqf";
-    ALIVE_fnc_indexViabilityEdenCheck = compile preprocessFileLineNumbers "\x\alive\addons\fnc_analysis\fnc_indexViabilityEdenCheck.sqf";
+    if (isNil "ALIVE_fnc_hashCreate") then { ALIVE_fnc_hashCreate = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\data\fnc_hashCreate.sqf"; };
+    if (isNil "ALIVE_fnc_hashSet") then { ALIVE_fnc_hashSet = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\data\fnc_hashSet.sqf"; };
+    if (isNil "ALIVE_fnc_hashGet") then { ALIVE_fnc_hashGet = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\data\fnc_hashGet.sqf"; };
+    if (isNil "ALIVE_fnc_dump") then { ALIVE_fnc_dump = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\logging\fnc_dump.sqf"; };
+    if (isNil "ALIVE_fnc_assessIndexViability") then { ALIVE_fnc_assessIndexViability = compile preprocessFileLineNumbers "\x\alive\addons\fnc_analysis\fnc_assessIndexViability.sqf"; };
+    if (isNil "ALIVE_fnc_indexViabilityEdenCheck") then { ALIVE_fnc_indexViabilityEdenCheck = compile preprocessFileLineNumbers "\x\alive\addons\fnc_analysis\fnc_indexViabilityEdenCheck.sqf"; };
 
     // #887 artillery-donor dropdown (FactionChoice "artilleryOnly" flag):
     // the Eden load handler runs the isArtillery chain to keep only
@@ -83,10 +85,10 @@ if (is3DEN) then {
     // isMagazineOfOrdnanceType; isArtillery additionally needs the hash
     // trio compiled above for its per-class result cache. No other ALiVE
     // deps (verified by grepping the sources).
-    ALIVE_fnc_isArtillery              = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\vehicles\fnc_isArtillery.sqf";
-    ALIVE_fnc_getArtyRounds            = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\config\fnc_getArtyRounds.sqf";
-    ALIVE_fnc_getArtyMagazines         = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\config\fnc_getArtyMagazines.sqf";
-    ALIVE_fnc_isMagazineOfOrdnanceType = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\config\fnc_isMagazineOfOrdnanceType.sqf";
+    if (isNil "ALIVE_fnc_isArtillery") then { ALIVE_fnc_isArtillery = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\vehicles\fnc_isArtillery.sqf"; };
+    if (isNil "ALIVE_fnc_getArtyRounds") then { ALIVE_fnc_getArtyRounds = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\config\fnc_getArtyRounds.sqf"; };
+    if (isNil "ALIVE_fnc_getArtyMagazines") then { ALIVE_fnc_getArtyMagazines = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\config\fnc_getArtyMagazines.sqf"; };
+    if (isNil "ALIVE_fnc_isMagazineOfOrdnanceType") then { ALIVE_fnc_isMagazineOfOrdnanceType = compile preprocessFileLineNumbers "\x\alive\addons\x_lib\functions\config\fnc_isMagazineOfOrdnanceType.sqf"; };
     ["ALiVE 3DEN: inline-compiled validators; OPCOM=%1, compilerSync=%2, hashCreate=%3, hashSet=%4, hashGet=%5, dump=%6, assessor=%7, edenViability=%8",
         typeName ALiVE_edenFactionValidator,
         typeName ALiVE_edenValidateFactionCompilerSync,

--- a/addons/main/data/ui/common.hpp
+++ b/addons/main/data/ui/common.hpp
@@ -1,9 +1,9 @@
-#define GUI_GRID_X  (0)
-#define GUI_GRID_Y  (0)
-#define GUI_GRID_W  (0.025)
-#define GUI_GRID_H  (0.04)
-#define GUI_GRID_WAbs (1)
-#define GUI_GRID_HAbs (1)
+#define GUI_GRID_HAbs        (1.14 * safezoneH)
+#define GUI_GRID_WAbs        (1.2 * GUI_GRID_HAbs)
+#define GUI_GRID_W           (GUI_GRID_WAbs / 40)
+#define GUI_GRID_H           (GUI_GRID_HAbs / 25)
+#define GUI_GRID_X           (safezoneX + (safezoneW - GUI_GRID_WAbs) / 2)
+#define GUI_GRID_Y           (safezoneY + (safezoneH - GUI_GRID_HAbs) / 2)
 
 class RscPicture;
 
@@ -48,7 +48,7 @@ class MainTablet_RscText
     type = 13;
     style = 0x00;
     colorBackground[] = { 0, 0, 0, 0 };
-    size = "((safeZoneW / 75) + (safeZoneH / 225))";
+    size = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 6)";
     y = "safeZoneY + (safeZoneH / 6)";
     w = "safeZoneW / 5";
@@ -87,7 +87,7 @@ class MainTablet_RscListBox {
     type = 5;
     style = 0 + 0x10;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -130,7 +130,7 @@ class MainTablet_RscGUIListBox : MainTablet_RscListBox {
     colorSelectBackground[] = {0.333,0.333,0.333,1};
     colorSelectBackground2[] = {0.333,0.333,0.333,1};
     period = 0;
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     class ListScrollBar
     {
         color[] = {1, 1, 1, 0.6};
@@ -180,7 +180,7 @@ class MainTablet_RscComboBox
     colorActive[] = {0,0,0,1};
     colorDisabled[] = {0,0,0,0.3};
     font = "PuristaMedium";
-    sizeEx = "(safeZoneH / 100) + (safeZoneH / 100)";
+    sizeEx = 0.5 * GUI_GRID_H;
 };
 
 class MainTablet_RscButton
@@ -230,7 +230,7 @@ class MainTablet_RscButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};

--- a/addons/main/data/ui/main.hpp
+++ b/addons/main/data/ui/main.hpp
@@ -16,10 +16,10 @@ class MainTablet
         class MainTablet_background : RscPicture
         {
             idc = -1;
-            x = 0.142424 * safezoneW + safezoneX;
-            y = 0.0632 * safezoneH + safezoneY;
-            w = 0.73 * safezoneW;
-            h = 0.84 * safezoneH;
+            x = 0.142424 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.0632 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.73 * GUI_GRID_WAbs;
+            h = 0.84 * GUI_GRID_HAbs;
             text = "x\alive\addons\main\data\ui\ALiVE_toughbook.paa";
             moving = 0;
             colorBackground[] = {0,0,0,0};
@@ -29,10 +29,10 @@ class MainTablet
         {
             idc = 10002;
             text = "";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.1430 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1430 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -49,14 +49,14 @@ class MainTablet
         class MainTablet_statusList : MainTablet_RscGUIListBox
         {
             idc = 10003;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.58 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.58 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
 

--- a/addons/main/fnc_listFactionVehicleClasses.sqf
+++ b/addons/main/fnc_listFactionVehicleClasses.sqf
@@ -82,14 +82,11 @@ private _isVehicleKind = (_kind in ["land", "air", "support"]);
 // mission init when CBA cfgFunctions actually fires.
 if (isNil "ALIVE_factionDefaultTransport" || {isNil "ALIVE_factionDefaultContainers"}) then {
     ["ALIVE listFactionVehicleClasses: registries not loaded - lazy-loading Placement.hpp + Logistics.hpp"] call ALiVE_fnc_dump;
-    // Force-override the ALiVE hash wrappers - the cfgFunctions-
-    // registered originals aren't reliably callable in 3DEN editor
-    // context. CBA equivalents are functionally identical for the
-    // operations Logistics.hpp / Placement.hpp use. The real wrappers
-    // get reinstalled by cfgFunctions at mission preInit.
-    ALIVE_fnc_hashCreate = CBA_fnc_hashCreate;
-    ALIVE_fnc_hashSet    = CBA_fnc_hashSet;
-    ALIVE_fnc_hashGet    = CBA_fnc_hashGet;
+    // Fill only helpers that pure Eden did not receive from CfgFunctions.
+    // In normal mission contexts the registered functions are compileFinal.
+    if (isNil "ALIVE_fnc_hashCreate") then { ALIVE_fnc_hashCreate = CBA_fnc_hashCreate; };
+    if (isNil "ALIVE_fnc_hashSet") then { ALIVE_fnc_hashSet = CBA_fnc_hashSet; };
+    if (isNil "ALIVE_fnc_hashGet") then { ALIVE_fnc_hashGet = CBA_fnc_hashGet; };
     // Placement.hpp creates ALIVE_factionDefaultSupports / Supplies
     // which Logistics.hpp's CFP/RHS sub-includes reference. Must load
     // Placement FIRST to avoid undefined-hash errors in the cross-

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -61,7 +61,16 @@
 #ifdef RECOMPILE
     #undef RECOMPILE
 #endif
-#define RECOMPILE recompile = 1
+// Addon functions are compiled when their configs are loaded. Recompiling the
+// complete function library at every mission start also recompiles it for the
+// main-menu mission, briefly blocking the UI each time the menu is entered.
+// Keep hot-reload available for local source-development builds without making
+// public development/release builds pay that cost.
+#ifdef ALIVE_DEV_RECOMPILE_FUNCTIONS
+    #define RECOMPILE recompile = 1
+#else
+    #define RECOMPILE recompile = 0
+#endif
 #define MODULE_AUTHOR QUOTE(ALiVE Mod Team)
 #define MACRO_ADDITEM(ITEM,COUNT) class _xx_##ITEM { \
     name = #ITEM; \

--- a/addons/mil_c2istar/data/ui/common.hpp
+++ b/addons/mil_c2istar/data/ui/common.hpp
@@ -1,9 +1,9 @@
-#define GUI_GRID_X  (0)
-#define GUI_GRID_Y  (0)
-#define GUI_GRID_W  (0.025)
-#define GUI_GRID_H  (0.04)
-#define GUI_GRID_WAbs (1)
-#define GUI_GRID_HAbs (1)
+#define GUI_GRID_HAbs        (1.14 * safezoneH)
+#define GUI_GRID_WAbs        (1.2 * GUI_GRID_HAbs)
+#define GUI_GRID_W           (GUI_GRID_WAbs / 40)
+#define GUI_GRID_H           (GUI_GRID_HAbs / 25)
+#define GUI_GRID_X           (safezoneX + (safezoneW - GUI_GRID_WAbs) / 2)
+#define GUI_GRID_Y           (safezoneY + (safezoneH - GUI_GRID_HAbs) / 2)
 
 class RscPicture;
 
@@ -48,7 +48,7 @@ class C2Tablet_RscText
     type = 13;
     style = 0x00;
     colorBackground[] = { 0, 0, 0, 0 };
-    size = "((safeZoneW / 75) + (safeZoneH / 225))";
+    size = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 6)";
     y = "safeZoneY + (safeZoneH / 6)";
     w = "safeZoneW / 5";
@@ -87,7 +87,7 @@ class C2Tablet_RscListBox {
     type = 5;
     style = 0 + 0x10;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -130,7 +130,7 @@ class C2Tablet_RscGUIListBox : C2Tablet_RscListBox {
     colorSelectBackground[] = {0.333,0.333,0.333,1};
     colorSelectBackground2[] = {0.333,0.333,0.333,1};
     period = 0;
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     class ListScrollBar
     {
         color[] = {1, 1, 1, 0.6};
@@ -180,7 +180,7 @@ class C2Tablet_RscComboBox
     colorActive[] = {0,0,0,1};
     colorDisabled[] = {0,0,0,0.3};
     font = "PuristaMedium";
-    sizeEx = "(safeZoneH / 100) + (safeZoneH / 100)";
+    sizeEx = 0.5 * GUI_GRID_H;
 };
 
 // #698 real CT_BUTTON (type 1) base for the Terrain toggle. The tablet's other buttons are
@@ -224,7 +224,7 @@ class C2Tablet_RscRealButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};
@@ -298,7 +298,7 @@ class C2Tablet_RscButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};

--- a/addons/mil_c2istar/data/ui/main.hpp
+++ b/addons/mil_c2istar/data/ui/main.hpp
@@ -13,10 +13,10 @@ class C2Tablet
 
         class C2Tablet_background : RscPicture {
             idc = 70002;
-            x = 0.142424 * safezoneW + safezoneX;
-            y = 0.0632 * safezoneH + safezoneY;
-            w = 0.73 * safezoneW;
-            h = 0.84 * safezoneH;
+            x = 0.142424 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.0632 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.73 * GUI_GRID_WAbs;
+            h = 0.84 * GUI_GRID_HAbs;
             text = "x\alive\addons\main\data\ui\ALiVE_toughbook.paa";
             moving = 0;
         };
@@ -30,10 +30,10 @@ class C2Tablet
         {
             idc = 70007;
             text = "";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.1430 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1430 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -52,11 +52,11 @@ class C2Tablet
             idc = 70006;
             text = "Back";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.7000 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.7000 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.376,0.196,0.204,1};
             colorText[] = {0.706,0.706,0.706,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
@@ -68,11 +68,11 @@ class C2Tablet
             idc = 70010;
             text = "Close";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.7350 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.7350 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.376,0.196,0.204,1};
             colorText[] = {0.706,0.706,0.706,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
@@ -85,10 +85,10 @@ class C2Tablet
         class C2Tablet_TerrainButton : C2Tablet_RscRealButton
         {
             idc = 70003;
-            x = 0.686 * safezoneW + safezoneX;
-            y = 0.098 * safezoneH + safezoneY;
-            w = 0.0597643 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.686 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.098 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0597643 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Terrain";
             periodFocus = 1e10;
             periodOver = 1e10;
@@ -97,31 +97,31 @@ class C2Tablet
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.384,0.439,0.341,1};
             colorFocused[] = {0.706,0.706,0.706,1};
-            sizeEx = 0.9 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
         };
 
         class C2Tablet_currentTaskList : C2Tablet_RscGUIListBox
         {
             idc = 70025;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.35 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.35 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_createTaskButton : C2Tablet_RscButton
         {
             idc = 70016;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.5150 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5150 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Create task";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -130,12 +130,12 @@ class C2Tablet
         class C2Tablet_generateTaskButton : C2Tablet_RscButton
         {
             idc = 70038;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.5480 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5480 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Generate a task";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -144,12 +144,12 @@ class C2Tablet
         class C2Tablet_autoGenerateTaskButton : C2Tablet_RscButton
         {
             idc = 70048;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.5820 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5820 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Auto generate tasks for my side";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -160,11 +160,11 @@ class C2Tablet
             idc = 70026;
             text = "Edit Task";
             style = 0x02;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.6160 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6160 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -175,11 +175,11 @@ class C2Tablet
             idc = 70027;
             text = "Delete Task";
             style = 0x02;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.6500 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6500 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.376,0.196,0.204,1};
             colorText[] = {0.706,0.706,0.706,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
@@ -189,25 +189,25 @@ class C2Tablet
         class C2Tablet_taskPlayerList : C2Tablet_RscGUIListBox
         {
             idc = 70011;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.13 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.13 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_taskSelectGroupButton : C2Tablet_RscButton
         {
             idc = 70014;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.2900 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.2900 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Select all group members";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -217,10 +217,10 @@ class C2Tablet
         {
             idc = 70012;
             text = "Selected Players";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.3290 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.3290 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -237,25 +237,25 @@ class C2Tablet
         class C2Tablet_taskSelectedPlayerList : C2Tablet_RscGUIListBox
         {
             idc = 70013;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.3460 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.13 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.3460 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.13 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_taskSelectedPlayerListDeleteButton : C2Tablet_RscButton
         {
             idc = 70015;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.4770 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.4770 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Delete";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -264,12 +264,12 @@ class C2Tablet
         class C2Tablet_taskSelectedPlayersClearButton : C2Tablet_RscButton
         {
             idc = 70029;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.5100 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5100 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Clear selected players";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -279,10 +279,10 @@ class C2Tablet
         {
             idc = 70018;
             text = "Task Title";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -299,20 +299,20 @@ class C2Tablet
         class C2Tablet_taskingAddTaskTitleEdit : C2Tablet_RscEdit
         {
             idc = 70019;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1770 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1770 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
         };
 
         class C2Tablet_taskingAddTaskDescriptionEditTitle : C2Tablet_RscText
         {
             idc = 70020;
             text = "Task Description";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.2100 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.2100 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -329,10 +329,10 @@ class C2Tablet
         class C2Tablet_taskingAddTaskDescriptionEdit : C2Tablet_RscEdit
         {
             idc = 70021;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.2270 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.13 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.2270 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.13 * GUI_GRID_HAbs;
             style = 16;
         };
 
@@ -340,10 +340,10 @@ class C2Tablet
         {
             idc = 70030;
             text = "Task State";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.3600 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0208 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.3600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0208 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -360,23 +360,23 @@ class C2Tablet
         class C2Tablet_taskingAddTaskStateEditList : C2Tablet_RscGUIListBox
         {
             idc = 70031;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.3770 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.1 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.3770 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.1 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_taskingMap : C2Tablet_RscMap
         {
             idc = 70022;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.1584 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.4 * safezoneH;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1584 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.4 * GUI_GRID_HAbs;
         };
 
         class C2Tablet_taskingAddTaskCreateButton : C2Tablet_RscButton
@@ -384,11 +384,11 @@ class C2Tablet
             idc = 70023;
             text = "Create Task";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.6650 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6650 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -399,11 +399,11 @@ class C2Tablet
             idc = 70028;
             text = "Update Task";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.6650 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6650 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -414,11 +414,11 @@ class C2Tablet
             idc = 70032;
             text = "Assign Players";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.6300 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6300 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -428,10 +428,10 @@ class C2Tablet
         {
             idc = 70033;
             text = "Applied to players";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.4800 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0208 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.4800 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0208 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -448,24 +448,24 @@ class C2Tablet
         class C2Tablet_taskingAddTaskApplyEditList : C2Tablet_RscGUIListBox
         {
             idc = 70034;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.4970 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.06 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.4970 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.06 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_taskingAddTaskSetCurrent : C2Tablet_RscText
         {
             idc = 70035;
             text = "Set Current";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.5600 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0208 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0208 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -482,24 +482,24 @@ class C2Tablet
         class C2Tablet_taskingAddTaskSetCurrentList : C2Tablet_RscGUIListBox
         {
             idc = 70036;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.5770 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.04 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5770 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.04 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_taskingAddTaskStatus : C2Tablet_RscText
         {
             idc = 70037;
             text = "STATUS";
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.5800 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.0208 * safezoneH;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5800 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.0208 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -517,10 +517,10 @@ class C2Tablet
         {
             idc = 70039;
             text = "Select Parent Task";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6250 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0208 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6250 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0208 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -537,24 +537,24 @@ class C2Tablet
         class C2Tablet_taskingCurrentParentTaskList : C2Tablet_RscGUIListBox
         {
             idc = 70040;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.6420 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.11 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6420 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.11 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_taskingGenerateTaskTypeEditTitle : C2Tablet_RscText
         {
             idc = 70041;
             text = "Task Type";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -571,14 +571,14 @@ class C2Tablet
         class C2Tablet_taskingGenerateTaskTypeEdit : C2Tablet_RscGUIListBox
         {
             idc = 70042;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1770 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.11 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1770 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.11 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_taskingGenerateTaskCreateButton : C2Tablet_RscButton
@@ -586,11 +586,11 @@ class C2Tablet
             idc = 70043;
             text = "Generate Task";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.6650 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6650 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -600,10 +600,10 @@ class C2Tablet
         {
             idc = 70044;
             text = "Task Location";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.2900 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.2900 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -620,24 +620,24 @@ class C2Tablet
         class C2Tablet_taskingGenerateTaskLocationEdit : C2Tablet_RscGUIListBox
         {
             idc = 70045;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.3070 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.08 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.3070 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.08 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_taskingGenerateTaskFactionEditTitle : C2Tablet_RscText
         {
             idc = 70046;
             text = "Task Enemy Faction";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.3900 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.3900 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -654,24 +654,24 @@ class C2Tablet
         class C2Tablet_taskingGenerateTaskFactionEdit : C2Tablet_RscGUIListBox
         {
             idc = 70047;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.4070 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.12 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.4070 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.12 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_taskingAutoGenerateTaskFactionEditTitle : C2Tablet_RscText
         {
             idc = 70049;
             text = "Task Enemy Faction";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -688,14 +688,14 @@ class C2Tablet
         class C2Tablet_taskingAutoGenerateTaskFactionEdit : C2Tablet_RscGUIListBox
         {
             idc = 70050;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1770 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.2 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1770 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.2 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_taskingAutoGenerateTaskCreateButton : C2Tablet_RscButton
@@ -703,11 +703,11 @@ class C2Tablet
             idc = 70051;
             text = "Enable Tactical Tasks";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.6650 * safezoneH + safezoneY;
-            w = 0.105 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6650 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.105 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -718,11 +718,11 @@ class C2Tablet
             idc = 70056;
             text = "Enable Strategic Tasks";
             style = 0x02;
-            x = 0.631321 * safezoneW + safezoneX;
-            y = 0.6650 * safezoneH + safezoneY;
-            w = 0.105 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.631321 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6650 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.105 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -732,10 +732,10 @@ class C2Tablet
         {
             idc = 70052;
             text = "Applied to players";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.5300 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0208 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5300 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0208 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -752,24 +752,24 @@ class C2Tablet
         class C2Tablet_taskingGenerateApplyEditList : C2Tablet_RscGUIListBox
         {
             idc = 70053;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.5470 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.06 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5470 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.06 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class C2Tablet_taskingGenerateSetCurrent : C2Tablet_RscText
         {
             idc = 70054;
             text = "Set Current";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6100 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0208 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6100 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0208 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -786,14 +786,14 @@ class C2Tablet
         class C2Tablet_taskingGenerateSetCurrentList : C2Tablet_RscGUIListBox
         {
             idc = 70055;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.6270 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.04 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6270 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.04 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
     };

--- a/addons/mil_c2istar/fnc_C2ISTAR.sqf
+++ b/addons/mil_c2istar/fnc_C2ISTAR.sqf
@@ -1977,13 +1977,17 @@ switch(_operation) do {
                         case "Mapbag01": {
                             createDialog "C2Tablet";
 
+                            private _uiW = (safezoneW / safezoneH) min 1.2;
+                            private _uiH = _uiW / 1.2;
+                            private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+                            private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                             private _ctrlBackground = ((findDisplay 70001) displayCtrl 70002);
                             _ctrlBackground ctrlsettext "x\alive\addons\main\data\ui\ALiVE_mapbag.paa";
                             _ctrlBackground ctrlSetPosition [
-                                0.15 * safezoneW + safezoneX,
-                                -0.242 * safezoneH + safezoneY,
-                                0.72 * safezoneW,
-                                1.372 * safezoneH
+                                0.15 * _uiW + _uiX,
+                                -0.242 * _uiH + _uiY,
+                                0.72 * _uiW,
+                                1.372 * _uiH
                             ];
                             _ctrlBackground ctrlCommit 0;
                         };

--- a/addons/mil_c2istar/fnc_C2MenuDef.sqf
+++ b/addons/mil_c2istar/fnc_C2MenuDef.sqf
@@ -232,13 +232,17 @@ if (_menuName == "C2ISTAR") then {
                             case "Mapbag01": {
                                 createDialog "RscDisplayALIVESITREP";
 
+                                private _uiW = (safezoneW / safezoneH) min 1.2;
+                                private _uiH = _uiW / 1.2;
+                                private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+                                private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                                 private _ctrlBackground = ((findDisplay 90001) displayCtrl 90002);
                                 _ctrlBackground ctrlsettext "x\alive\addons\main\data\ui\ALiVE_mapbag.paa";
                                 _ctrlBackground ctrlSetPosition [
-                                    0.15 * safezoneW + safezoneX,
-                                    -0.242 * safezoneH + safezoneY,
-                                    0.72 * safezoneW,
-                                    1.372 * safezoneH
+                                    0.15 * _uiW + _uiX,
+                                    -0.242 * _uiH + _uiY,
+                                    0.72 * _uiW,
+                                    1.372 * _uiH
                                 ];
                                 _ctrlBackground ctrlCommit 0;
                             };
@@ -265,13 +269,17 @@ if (_menuName == "C2ISTAR") then {
                             case "Mapbag01": {
                                 createDialog "RscDisplayALIVEPATROLREP";
 
+                                private _uiW = (safezoneW / safezoneH) min 1.2;
+                                private _uiH = _uiW / 1.2;
+                                private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+                                private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                                 private _ctrlBackground = ((findDisplay 90002) displayCtrl 90003);
                                 _ctrlBackground ctrlsettext "x\alive\addons\main\data\ui\ALiVE_mapbag.paa";
                                 _ctrlBackground ctrlSetPosition [
-                                    0.15 * safezoneW + safezoneX,
-                                    -0.242 * safezoneH + safezoneY,
-                                    0.72 * safezoneW,
-                                    1.372 * safezoneH
+                                    0.15 * _uiW + _uiX,
+                                    -0.242 * _uiH + _uiY,
+                                    0.72 * _uiW,
+                                    1.372 * _uiH
                                 ];
                                 _ctrlBackground ctrlCommit 0;
                             };

--- a/addons/mil_command/fnc_ambientMovement.sqf
+++ b/addons/mil_command/fnc_ambientMovement.sqf
@@ -128,67 +128,100 @@ if (count _waypoints == 0 && {!_parkedAir}) then {
 
     //defaults
     private _startPos = _pos;
-    private _type = "MOVE";
     private _speed = "LIMITED";
     private _formation = "COLUMN";
+    private _routePositions = [];
+    private _minimumWaypointSeparation = (10 min ((_radius max 0) * 0.1)) max 3;
 
-    for "_i" from 0 to 4 do {
-        if (count _locations > 0) then {
-            private _location = selectRandom _locations;
-            
-            _locations deleteAt (_locations find _location);
-            _pos = position _location;
+    // Generate distinct patrol nodes before adding the CYCLE return. A bounded
+    // retry avoids duplicate/near-duplicate nodes from random, road, shoreline,
+    // or location snapping without risking an unbounded scheduler loop.
+    for "_i" from 0 to 3 do {
+        private _accepted = false;
+        private _candidate = [];
+        private _attempt = 0;
 
-            if (_debug) then {
-                ["ALIVE_fnc_ambientMovement selected the location %1 at %2 as waypoint-index %3 for profileID %4!",_location,_pos,_i,_profileID] call ALiVE_fnc_Dump;
-            };
-        } else {
-            //to be done: min distance to avoid waypoints too close together
-            _pos = [_startPos,_radius] call CBA_fnc_RandPos;
+        while {_attempt < 20 && {!_accepted}} do {
+            _attempt = _attempt + 1;
 
-            if (_vehicleObjectType == "Ship") then {
-                // #943 - boats keep their ambient waypoints ON water. The land
-                // relocation below hands a spawned boat shoreline waypoints its
-                // engine AI can never reach, halting it against the beach.
-                if !(surfaceIsWater _pos) then {
-                    _pos = [_pos] call ALiVE_fnc_getClosestSea;
-                };
-                if !(surfaceIsWater _pos) then { _pos = _startPos; };
-            } else {
-                if (surfaceIsWater _pos) then {
-                    _pos = [_pos] call ALiVE_fnc_getClosestLand;
-                };
-            };
-
-            if (_debug) then {
-                ["ALIVE_fnc_ambientMovement didn't find have locations available on waypoint-index %2 for profileID %3! Selecting random position %1!",_pos,_i,_profileID] call ALiVE_fnc_Dump;
-            };
-        };
-
-        if (_roads) then {
-            private _roadsArray = _pos nearRoads 200;
-
-            if (count _roadsArray > 0) then {
-                _pos = getposATL (selectRandom _roadsArray);
+            if (count _locations > 0) then {
+                private _location = selectRandom _locations;
+                _locations deleteAt (_locations find _location);
+                _candidate = position _location;
 
                 if (_debug) then {
-                    ["ALIVE_fnc_ambientMovement selected a road at %1 as waypoint-index %2 for profileID %3!",_pos,_i, _profileID] call ALiVE_fnc_Dump;
+                    ["ALIVE_fnc_ambientMovement selected the location %1 at %2 as waypoint-index %3 for profileID %4!",_location,_candidate,_i,_profileID] call ALiVE_fnc_Dump;
                 };
             } else {
-                //For ambientmovement keep motorized, mechanized or armored groups on road or default to startposition (which is likely near a road) 
-                _pos = _startPos;
+                _candidate = [_startPos,_radius] call CBA_fnc_RandPos;
+
+                if (_vehicleObjectType == "Ship") then {
+                    // #943 - boats keep their ambient waypoints ON water. The land
+                    // relocation below hands a spawned boat shoreline waypoints its
+                    // engine AI can never reach, halting it against the beach.
+                    if !(surfaceIsWater _candidate) then {
+                        _candidate = [_candidate] call ALiVE_fnc_getClosestSea;
+                    };
+                    if !(surfaceIsWater _candidate) then {_candidate = _startPos};
+                } else {
+                    if (surfaceIsWater _candidate) then {
+                        _candidate = [_candidate] call ALiVE_fnc_getClosestLand;
+                    };
+                };
 
                 if (_debug) then {
-                    ["ALIVE_fnc_ambientMovement has no roads on waypoint-index %2 for profileID %3! Defaulting to startposition %1!",_pos,_i, _profileID] call ALiVE_fnc_Dump;
+                    ["ALIVE_fnc_ambientMovement didn't find have locations available on waypoint-index %2 for profileID %3! Selecting random position %1!",_candidate,_i,_profileID] call ALiVE_fnc_Dump;
+                };
+            };
+
+            if (_roads) then {
+                private _roadsArray = _candidate nearRoads 200;
+
+                if (count _roadsArray > 0) then {
+                    _candidate = getPosATL (selectRandom _roadsArray);
+
+                    if (_debug) then {
+                        ["ALIVE_fnc_ambientMovement selected a road at %1 as waypoint-index %2 for profileID %3!",_candidate,_i,_profileID] call ALiVE_fnc_Dump;
+                    };
+                } else {
+                    // Keep motorized, mechanized, and armored groups on a road or
+                    // reject this candidate and retry from another random position.
+                    _candidate = _startPos;
+
+                    if (_debug) then {
+                        ["ALIVE_fnc_ambientMovement has no roads on waypoint-index %2 for profileID %3! Rejecting candidate at startposition %1!",_candidate,_i,_profileID] call ALiVE_fnc_Dump;
+                    };
+                };
+            };
+
+            if (count _candidate >= 2) then {
+                private _tooClose = (_candidate distance2D _startPos) < _minimumWaypointSeparation;
+                if (!_tooClose) then {
+                    _tooClose = (_routePositions findIf {(_candidate distance2D _x) < _minimumWaypointSeparation}) >= 0;
+                };
+                if (!_tooClose) then {
+                    _accepted = true;
+                    _routePositions pushBack _candidate;
                 };
             };
         };
+    };
 
-        //Loop last Waypoint
-        if (_i == 4) then {_pos = _startPos; _type = "CYCLE"};
+    if !(_routePositions isEqualTo []) then {
+        _routePositions pushBack _startPos;
+        private _routeCount = count _routePositions;
 
-        _profileWaypoint = [_pos, 20, _type, _speed, 50, [], _formation, "NO CHANGE", _behaviour] call ALIVE_fnc_createProfileWaypoint;
-        [_profileWaypoint,"statements",["true","_disableSimulation = true;"]] call ALIVE_fnc_hashSet;
-        [_profile, "addWaypoint", _profileWaypoint] call ALIVE_fnc_profileEntity;
+        {
+            private _previousIndex = if (_forEachIndex == 0) then {_routeCount - 1} else {_forEachIndex - 1};
+            private _nextIndex = if (_forEachIndex == (_routeCount - 1)) then {0} else {_forEachIndex + 1};
+            private _shortestLeg = ((_x distance2D (_routePositions select _previousIndex)) min (_x distance2D (_routePositions select _nextIndex)));
+            // Adjacent radii total at most 90% of their leg, leaving a gap that
+            // prevents a CYCLE route from completing two waypoints at once.
+            private _completionRadius = 50 min (_shortestLeg * 0.45);
+            private _type = if (_forEachIndex == (_routeCount - 1)) then {"CYCLE"} else {"MOVE"};
+            private _profileWaypoint = [_x,20,_type,_speed,_completionRadius,[],_formation,"NO CHANGE",_behaviour] call ALIVE_fnc_createProfileWaypoint;
+            [_profileWaypoint,"statements",["true","_disableSimulation = true;"]] call ALIVE_fnc_hashSet;
+            [_profile,"addWaypoint",_profileWaypoint] call ALIVE_fnc_profileEntity;
+        } forEach _routePositions;
     };
 };

--- a/addons/sup_combatsupport/fnc_radioAction.sqf
+++ b/addons/sup_combatsupport/fnc_radioAction.sqf
@@ -13,13 +13,17 @@ switch (MOD(TABLET_MODEL)) do {
     case "Mapbag01": {
         createDialog "NEO_resourceRadio";
 
+private _uiH = 1.14 * safezoneH;
+private _uiW = 1.2 * _uiH;
+        private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+        private _uiY = safezoneY + (safezoneH - _uiH) / 2;
         private _ctrlBackground = ((findDisplay 655555) displayCtrl 655556);
         _ctrlBackground ctrlsettext "x\alive\addons\main\data\ui\ALiVE_mapbag.paa";
         _ctrlBackground ctrlSetPosition [
-            0.15 * safezoneW + safezoneX,
-            -0.242 * safezoneH + safezoneY,
-            0.72 * safezoneW,
-            1.372 * safezoneH
+            0.15 * _uiW + _uiX,
+            -0.242 * _uiH + _uiY,
+            0.72 * _uiW,
+            1.372 * _uiH
         ];
         _ctrlBackground ctrlCommit 0;
     };

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/arty/fn_artyOrdLbSelChanged.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/arty/fn_artyOrdLbSelChanged.sqf
@@ -4,6 +4,10 @@ private
     "_artyRoundCountLb", "_artyDispersionText", "_artyDispersionSlider", "_artyUnitLb", "_artyRateDelayText", "_artyRateDelaySlider",
     "_battery", "_ord", "_count", "_countArray"
 ];
+private _uiH = 1.14 * safezoneH;
+private _uiW = 1.2 * _uiH;
+private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+private _uiY = safezoneY + (safezoneH - _uiH) / 2;
 
   	    _has_SPE_leFH18 = false;
   	    {
@@ -36,6 +40,7 @@ _battery = _artyArray select (lbCurSel _artyUnitLb) select 0;
 _ord = _artyOrdnanceTypeLb lbData (lbCurSel _artyOrdnanceTypeLb);
 _count = 0;
 _countArray = [];
+{ _x ctrlSetBackgroundColor [0, 0, 0, 0] } forEach [_artyRateOfFireLb, _artyRoundCountLb];
 
 {
     if ((_x select 0) == _ord) then
@@ -51,6 +56,7 @@ if (_count >= 24) then { _countArray pushback ("24 ROUNDS") };
 
 if (count _countArray > 0) then
 {
+    { _x ctrlSetBackgroundColor [0.047, 0.047, 0.047, 0.72] } forEach [_artyRateOfFireLb, _artyRoundCountLb];
     //Texts
     _artyRateOfFireText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>RATE OF FIRE</t>";
     _artyRoundCountText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>ROUND COUNT</t>";
@@ -71,7 +77,7 @@ if (count _countArray > 0) then
     } forEach _countArray;
 
     //Slider
-    _artyDispersionSlider ctrlSetPosition [0.270903 * safezoneW + safezoneX, 0.710018 * safezoneH + safezoneY, (0.105833 * safezoneW), (0.0280024 * safezoneH)];
+    _artyDispersionSlider ctrlSetPosition [0.270903 * _uiW + _uiX, 0.710018 * _uiH + _uiY, (0.105833 * _uiW), (0.0280024 * _uiH)];
     _artyDispersionSlider sliderSetRange [0, 500];
     _artyDispersionSlider sliderSetspeed [1, 50];
     _artyDispersionSlider sliderSetPosition 0;

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/arty/fn_artyRateOfFireLbOnSelChanged.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/arty/fn_artyRateOfFireLbOnSelChanged.sqf
@@ -2,6 +2,10 @@ private
 [
     "_display", "_artyRateOfFireLb", "_rate", "_artyRoundCountLb", "_artyRateDelayText", "_artyRateDelaySlider"
 ];
+private _uiH = 1.14 * safezoneH;
+private _uiW = 1.2 * _uiH;
+private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+private _uiY = safezoneY + (safezoneH - _uiH) / 2;
 _display = findDisplay 655555;
 _artyRateOfFireLb = _this select 0;
 _rate = _artyRateOfFireLb lbText (lbCurSel _artyRateOfFireLb);
@@ -13,7 +17,7 @@ if (_rate == "STAGGERED") then
 {
     _artyRateDelayText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>DELAY - 5/30s</t>";
 
-    _artyRateDelaySlider ctrlSetPosition [0.404129 * safezoneW + safezoneX, 0.710018 * safezoneH + safezoneY, (0.105833 * safezoneW), (0.0280024 * safezoneH)];
+    _artyRateDelaySlider ctrlSetPosition [0.404129 * _uiW + _uiX, 0.710018 * _uiH + _uiY, (0.105833 * _uiW), (0.0280024 * _uiH)];
     _artyRateDelaySlider sliderSetRange [5, 30];
     _artyRateDelaySlider sliderSetspeed [1, 10];
     _artyRateDelaySlider sliderSetPosition 5;
@@ -22,6 +26,6 @@ if (_rate == "STAGGERED") then
 else
 {
     _artyRateDelayText ctrlSetText "";
-    _artyRateDelaySlider ctrlSetPosition [safeZoneX + (safeZoneW / 2), safeZoneY + (safeZoneH / 2), (safeZoneW / 1000), (safeZoneH / 1000)];
+    _artyRateDelaySlider ctrlSetPosition [_uiX + (_uiW / 2), _uiY + (_uiH / 2), (_uiW / 1000), (_uiH / 1000)];
     _artyRateDelaySlider ctrlCommit 0;
 };

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/arty/fn_artyUnitLbSelChanged.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/arty/fn_artyUnitLbSelChanged.sqf
@@ -1,4 +1,8 @@
 private ["_display", "_map"];
+private _uiH = 1.14 * safezoneH;
+private _uiW = 1.2 * _uiH;
+private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+private _uiY = safezoneY + (safezoneH - _uiH) / 2;
 _display = findDisplay 655555;
 _map = _display displayCtrl 655560;
 
@@ -70,15 +74,15 @@ _sitRepButton ctrlEnable (_status != "KILLED");
 if (_status == "RESPONSE") then
 {
     // Get in Range on top, Don't Move below (positive option first)
-    _artyMoveButton ctrlEnable true; _artyMoveButton ctrlSetPosition [0.519796 * safezoneW + safezoneX, 0.584 * safezoneH + safezoneY, (0.216525 * safezoneW), (0.028 * safezoneH)]; _artyMoveButton ctrlCommit 0;
+        _artyMoveButton ctrlEnable true; _artyMoveButton ctrlSetPosition [0.519796 * _uiW + _uiX, 0.584 * _uiH + _uiY, (0.216525 * _uiW), (0.028 * _uiH)]; _artyMoveButton ctrlCommit 0;
     _artyMoveButton ctrlSetEventHandler ["ButtonClick", "_this call NEO_fnc_artyMoveButtons"];
-    _artyDontMoveButton ctrlEnable true; _artyDontMoveButton ctrlSetPosition [0.519796 * safezoneW + safezoneX, 0.6176 * safezoneH + safezoneY, (0.216525 * safezoneW), (0.028 * safezoneH)]; _artyDontMoveButton ctrlCommit 0;
+        _artyDontMoveButton ctrlEnable true; _artyDontMoveButton ctrlSetPosition [0.519796 * _uiW + _uiX, 0.6176 * _uiH + _uiY, (0.216525 * _uiW), (0.028 * _uiH)]; _artyDontMoveButton ctrlCommit 0;
     _artyDontMoveButton ctrlSetEventHandler ["ButtonClick", "_this call NEO_fnc_artyMoveButtons"];
 }
 else
 {
-    _artyMoveButton ctrlEnable false; _artyMoveButton ctrlSetPosition [safeZoneX + (safeZoneW / 1000), safeZoneY + (safeZoneH / 1.425), (safeZoneW / 1000), (safeZoneH / 1000)]; _artyMoveButton ctrlCommit 0;
-    _artyDontMoveButton ctrlEnable false; _artyDontMoveButton ctrlSetPosition [safeZoneX + (safeZoneW / 1000), safeZoneY + (safeZoneH / 1.375), (safeZoneW / 1000), (safeZoneH / 1000)];  _artyDontMoveButton ctrlCommit 0;
+        _artyMoveButton ctrlEnable false; _artyMoveButton ctrlSetPosition [_uiX + (_uiW / 1000), _uiY + (_uiH / 1.425), (_uiW / 1000), (_uiH / 1000)]; _artyMoveButton ctrlCommit 0;
+        _artyDontMoveButton ctrlEnable false; _artyDontMoveButton ctrlSetPosition [_uiX + (_uiW / 1000), _uiY + (_uiH / 1.375), (_uiW / 1000), (_uiH / 1000)];  _artyDontMoveButton ctrlCommit 0;
 };
 
 //Markers
@@ -87,12 +91,14 @@ uinamespace setVariable ["NEO_artyMarkerCreated", nil];
 [[], 0] call NEO_fnc_supportDrawRing; // clear any dispersion ring from the previous target
 
 //Re-initialize Controls
-{ _x ctrlSetPosition [1, 1, (safeZoneW / 1000), (safeZoneH / 1000)]; _x ctrlCommit 0; } forEach [_artyDispersionSlider, _artyRateDelaySlider];
+        { _x ctrlSetPosition [1, 1, (_uiW / 1000), (_uiH / 1000)]; _x ctrlCommit 0; } forEach [_artyDispersionSlider, _artyRateDelaySlider];
 { _x ctrlSetText "" } forEach [_artyOrdnanceTypeText, _artyRateOfFireText, _artyRoundCountText, _artyDispersionText, _artyRateDelayText];
 { lbClear _x } forEach [_artyOrdnanceTypeLb, _artyRateOfFireLb, _artyRoundCountLb];
+{ _x ctrlSetBackgroundColor [0, 0, 0, 0] } forEach [_artyOrdnanceTypeLb, _artyRateOfFireLb, _artyRoundCountLb];
 
 if (!(_status in ["KILLED", "MISSION", "RTB", "MOVE", "RESPONSE", "NOAMMO"]) && count _ord > 0) then
 {
+    _artyOrdnanceTypeLb ctrlSetBackgroundColor [0.047, 0.047, 0.047, 0.72];
     //Ordnance
     _artyOrdnanceTypeText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>ORDNANCE</t>";
     _artyOrdnanceTypeLb ctrlEnable true;

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/cas/fn_casTaskLbSelChanged.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/cas/fn_casTaskLbSelChanged.sqf
@@ -1,4 +1,8 @@
 private ["_lb", "_index", "_display", "_map"];
+private _uiH = 1.14 * safezoneH;
+private _uiW = 1.2 * _uiH;
+private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+private _uiY = safezoneY + (safezoneH - _uiH) / 2;
 _lb = _this select 0;
 _index = _this select 1;
 _display = findDisplay 655555;
@@ -22,6 +26,7 @@ _casAttackRunText = _display displayCtrl 655614;
 _casAttackRunLB = _display displayCtrl 655613;
 _casROELb = _display displayCtrl 655615;
 _casROEText = _display displayCtrl 655616;
+private _listBackground = [0.047, 0.047, 0.047, 0.72];
 
 _show = switch (toUpper (_lb lbData _index)) do
 {
@@ -34,15 +39,17 @@ _casRadiusSlider = _display displayCtrl 655592;
 _casRadiusSliderText = _display displayCtrl 655593;
 _casAttackRunText ctrlSetText "";
 _casAttackRunLB ctrlEnable false;
+{ _x ctrlSetBackgroundColor [0, 0, 0, 0] } forEach [_casAttackRunLB, _casROELb];
 
 //Radius Slider
 if (toUpper (_lb lbData _index) == "SAD" || toUpper (_lb lbData _index) == "LOITER" || toUpper (_lb lbData _index) == "ATTACK") then
 {
+    _casAttackRunLB ctrlSetBackgroundColor _listBackground;
 
     _casRadiusSliderText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>CAS Radius: 500m</t>";
-    _casRadiusSliderText ctrlSetPosition [0.280111 * safezoneW + safezoneX, 0.514 * safezoneH + safezoneY, (0.0927966 * safezoneW), (0.028 * safezoneH)];
+        _casRadiusSliderText ctrlSetPosition [0.280111 * _uiW + _uiX, 0.514 * _uiH + _uiY, (0.0927966 * _uiW), (0.028 * _uiH)];
     _casRadiusSliderText ctrlCommit 0;
-    _casRadiusSlider ctrlSetPosition [0.281002 * safezoneW + safezoneX, 0.5504 * safezoneH + safezoneY, (0.0927966 * safezoneW), (0.0196 * safezoneH)];
+        _casRadiusSlider ctrlSetPosition [0.281002 * _uiW + _uiX, 0.5504 * _uiH + _uiY, (0.0927966 * _uiW), (0.0196 * _uiH)];
     _casRadiusSlider ctrlCommit 0;
 
     _casFlyHeighSliderText ctrlCommit 0;
@@ -76,10 +83,11 @@ if (toUpper (_lb lbData _index) == "SAD" || toUpper (_lb lbData _index) == "LOIT
         _casROELb ctrlEnable false;
         lbClear _casROELb;
     } else {
+        _casROELb ctrlSetBackgroundColor _listBackground;
         _casROEText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>RULES OF ENGAGEMENT</t>";
         // sits just left of the ROE list so "RULES OF ENGAGEMENT" reads flush with it;
         // wide (transparent bg, so the extra width is invisible) to stay on one line
-        _casROEText ctrlSetPosition [0.38 * safezoneW + safezoneX, 0.59 * safezoneH + safezoneY, (0.16 * safezoneW), (0.028 * safezoneH)];
+                _casROEText ctrlSetPosition [0.38 * _uiW + _uiX, 0.59 * _uiH + _uiY, (0.16 * _uiW), (0.028 * _uiH)];
         _casROEText ctrlCommit 0;
 
         _casROELb ctrlEnable true;
@@ -98,7 +106,7 @@ if (toUpper (_lb lbData _index) == "SAD" || toUpper (_lb lbData _index) == "LOIT
     private _usableWeapons = [_veh] call NEO_fnc_casUsableWeapons;
     if (toUpper (_lb lbData _index) == "ATTACK") then {
         _casAttackRunText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>CHOOSE WEAPON</t>";
-        _casAttackRunText ctrlSetPosition [0.280111 * safezoneW + safezoneX, 0.59 * safezoneH + safezoneY, (0.0927966 * safezoneW), (0.028 * safezoneH)];
+                _casAttackRunText ctrlSetPosition [0.280111 * _uiW + _uiX, 0.59 * _uiH + _uiY, (0.0927966 * _uiW), (0.028 * _uiH)];
         _casAttackRunText ctrlCommit 0;
 
         _casAttackRunLB ctrlEnable true;
@@ -124,7 +132,7 @@ if (toUpper (_lb lbData _index) == "SAD" || toUpper (_lb lbData _index) == "LOIT
             // loiter never delivers ordnance - reuse the freed weapon list as a
             // loiter-duration picker (lbData carries seconds; Indefinite = -1)
             _casAttackRunText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>LOITER DURATION</t>";
-            _casAttackRunText ctrlSetPosition [0.280111 * safezoneW + safezoneX, 0.59 * safezoneH + safezoneY, (0.0927966 * safezoneW), (0.028 * safezoneH)];
+                _casAttackRunText ctrlSetPosition [0.280111 * _uiW + _uiX, 0.59 * _uiH + _uiY, (0.0927966 * _uiW), (0.028 * _uiH)];
             _casAttackRunText ctrlCommit 0;
 
             _casAttackRunLB ctrlEnable true;
@@ -153,9 +161,9 @@ if (toUpper (_lb lbData _index) == "SAD" || toUpper (_lb lbData _index) == "LOIT
 else
 {
     _casRadiusSliderText ctrlSetText "";
-    _casRadiusSliderText ctrlSetPosition [safeZoneX + (safeZoneW / 2.255), safeZoneY + (safeZoneH / 1.48), (safeZoneW / 1000), (safeZoneH / 1000)];
+        _casRadiusSliderText ctrlSetPosition [_uiX + (_uiW / 2.255), _uiY + (_uiH / 1.48), (_uiW / 1000), (_uiH / 1000)];
     _casRadiusSliderText ctrlCommit 0;
-    _casRadiusSlider ctrlSetPosition [safeZoneX + (safeZoneW / 2.275), safeZoneY + (safeZoneH / 1.45), (safeZoneW / 1000), (safeZoneH / 1000)];
+        _casRadiusSlider ctrlSetPosition [_uiX + (_uiW / 2.275), _uiY + (_uiH / 1.45), (_uiW / 1000), (_uiH / 1000)];
     _casRadiusSlider ctrlCommit 0;
 
     _casAttackRunText ctrlSetText "";

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/cas/fn_casUnitLbSelChanged.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/cas/fn_casUnitLbSelChanged.sqf
@@ -1,4 +1,8 @@
 private ["_display", "_map"];
+private _uiH = 1.14 * safezoneH;
+private _uiW = 1.2 * _uiH;
+private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+private _uiY = safezoneY + (safezoneH - _uiH) / 2;
 _display = findDisplay 655555;
 _map = _display displayCtrl 655560;
 
@@ -55,9 +59,10 @@ else
 };
 
 //Re-initialize Controls
-{ _x ctrlSetPosition [1, 1, (safeZoneW / 1000), (safeZoneH / 1000)]; _x ctrlCommit 0; } forEach [_casFlyHeightSlider, _casRadiusSlider];
+        { _x ctrlSetPosition [1, 1, (_uiW / 1000), (_uiH / 1000)]; _x ctrlCommit 0; } forEach [_casFlyHeightSlider, _casRadiusSlider];
 { _x ctrlSetText "" } forEach [_casTaskText, _casTaskHelpText, _casROEText, _casFlyHeighSliderText, _casRadiusSliderText, _casAttackRunText];
 { lbClear _x } forEach [_casTaskLb,_casAttackRunLB, _casROELb];
+{ _x ctrlSetBackgroundColor [0, 0, 0, 0] } forEach [_casAttackRunLB, _casROELb];
 
 if (_status != "KILLED") then
 {
@@ -85,9 +90,9 @@ if (_status != "KILLED") then
 
     //Sliders
     _casFlyHeighSliderText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>Altitude: Medium</t>";
-    _casFlyHeighSliderText ctrlSetPosition [0.397304 * safezoneW + safezoneX, 0.514 * safezoneH + safezoneY, (0.105169 * safezoneW), (0.028 * safezoneH)];
+        _casFlyHeighSliderText ctrlSetPosition [0.397304 * _uiW + _uiX, 0.514 * _uiH + _uiY, (0.105169 * _uiW), (0.028 * _uiH)];
     _casFlyHeighSliderText ctrlCommit 0;
-    _casFlyHeightSlider ctrlSetPosition [0.402708 * safezoneW + safezoneX, 0.5508 * safezoneH + safezoneY, (0.0927966 * safezoneW), (0.0196 * safezoneH)];
+        _casFlyHeightSlider ctrlSetPosition [0.402708 * _uiW + _uiX, 0.5508 * _uiH + _uiY, (0.0927966 * _uiW), (0.0196 * _uiH)];
     _casFlyHeightSlider ctrlCommit 0;
 
     _casFlyHeightSlider sliderSetRange [1, 3];

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/fn_radioLbSelChanged.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/fn_radioLbSelChanged.sqf
@@ -1,4 +1,8 @@
 private ["_display", "_map", "_lb", "_index", "_supportMarker", "_artyMarkers", "_sitRepButton"];
+private _uiH = 1.14 * safezoneH;
+private _uiW = 1.2 * _uiH;
+private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+private _uiY = safezoneY + (safezoneH - _uiH) / 2;
 _display = findDisplay 655555;
 _map = _display displayCtrl 655560;
 _lb = _this select 0;
@@ -79,15 +83,27 @@ _artyDispersionText = _display displayCtrl 655608;
 _artyDispersionSlider = _display displayCtrl 655609;
 _artyRateDelayText = _display displayCtrl 655611;
 _artyRateDelaySlider = _display displayCtrl 655612;
+private _listBackground = [0.047, 0.047, 0.047, 0.72];
+private _transportControls = [_transportUnitLb, _transportTaskLb, _transportUnitText, _transportTaskText, _transportHelpUnitText, _transportHelpTaskText, _transportConfirmButton, _transportBaseButton, _transportSmokeFoundButton, _transportSmokeNotFoundButton, _transportSlider, _transportSliderText, _transportHeightCombo, _transportSpeedCombo, _transportRoeCombo, _transportComboText, _objectLb];
+private _casControls = [_casUnitLb, _casUnitText, _casHelpUnitText, _casConfirmButton, _casBaseButton, _casTaskLb, _casTaskText, _casTaskHelpText, _casFlyHeightSlider, _casFlyHeighSliderText, _casRadiusSlider, _casRadiusSliderText, _casAttackRunText, _casAttackRunLB, _casROELb, _casROEText];
+private _artyControls = [_artyUnitLb, _artyUnitText, _artyHelpUnitText, _artyConfirmButton, _artyBaseButton, _artyOrdnanceTypeText, _artyOrdnanceTypeLb, _artyRateOfFireText, _artyRateOfFireLb, _artyRoundCountText, _artyRoundCountLb, _artyMoveButton, _artyDontMoveButton, _artyDispersionText, _artyDispersionSlider, _artyRateDelayText, _artyRateDelaySlider];
 
 //Re-initialize Controls
+// These three categories reuse the same coordinates. Hiding inactive controls is
+// essential: a transparent/disabled list box can still be later in the UI draw
+// order and cover or intercept the active category's rows.
+{ _x ctrlShow false } forEach (_transportControls + _casControls + _artyControls);
 { (_x select 0) ctrlSetEventHandler [(_x select 1), ""] } forEach [[_map, "MouseButtonDown"]];
 uinamespace setVariable ["NEO_radioMapClickArmed", false]; // #698 map-click handler just cleared - mirror for the terrain toggle
-{ _x ctrlSetPosition [1, 1, (safeZoneW / 1000), (safeZoneH / 1000)]; _x ctrlCommit 0; } forEach [_transportConfirmButton, _transportBaseButton, _transportSmokeFoundButton, _transportSmokeNotFoundButton, _transportSlider, _transportSliderText, _casConfirmButton, _casBaseButton, _casFlyHeightSlider, _casRadiusSlider, _artyConfirmButton, _artyMoveButton, _artyDontMoveButton, _artyDispersionSlider, _artyBaseButton, _artyRateDelaySlider, _transportHeightCombo, _transportSpeedCombo, _transportRoeCombo, _objectLb];
+{ _x ctrlSetPosition [1, 1, (_uiW / 1000), (_uiH / 1000)]; _x ctrlCommit 0; } forEach [_transportConfirmButton, _transportBaseButton, _transportSmokeFoundButton, _transportSmokeNotFoundButton, _transportSlider, _transportSliderText, _casConfirmButton, _casBaseButton, _casFlyHeightSlider, _casRadiusSlider, _artyConfirmButton, _artyMoveButton, _artyDontMoveButton, _artyDispersionSlider, _artyBaseButton, _artyRateDelaySlider, _transportHeightCombo, _transportSpeedCombo, _transportRoeCombo, _objectLb];
 { _x ctrlSetText "" } forEach [_transportUnitText, _transportTaskText, _transportHelpUnitText, _transportHelpTaskText, _transportSliderText, _casUnitText, _casHelpUnitText, _casTaskText, _casROEText,_casTaskHelpText, _casFlyHeighSliderText, _casRadiusSliderText, _casAttackRunText, _artyUnitText, _artyHelpUnitText, _artyOrdnanceTypeText, _artyRateOfFireText, _artyRoundCountText, _artyDispersionText, _artyRateDelayText, _transportComboText];
 { _x ctrlEnable false; } forEach [_transportUnitLb, _transportTaskLb, _casUnitLb, _casTaskLb, _casROELb, _casAttackRunLB, _artyUnitLb, _artyOrdnanceTypeLb, _artyRateOfFireLb, _artyRoundCountLb, _transportHeightCombo, _transportSpeedCombo, _transportRoeCombo, _objectLb];
 _sitRepButton ctrlEnable false; // no unit selected yet - each unit handler re-enables it
 { lbClear _x } forEach [_transportUnitLb, _transportTaskLb, _casUnitLb, _casTaskLb, _casROELb, _casAttackRunLB, _artyUnitLb, _artyOrdnanceTypeLb, _artyRateOfFireLb, _artyRoundCountLb, _transportHeightCombo, _transportSpeedCombo, _transportRoeCombo, _objectLb];
+// Transport, CAS and artillery controls deliberately occupy the same layout slots.
+// Disabled list boxes still paint their background, so clear every category before
+// enabling the selected one to prevent opaque panels from stacking over its content.
+{ _x ctrlSetBackgroundColor [0, 0, 0, 0] } forEach [_transportUnitLb, _transportTaskLb, _casUnitLb, _casTaskLb, _casROELb, _casAttackRunLB, _artyUnitLb, _artyOrdnanceTypeLb, _artyRateOfFireLb, _artyRoundCountLb];
 
 //Markers
 { uinamespace setVariable [_x, nil] } forEach ["NEO_transportMarkerCreated", "NEO_casMarkerCreated", "NEO_artyMarkerCreated"];
@@ -98,16 +114,18 @@ switch (toUpper (_lb lbText _index)) do
 {
     case "TRANSPORT" :
     {
+        { _x ctrlShow true } forEach _transportControls;
         private ["_transportArray"];
         _transportArray = NEO_radioLogic getVariable [format ["NEO_radioTrasportArray_%1", playerSide], []];
 
         if ((count _transportArray > 0) && (isNil { NEO_radioLogic getVariable "NEO_radioTalkWithArty" })) then
         {
+            { _x ctrlSetBackgroundColor _listBackground } forEach [_transportUnitLb, _transportTaskLb];
             _transportUnitText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>UNIT</t>";
             _transportHelpUnitText ctrlSetStructuredText parseText "<t color='#FFFF00' size='0.7' font='PuristaMedium'>Select a unit</t>";
             //done
-            _transportConfirmButton ctrlEnable false; _transportConfirmButton ctrlSetPosition [0.519796* safezoneW + safezoneX, 0.6848 * safezoneH + safezoneY, (0.216525 * safezoneW), (0.028 * safezoneH)]; _transportConfirmButton ctrlCommit 0;
-            _transportBaseButton ctrlEnable false; _transportBaseButton ctrlSetPosition [0.519796 * safezoneW + safezoneX, 0.6512 * safezoneH + safezoneY, (0.216525 * safezoneW), (0.028 * safezoneH)]; _transportBaseButton ctrlCommit 0;
+    _transportConfirmButton ctrlEnable false; _transportConfirmButton ctrlSetPosition [0.519796 * _uiW + _uiX, 0.6848 * _uiH + _uiY, (0.216525 * _uiW), (0.028 * _uiH)]; _transportConfirmButton ctrlCommit 0;
+    _transportBaseButton ctrlEnable false; _transportBaseButton ctrlSetPosition [0.519796 * _uiW + _uiX, 0.6512 * _uiH + _uiY, (0.216525 * _uiW), (0.028 * _uiH)]; _transportBaseButton ctrlCommit 0;
 
             if (!isNil { NEO_radioLogic getVariable "NEO_radioTalkWithPilot" }) then
             {
@@ -144,16 +162,18 @@ switch (toUpper (_lb lbText _index)) do
 
     case "CAS" :
     {
+        { _x ctrlShow true } forEach _casControls;
         private ["_casArray"];
         _casArray = NEO_radioLogic getVariable [format ["NEO_radioCasArray_%1", playerSide], []];
 
         if ((count _casArray > 0) && (isNil { NEO_radioLogic getVariable "NEO_radioTalkWithPilot" }) && (isNil { NEO_radioLogic getVariable "NEO_radioTalkWithArty" })) then
         {
+            { _x ctrlSetBackgroundColor _listBackground } forEach [_casUnitLb, _casTaskLb];
             _casUnitText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>UNIT</t>";
             _casHelpUnitText ctrlSetStructuredText parseText "<t color='#FFFF00' size='0.7' font='PuristaMedium'>Select a unit</t>";
             //done
-            _casConfirmButton ctrlEnable false; _casConfirmButton ctrlSetPosition [0.519796 * safezoneW + safezoneX, 0.6848 * safezoneH + safezoneY, (0.216525 * safezoneW), (0.028 * safezoneH)]; _casConfirmButton ctrlCommit 0;
-            _casBaseButton ctrlEnable false; _casBaseButton ctrlSetPosition [0.519796 * safezoneW + safezoneX, 0.6512 * safezoneH + safezoneY, (0.216525 * safezoneW), (0.028 * safezoneH)]; _casBaseButton ctrlCommit 0;
+    _casConfirmButton ctrlEnable false; _casConfirmButton ctrlSetPosition [0.519796 * _uiW + _uiX, 0.6848 * _uiH + _uiY, (0.216525 * _uiW), (0.028 * _uiH)]; _casConfirmButton ctrlCommit 0;
+    _casBaseButton ctrlEnable false; _casBaseButton ctrlSetPosition [0.519796 * _uiW + _uiX, 0.6512 * _uiH + _uiY, (0.216525 * _uiW), (0.028 * _uiH)]; _casBaseButton ctrlCommit 0;
 
             _casUnitLb ctrlEnable true;
             lbClear _casUnitLb;
@@ -175,6 +195,7 @@ switch (toUpper (_lb lbText _index)) do
 
     case "ARTY" :
     {
+        { _x ctrlShow true } forEach _artyControls;
     	
     	
   	    _has_SPE_leFH18 = false;
@@ -196,11 +217,12 @@ switch (toUpper (_lb lbText _index)) do
 
         if ((count _artyArray > 0) && (isNil { NEO_radioLogic getVariable "NEO_radioTalkWithPilot" })) then
         {
+            { _x ctrlSetBackgroundColor _listBackground } forEach [_artyUnitLb, _artyOrdnanceTypeLb];
             _artyUnitText ctrlSetStructuredText parseText "<t color='#B4B4B4' size='0.8' font='PuristaMedium'>BATTERY</t>";
             _artyHelpUnitText ctrlSetStructuredText parseText "<t color='#FFFF00' size='0.7' font='PuristaMedium'>Select a battery</t>";
             //done
-            _artyConfirmButton ctrlEnable false; _artyConfirmButton ctrlSetPosition [0.519796 * safezoneW + safezoneX, 0.6848 * safezoneH + safezoneY, (0.216525 * safezoneW), (0.028 * safezoneH)]; _artyConfirmButton ctrlCommit 0;
-            _artyBaseButton ctrlEnable false; _artyBaseButton ctrlSetPosition [0.519796 * safezoneW + safezoneX, 0.6512 * safezoneH + safezoneY, (0.216525 * safezoneW), (0.028 * safezoneH)]; _artyBaseButton ctrlCommit 0;
+    _artyConfirmButton ctrlEnable false; _artyConfirmButton ctrlSetPosition [0.519796 * _uiW + _uiX, 0.6848 * _uiH + _uiY, (0.216525 * _uiW), (0.028 * _uiH)]; _artyConfirmButton ctrlCommit 0;
+    _artyBaseButton ctrlEnable false; _artyBaseButton ctrlSetPosition [0.519796 * _uiW + _uiX, 0.6512 * _uiH + _uiY, (0.216525 * _uiW), (0.028 * _uiH)]; _artyBaseButton ctrlCommit 0;
 
             if (!isNil { NEO_radioLogic getVariable "NEO_radioTalkWithArty" }) then
             {

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/transport/fn_transportTaskLbSelChanged.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/transport/fn_transportTaskLbSelChanged.sqf
@@ -1,4 +1,8 @@
 private ["_display", "_text", "_lb", "_index", "_slider", "_sliderText", "_show", "_chopper"];
+private _uiH = 1.14 * safezoneH;
+private _uiW = 1.2 * _uiH;
+private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+private _uiY = safezoneY + (safezoneH - _uiH) / 2;
 _display = findDisplay 655555;
 _text = _display displayCtrl 655573;
 _lb = _this select 0;
@@ -40,13 +44,13 @@ _task = switch (_lb lbText _index) do
 {
     CASE "CIRCLE" :
     {
-        _objectLb ctrlSetPosition [safeZoneX + (safeZoneW / 2.275), safeZoneY + (safeZoneH / 1.45), (safeZoneW / 1000), (safeZoneH / 1000)];
+        _objectLb ctrlSetPosition [_uiX + (_uiW / 2.275), _uiY + (_uiH / 1.45), (_uiW / 1000), (_uiH / 1000)];
         _objectLb ctrlCommit 0;
         _objectLb ctrlEnable false;
-        _slider ctrlSetPosition [0.281002 * safezoneW + safezoneX, 0.5504 * safezoneH + safezoneY, (0.0927966 * safezoneW), (0.0196 * safezoneH)];
+        _slider ctrlSetPosition [0.281002 * _uiW + _uiX, 0.5504 * _uiH + _uiY, (0.0927966 * _uiW), (0.0196 * _uiH)];
         _slider ctrlCommit 0;
         _sliderText ctrlSetText "Radius: 200/300";
-        _sliderText ctrlSetPosition [0.225 * safezoneW + safezoneX, 0.52 * safezoneH + safezoneY, (0.19 * safezoneW), (0.028 * safezoneH)];
+        _sliderText ctrlSetPosition [0.225 * _uiW + _uiX, 0.52 * _uiH + _uiY, (0.19 * _uiW), (0.028 * _uiH)];
         _sliderText ctrlCommit 0;
 
         _slider sliderSetRange [100, 300];
@@ -64,13 +68,13 @@ _task = switch (_lb lbText _index) do
     };
     CASE "INSERTION" :
     {
-        _objectLb ctrlSetPosition [safeZoneX + (safeZoneW / 2.275), safeZoneY + (safeZoneH / 1.45), (safeZoneW / 1000), (safeZoneH / 1000)];
+        _objectLb ctrlSetPosition [_uiX + (_uiW / 2.275), _uiY + (_uiH / 1.45), (_uiW / 1000), (_uiH / 1000)];
         _objectLb ctrlCommit 0;
         _objectLb ctrlEnable false;
-        _slider ctrlSetPosition [0.281002 * safezoneW + safezoneX, 0.5504 * safezoneH + safezoneY, (0.0927966 * safezoneW), (0.0196 * safezoneH)];
+        _slider ctrlSetPosition [0.281002 * _uiW + _uiX, 0.5504 * _uiH + _uiY, (0.0927966 * _uiW), (0.0196 * _uiH)];
         _slider ctrlCommit 0;
         _sliderText ctrlSetText "Height: 20/50";
-        _sliderText ctrlSetPosition [0.225 * safezoneW + safezoneX, 0.52 * safezoneH + safezoneY, (0.19 * safezoneW), (0.028 * safezoneH)];
+        _sliderText ctrlSetPosition [0.225 * _uiW + _uiX, 0.52 * _uiH + _uiY, (0.19 * _uiW), (0.028 * _uiH)];
         _sliderText ctrlCommit 0;
 
         _slider sliderSetRange [2, 50];
@@ -90,12 +94,12 @@ _task = switch (_lb lbText _index) do
     CASE "SLINGLOAD" :
     {
         private ["_pos"];
-        _slider ctrlSetPosition [safeZoneX + (safeZoneW / 2.275), safeZoneY + (safeZoneH / 1.45), (safeZoneW / 1000), (safeZoneH / 1000)];
+        _slider ctrlSetPosition [_uiX + (_uiW / 2.275), _uiY + (_uiH / 1.45), (_uiW / 1000), (_uiH / 1000)];
         _slider ctrlCommit 0;
-        _objectLb ctrlSetPosition [0.280111 * safezoneW + safezoneX, 0.5504 * safezoneH + safezoneY, (0.22 * safezoneW), (0.028 * safezoneH)];
+        _objectLb ctrlSetPosition [0.280111 * _uiW + _uiX, 0.5504 * _uiH + _uiY, (0.22 * _uiW), (0.028 * _uiH)];
         _objectLb ctrlCommit 0;
         _sliderText ctrlSetText "Select cargo to lift:";
-        _sliderText ctrlSetPosition [0.280111 * safezoneW + safezoneX, 0.52 * safezoneH + safezoneY, (0.19 * safezoneW), (0.028 * safezoneH)]; // indent to line up with the cargo box below (was 0.225, flush with the section labels)
+        _sliderText ctrlSetPosition [0.280111 * _uiW + _uiX, 0.52 * _uiH + _uiY, (0.19 * _uiW), (0.028 * _uiH)]; // indent to line up with the cargo box below (was 0.225, flush with the section labels)
         _sliderText ctrlCommit 0;
 
         _pos = getMarkerPos (uinamespace getVariable ["NEO_transportMarkerCreated","unknown"]);
@@ -137,13 +141,13 @@ _task = switch (_lb lbText _index) do
     };
     CASE DEFAULT
     {
-        _objectLb ctrlSetPosition [safeZoneX + (safeZoneW / 2.275), safeZoneY + (safeZoneH / 1.45), (safeZoneW / 1000), (safeZoneH / 1000)];
+        _objectLb ctrlSetPosition [_uiX + (_uiW / 2.275), _uiY + (_uiH / 1.45), (_uiW / 1000), (_uiH / 1000)];
         _objectLb ctrlCommit 0;
         _objectLb ctrlEnable false;
-        _slider ctrlSetPosition [safeZoneX + (safeZoneW / 2.275), safeZoneY + (safeZoneH / 1.45), (safeZoneW / 1000), (safeZoneH / 1000)];
+        _slider ctrlSetPosition [_uiX + (_uiW / 2.275), _uiY + (_uiH / 1.45), (_uiW / 1000), (_uiH / 1000)];
         _slider ctrlCommit 0;
         _sliderText ctrlSetText "";
-        _sliderText ctrlSetPosition [safeZoneX + (safeZoneW / 2.255), safeZoneY + (safeZoneH / 1.48), (safeZoneW / 1000), (safeZoneH / 1000)];
+        _sliderText ctrlSetPosition [_uiX + (_uiW / 2.255), _uiY + (_uiH / 1.48), (_uiW / 1000), (_uiH / 1000)];
         _sliderText ctrlCommit 0;
     };
 };

--- a/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/transport/fn_transportUnitLbSelChanged.sqf
+++ b/addons/sup_combatsupport/scripts/NEO_radio/functions/ui/transport/fn_transportUnitLbSelChanged.sqf
@@ -4,6 +4,10 @@ private
     "_supportMarker", "_slider", "_sliderText", "_transportHeightCombo", "_transportSpeedCombo", "_transportRoeCombo", "_transportComboText", "_flyingProperties",
     "_height", "_speed", "_roeIndex", "_roe"
 ];
+private _uiH = 1.14 * safezoneH;
+private _uiW = 1.2 * _uiH;
+private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+private _uiY = safezoneY + (safezoneH - _uiH) / 2;
 _display = findDisplay 655555;
 _map = _display displayCtrl 655560;
 _transportBaseButton = _display displayCtrl 655575;
@@ -64,14 +68,14 @@ _transportSmokeNotFoundButton = _display displayCtrl 655577;
 
 if (_chopper getVariable "NEO_radioTrasportUnitStatus" == "SMOKECONF") then
 {
-    _transportSmokeFoundButton ctrlEnable true; _transportSmokeFoundButton ctrlSetPosition [0.519796 * safezoneW + safezoneX, 0.6176 * safezoneH + safezoneY, (0.216525 * safezoneW), (0.028 * safezoneH)]; _transportSmokeFoundButton ctrlCommit 0;
-    _transportSmokeNotFoundButton ctrlEnable true; _transportSmokeNotFoundButton ctrlSetPosition [0.519796 * safezoneW + safezoneX, 0.584 * safezoneH + safezoneY, (0.216525 * safezoneW), (0.028 * safezoneH)]; _transportSmokeNotFoundButton ctrlCommit 0;
+        _transportSmokeFoundButton ctrlEnable true; _transportSmokeFoundButton ctrlSetPosition [0.519796 * _uiW + _uiX, 0.6176 * _uiH + _uiY, (0.216525 * _uiW), (0.028 * _uiH)]; _transportSmokeFoundButton ctrlCommit 0;
+        _transportSmokeNotFoundButton ctrlEnable true; _transportSmokeNotFoundButton ctrlSetPosition [0.519796 * _uiW + _uiX, 0.584 * _uiH + _uiY, (0.216525 * _uiW), (0.028 * _uiH)]; _transportSmokeNotFoundButton ctrlCommit 0;
 }
 else
 
 {
-    _transportSmokeFoundButton ctrlEnable false; _transportSmokeFoundButton ctrlSetPosition [safeZoneX + (safeZoneW / 1000), safeZoneY + (safeZoneH / 1.425), (safeZoneW / 1000), (safeZoneH / 1000)]; _transportSmokeFoundButton ctrlCommit 0;
-    _transportSmokeNotFoundButton ctrlEnable false; _transportSmokeNotFoundButton ctrlSetPosition [safeZoneX + (safeZoneW / 1000), safeZoneY + (safeZoneH / 1.375), (safeZoneW / 1000), (safeZoneH / 1000)]; _transportSmokeNotFoundButton ctrlCommit 0;
+        _transportSmokeFoundButton ctrlEnable false; _transportSmokeFoundButton ctrlSetPosition [_uiX + (_uiW / 1000), _uiY + (_uiH / 1.425), (_uiW / 1000), (_uiH / 1000)]; _transportSmokeFoundButton ctrlCommit 0;
+        _transportSmokeNotFoundButton ctrlEnable false; _transportSmokeNotFoundButton ctrlSetPosition [_uiX + (_uiW / 1000), _uiY + (_uiH / 1.375), (_uiW / 1000), (_uiH / 1000)]; _transportSmokeNotFoundButton ctrlCommit 0;
 };
 
 //Transport Tasks
@@ -87,7 +91,7 @@ if ([(configFile >> "CfgVehicles" >> typeOf _chopper >> "slingLoadMaxCargoMass")
 
 
 //Re-initialize Controls
-{ _x ctrlSetPosition [1, 1, (safeZoneW / 1000), (safeZoneH / 1000)]; _x ctrlCommit 0; } forEach [_slider, _sliderText, _transportHeightCombo, _transportSpeedCombo, _transportRoeCombo];
+        { _x ctrlSetPosition [1, 1, (_uiW / 1000), (_uiH / 1000)]; _x ctrlCommit 0; } forEach [_slider, _sliderText, _transportHeightCombo, _transportSpeedCombo, _transportRoeCombo];
 { _x ctrlSetText "" } forEach [_sliderText, _transportTaskText, _transportHelpTaskText, _transportComboText];
 { lbClear _x } forEach [_transportTaskLb, _transportHeightCombo, _transportSpeedCombo, _transportRoeCombo];
 
@@ -118,10 +122,10 @@ if (_status != "KILLED") then
     uinamespace setVariable ["NEO_radioMapClickArmed", true]; // #698 mirror the map-click handler state for the terrain toggle
 
     //ComboBoxes
-    _transportHeightCombo ctrlEnable true; _transportHeightCombo ctrlSetPosition [0.278525 * safezoneW + safezoneX, 0.64 * safezoneH + safezoneY, (0.0927966 * safezoneW), (0.028 * safezoneH)]; _transportHeightCombo ctrlCommit 0;
-    _transportSpeedCombo ctrlEnable true; _transportSpeedCombo ctrlSetPosition [0.401017 * safezoneW + safezoneX, 0.64 * safezoneH + safezoneY, (0.0927966 * safezoneW), (0.028 * safezoneH)]; _transportSpeedCombo ctrlCommit 0;
-    _transportRoeCombo ctrlEnable true; _transportRoeCombo ctrlSetPosition [0.339153 * safezoneW + safezoneX, 0.696 * safezoneH + safezoneY, (0.0927966 * safezoneW), (0.028 * safezoneH)]; _transportRoeCombo ctrlCommit 0;
-    _transportComboText ctrlSetText "Behaviour"; _transportComboText ctrlSetPosition [0.363898 * safezoneW + safezoneX, 0.598 * safezoneH + safezoneY, (0.0494915 * safezoneW), (0.028 * safezoneH)]; _transportComboText ctrlCommit 0;
+        _transportHeightCombo ctrlEnable true; _transportHeightCombo ctrlSetPosition [0.278525 * _uiW + _uiX, 0.64 * _uiH + _uiY, (0.0927966 * _uiW), (0.028 * _uiH)]; _transportHeightCombo ctrlCommit 0;
+        _transportSpeedCombo ctrlEnable true; _transportSpeedCombo ctrlSetPosition [0.401017 * _uiW + _uiX, 0.64 * _uiH + _uiY, (0.0927966 * _uiW), (0.028 * _uiH)]; _transportSpeedCombo ctrlCommit 0;
+        _transportRoeCombo ctrlEnable true; _transportRoeCombo ctrlSetPosition [0.339153 * _uiW + _uiX, 0.696 * _uiH + _uiY, (0.0927966 * _uiW), (0.028 * _uiH)]; _transportRoeCombo ctrlCommit 0;
+        _transportComboText ctrlSetText "Behaviour"; _transportComboText ctrlSetPosition [0.363898 * _uiW + _uiX, 0.598 * _uiH + _uiY, (0.0494915 * _uiW), (0.028 * _uiH)]; _transportComboText ctrlCommit 0;
 
     lbClear _transportHeightCombo;
     {

--- a/addons/sup_combatsupport/scripts/NEO_radio/hpp/common.hpp
+++ b/addons/sup_combatsupport/scripts/NEO_radio/hpp/common.hpp
@@ -1,9 +1,9 @@
-#define GUI_GRID_X  (0)
-#define GUI_GRID_Y  (0)
-#define GUI_GRID_W  (0.025)
-#define GUI_GRID_H  (0.04)
-#define GUI_GRID_WAbs (1)
-#define GUI_GRID_HAbs (1)
+#define GUI_GRID_HAbs        (1.14 * safezoneH)
+#define GUI_GRID_WAbs        (1.2 * GUI_GRID_HAbs)
+#define GUI_GRID_W           (GUI_GRID_WAbs / 40)
+#define GUI_GRID_H           (GUI_GRID_HAbs / 25)
+#define GUI_GRID_X           (safezoneX + (safezoneW - GUI_GRID_WAbs) / 2)
+#define GUI_GRID_Y           (safezoneY + (safezoneH - GUI_GRID_HAbs) / 2)
 
 // Combat Support tablet font sizing (referenced by the list/button controls in main.hpp).
 // Lists previously drew the glyph at the full row height, so the text looked oversized
@@ -11,10 +11,10 @@
 // list heights (so the visible row count never drifts by monitor), while CS_LIST_SIZE
 // shrinks just the glyph within the row. CS_BTN_SIZE is the fixed button/caption size.
 // Tune the leading multipliers, then rebuild sup_combatsupport.
-#define CS_LIST_FORMULA ((safeZoneW / 75) + (safeZoneH / 275))
+#define CS_LIST_FORMULA (0.5 * GUI_GRID_H)
 #define CS_LIST_SIZE (0.85 * CS_LIST_FORMULA)   // list / combo glyph height (was 1.0 * formula)
 #define CS_LIST_ROW  (1.0 * CS_LIST_FORMULA)    // list row height (lower for tighter rows)
-#define CS_BTN_SIZE  (0.9 * GUI_GRID_H)         // button / caption glyph (was 0.8)
+#define CS_BTN_SIZE  (0.5 * GUI_GRID_H)         // button / caption glyph
 
 class RscPicture;
 
@@ -74,7 +74,7 @@ class NEO_RscText
     type = 13;
     style = 0x00;
     colorBackground[] = { 0, 0, 0, 0 };
-    size = "((safeZoneW / 75) + (safeZoneH / 225))";
+    size = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 6)";
     y = "safeZoneY + (safeZoneH / 6)";
     w = "safeZoneW / 5";
@@ -119,7 +119,7 @@ class NEO_RscListBox {
     type = 5;
     style = 0 + 0x10;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -162,7 +162,7 @@ class NEO_RscGUIListBox : NEO_RscListBox {
     colorSelectBackground[] = {0.6, 0.839, 0.47, 0.3};
     colorSelectBackground2[] = {0.6, 0.839, 0.47, 1};
     period = 0;
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
 class ListScrollBar
     {
         color[] = {1, 1, 1, 0.6};
@@ -215,7 +215,7 @@ class NEO_RscComboBox
     colorActive[] = {0,0,0,1};
     colorDisabled[] = {0,0,0,0.3};
     font = "PuristaMedium";
-    sizeEx = "(safeZoneH / 100) + (safeZoneH / 100)";
+    sizeEx = 0.5 * GUI_GRID_H;
 };
 
 
@@ -258,7 +258,7 @@ class NEO_RscButton
   animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
  soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
  soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};

--- a/addons/sup_combatsupport/scripts/NEO_radio/hpp/main.hpp
+++ b/addons/sup_combatsupport/scripts/NEO_radio/hpp/main.hpp
@@ -12,10 +12,10 @@ class NEO_resourceRadio
             class NEO_radioBackground : RscPicture
             {
                 idc = 655556;
-                x = 0.142424 * safezoneW + safezoneX;
-                y = 0.0632 * safezoneH + safezoneY;
-                w = 0.73 * safezoneW;
-                h = 0.84 * safezoneH;
+                x = 0.142424 * GUI_GRID_WAbs + GUI_GRID_X;
+                y = 0.0632 * GUI_GRID_HAbs + GUI_GRID_Y;
+                w = 0.73 * GUI_GRID_WAbs;
+                h = 0.84 * GUI_GRID_HAbs;
                 text = "x\alive\addons\main\data\ui\ALiVE_toughbook.paa";
                 moving = 0;
                 colorBackground[] = {0,0,0,0};
@@ -28,10 +28,10 @@ class NEO_resourceRadio
                 class NEO_radioMap : NEO_RscMap
                 {
                         idc = 655560;
-                        x = 0.519796 * safezoneW + safezoneX;
-                        y = 0.1584 * safezoneH + safezoneY;
-                        w = 0.216525 * safezoneW;
-                        h = 0.42 * safezoneH;
+                        x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.1584 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.216525 * GUI_GRID_WAbs;
+                        h = 0.42 * GUI_GRID_HAbs;
                 };
 
                 //Main Support Title
@@ -39,10 +39,10 @@ class NEO_resourceRadio
                 {
                         idc = -1;
                         text = "Combat Support Available"; //--- ToDo: Localize;
-                        x = 0.271103 * safezoneW + safezoneX;
-                        y = 0.1584 * safezoneH + safezoneY;
-                        w = 0.159596 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.271103 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.1584 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.159596 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         class Attributes
                         {
@@ -62,10 +62,10 @@ class NEO_resourceRadio
                         idc = 655561;
                         text = "Close";
                         style = 2;
-                        x = 0.519796 * safezoneW + safezoneX;
-                        y = 0.7184 * safezoneH + safezoneY;
-                        w = 0.216525 * safezoneW;
-                        h = 0.028 * safezoneH;
+                        x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.7184 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.216525 * GUI_GRID_WAbs;
+                        h = 0.028 * GUI_GRID_HAbs;
                         sizeEx = CS_BTN_SIZE;
                         colorBackground[] = {0.376,0.196,0.204,1};
                         colorText[] = {0.706,0.706,0.706,1};
@@ -78,11 +78,11 @@ class NEO_resourceRadio
                 class NEO_radioMainList : NEO_RscGUIListBox
                 {
                         idc = 655565;
-                        x = 0.271102 * safezoneW + safezoneX;
-                        y = 0.1892 * safezoneH + safezoneY;
-                        w = 0.241271 * safezoneW;
-                        h = 0.084 * safezoneH;
-                        colorBackground[] = {0,0,0,0};
+                        x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.1892 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.241271 * GUI_GRID_WAbs;
+                        h = 0.084 * GUI_GRID_HAbs;
+                        colorBackground[] = {0.047,0.047,0.047,0.72};
                         colorActive[] = {0.384,0.439,0.341,1};
                         sizeEx = CS_LIST_SIZE;
                         rowHeight = CS_LIST_ROW;
@@ -95,10 +95,13 @@ class NEO_resourceRadio
                         idc = 655568;
                         sizeEx = CS_LIST_SIZE;
                         rowHeight = CS_LIST_ROW;
-                        x = 0.269865 * safezoneW + safezoneX;
-                        y = 0.3068 * safezoneH + safezoneY;
-                        w = 0.242507 * safezoneW;
-                        h = 0.084 * safezoneH;
+                        x = 0.269865 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.3068 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.242507 * GUI_GRID_WAbs;
+                        h = 0.084 * GUI_GRID_HAbs;
+                        // Category lists share screen space; only the active category
+                        // receives a shaded background at runtime.
+                        colorBackground[] = {0,0,0,0};
                         colorActive[] = {0.384,0.439,0.341,1};
                 };
 
@@ -108,11 +111,11 @@ class NEO_resourceRadio
                         idc = 655569;
                         sizeEx = CS_LIST_SIZE;
                         rowHeight = CS_LIST_ROW;
-                        x = 0.269865 * safezoneW + safezoneX;
-                        y = 0.4272 * safezoneH + safezoneY;
-                        w = 0.242507 * safezoneW;
-                        h = 0.09 * safezoneH; // ends ~0.517, clearing the sling-load message/cargo row at y=0.52 (0.15 overlapped it); boxed above by the TASK header ending ~0.4244
-                        colorBackground[] = {0,0,0,0}; // transparent - this list shares the y-slot with the CAS/ARTY controls (disabled+empty when they're active), so the extra height must never draw over them
+                        x = 0.269865 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.4272 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.242507 * GUI_GRID_WAbs;
+                        h = 0.09 * GUI_GRID_HAbs; // ends ~0.517, clearing the sling-load message/cargo row at y=0.52 (0.15 overlapped it); boxed above by the TASK header ending ~0.4244
+                        colorBackground[] = {0,0,0,0};
                         colorActive[] = {0.384,0.439,0.341,1};
                 };
 
@@ -120,10 +123,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportUnitText : NEO_RscText
                 {
                         idc = 655570;
-                        x = 0.271103 * safezoneW + safezoneX;
-                        y = 0.2732 * safezoneH + safezoneY;
-                        w = 0.0779492 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.271103 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.2732 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.0779492 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorText[] = {0.384,0.439,0.341,1};
                         colorBackground[] = {0,0,0,0};
                         sizeEx = CS_BTN_SIZE;
@@ -134,10 +137,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportTaskText : NEO_radioTransportUnitText
                 {
                         idc = 655571;
-                        x = 0.271103 * safezoneW + safezoneX;
-                        y = 0.3936 * safezoneH + safezoneY;
-                        w = 0.0742373 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.271103 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.3936 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.0742373 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorText[] = {0.384,0.439,0.341,1};
                         colorBackground[] = {0,0,0,0};
                         sizeEx = CS_BTN_SIZE;
@@ -148,10 +151,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportHelpUnitText : NEO_radioTransportUnitText
                 {
                         idc = 655572;
-                        x = 0.351527 * safezoneW + safezoneX;
-                        y = 0.2732 * safezoneH + safezoneY;
-                        w = 0.160845 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.351527 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.2732 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.160845 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         sizeEx = 0.6 * GUI_GRID_H;
                         text = "";
@@ -161,10 +164,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportHelpTaskText : NEO_radioTransportHelpUnitText
                 {
                         idc = 655573;
-                        x = 0.351525 * safezoneW + safezoneX;
-                        y = 0.3936 * safezoneH + safezoneY;
-                        w = 0.160845 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.351525 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.3936 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.160845 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         sizeEx = 0.6 * GUI_GRID_H;
                         text = "";
@@ -174,10 +177,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportConfirmButton : NEO_RscButton
                 {
                         idc = 655574;
-                        x = 0.519796 * safezoneW + safezoneX;
-                        y = 0.6848 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.6848 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         text = "Confirm";
                         colorBackground[] = {0.384,0.439,0.341,1};
                         sizeEx = CS_BTN_SIZE;
@@ -189,10 +192,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportBaseButton : NEO_radioTransportConfirmButton
                 {
                         idc = 655575;
-                        x = 0.519796 * safezoneW + safezoneX;
-                        y = 0.6512 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.6512 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         text = "Order Unit RTB";
                         colorBackground[] = {0.173,0.173,0.173,1};
                         colorBackgroundFocused[] = {0.173,0.173,0.173,1};
@@ -204,10 +207,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportSmokeFoundButton : NEO_radioTransportConfirmButton
                 {
                         idc = 655576;
-                        x = 1000 * safezoneW + safezoneX;
-                        y = 0.6176 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 1000 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.6176 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         text = "Confirm Smoke";
                         colorBackground[] = {0.431,0.494,0.596,1};
                         colorBackgroundFocused[] = {0.431,0.494,0.596,1};
@@ -219,10 +222,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportSmokeNotFoundButton : NEO_radioTransportBaseButton
                 {
                         idc = 655577;
-                        x = 0.519796 * safezoneW + safezoneX;
-                        y = 0.584 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.584 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         text = "New Smoke";
                         colorBackground[] = {0.722,0.439,0.282,1};
                         colorBackgroundFocused[] = {0.722,0.439,0.282,1};
@@ -234,10 +237,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportCircleSlider : NEO_RscSlider
                 {
                         idc = 655578;
-                        x = 0.281002 * safezoneW + safezoneX;
-                        y = 0.5504 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.281002 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.5504 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         colorText[] = {0.384,0.439,0.341,1};
                         colorActive[] = {0.384,0.439,0.341,1};
                         color[] = {0.384,0.439,0.341,1};
@@ -250,10 +253,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportCircleSliderText : NEO_radioTransportHelpUnitText
                 {
                         idc = 655579;
-                        x = 0.280111 * safezoneW + safezoneX;
-                        y = 0.514 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.280111 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.514 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         text = "";
                         colorText[] = {0.706,0.706,0.706,1};
                         colorBackground[] = {0,0,0,0};
@@ -274,10 +277,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportObjectCb : NEO_RscComboBox
                 {
                         idc = 655580;
-                        x = 0.281002 * safezoneW + safezoneX;
-                        y = 0.5504 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.281002 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.5504 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         colorSelectBackground[] = {0.384,0.439,0.341,1};
                         colorSelect[] = {0.023529, 0, 0.0313725, 1.000};
                         colorText[] = {0.384,0.439,0.341,1};
@@ -292,10 +295,10 @@ class NEO_resourceRadio
                 {
                         idc = 655633;
                         text = "Behaviour";
-                        x = 0.363898 * safezoneW + safezoneX;
-                        y = 0.598 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.363898 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.598 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         colorText[] = {0.706,0.706,0.706,1};
                         colorBackground[] = {0,0,0,0};
                         sizeEx = CS_BTN_SIZE;
@@ -305,10 +308,10 @@ class NEO_resourceRadio
                 class NEO_radioTransportHeightCb : NEO_RscComboBox
                 {
                         idc = 655630;
-                        x = 0.278525 * safezoneW + safezoneX;
-                        y = 0.64 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.278525 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.64 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         colorSelectBackground[] = {0.384,0.439,0.341,1};
                         colorSelect[] = {0.023529, 0, 0.0313725, 1.000};
                         colorText[] = {0.384,0.439,0.341,1};
@@ -322,20 +325,20 @@ class NEO_resourceRadio
                 class NEO_radioTransportSpeedCb : NEO_radioTransportHeightCb
                 {
                         idc = 655631;
-                        x = 0.401017 * safezoneW + safezoneX;
-                        y = 0.64 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.401017 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.64 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                 };
 
                 //ROE
                 class NEO_radioTransportRoeCb : NEO_radioTransportHeightCb
                 {
                         idc = 655632;
-                        x = 0.339153 * safezoneW + safezoneX;
-                        y = 0.696 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.339153 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.696 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                 };
 
                 //=======================
@@ -343,10 +346,10 @@ class NEO_resourceRadio
                 class NEO_radioCasUnitList : NEO_RscGUIListBox
                 {
                         idc = 655582;
-                        x = 0.269865 * safezoneW + safezoneX;
-                        y = 0.3068 * safezoneH + safezoneY;
-                        w = 0.242507 * safezoneW;
-                        h = 0.084 * safezoneH;
+                        x = 0.269865 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.3068 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.242507 * GUI_GRID_WAbs;
+                        h = 0.084 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         colorActive[] = {0.384,0.439,0.341,1};
                         sizeEx = CS_LIST_SIZE;
@@ -357,10 +360,10 @@ class NEO_resourceRadio
                 class NEO_radioCasUnitText : NEO_RscText
                 {
                         idc = 655583;
-                        x = 0.271103 * safezoneW + safezoneX;
-                        y = 0.2732 * safezoneH + safezoneY;
-                        w = 0.0779492 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.271103 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.2732 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.0779492 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorText[] = {0.706,0.706,0.706,1};
                         colorBackground[] = {0,0,0,0};
                         sizeEx = CS_BTN_SIZE;
@@ -371,10 +374,10 @@ class NEO_resourceRadio
                 class NEO_radioCasHelpUnitText : NEO_radioCasUnitText
                 {
                         idc = 655584;
-                        x = 0.351527 * safezoneW + safezoneX;
-                        y = 0.2732 * safezoneH + safezoneY;
-                        w = 0.160845 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.351527 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.2732 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.160845 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         sizeEx = CS_LIST_SIZE;
                         rowHeight = CS_LIST_ROW;
@@ -385,10 +388,10 @@ class NEO_resourceRadio
                 class NEO_radioCasConfirmButton : NEO_radioTransportConfirmButton
                 {
                         idc = 655585;
-                        x = 0.519796 * safezoneW + safezoneX;
-                        y = 0.6848 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.6848 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         text = "Confirm";
                         colorBackground[] = {0.384,0.439,0.341,1};
                         colorBackgroundFocused[] = {0.384,0.439,0.341,1};
@@ -400,10 +403,10 @@ class NEO_resourceRadio
                 class NEO_radioCasBaseButton : NEO_radioCasConfirmButton
                 {
                         idc = 655586;
-                        x = 0.519796 * safezoneW + safezoneX;
-                        y = 0.6512 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.6512 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         text = "Order Unit RTB";
                         colorBackground[] = {0.173,0.173,0.173,1};
                         colorBackgroundFocused[] = {0.173,0.173,0.173,1};
@@ -414,10 +417,10 @@ class NEO_resourceRadio
                 {
                         idc = 655625;
                         enable = 0; // starts disabled - SITREP no-ops until a unit is selected (enabled in the unit handlers)
-                        x = 0.445231 * safezoneW + safezoneX;
-                        y = 0.150015 * safezoneH + safezoneY;
-                        w = 0.0597643 * safezoneW;
-                        h = 0.028 * safezoneH;
+                        x = 0.445231 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.150015 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.0597643 * GUI_GRID_WAbs;
+                        h = 0.028 * GUI_GRID_HAbs;
                         text = "SITREP";
                         action = "[] spawn fnc_getSitrep";
                         colorBackground[] = {0.384,0.439,0.341,1};
@@ -432,10 +435,10 @@ class NEO_resourceRadio
                 class NEO_radioTerrainButton : NEO_radioCasConfirmButton
                 {
                         idc = 655634;
-                        x = 0.686 * safezoneW + safezoneX;   // top-right of the header bezel (mirrors the logo), above the map
-                        y = 0.108 * safezoneH + safezoneY;   // on the light-grey header band (nudged down with the grid row)
-                        w = 0.0597643 * safezoneW;
-                        h = 0.028 * safezoneH;
+                        x = 0.686 * GUI_GRID_WAbs + GUI_GRID_X;   // top-right of the header bezel (mirrors the logo), above the map
+                        y = 0.108 * GUI_GRID_HAbs + GUI_GRID_Y;   // on the light-grey header band (nudged down with the grid row)
+                        w = 0.0597643 * GUI_GRID_WAbs;
+                        h = 0.028 * GUI_GRID_HAbs;
                         text = "Terrain";
                         periodFocus = 1e10; // never blink (periodFocus = 0 can fall back to the default focus-pulse)
                         periodOver = 1e10;
@@ -452,10 +455,10 @@ class NEO_resourceRadio
                 class NEO_radioGridLabel : NEO_RscText
                 {
                         idc = 655635;
-                        x = 0.5198 * safezoneW + safezoneX;
-                        y = 0.108 * safezoneH + safezoneY;
-                        w = 0.032 * safezoneW;
-                        h = 0.028 * safezoneH;
+                        x = 0.5198 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.108 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.032 * GUI_GRID_WAbs;
+                        h = 0.028 * GUI_GRID_HAbs;
                         text = "GRID";
                         sizeEx = CS_BTN_SIZE;
                         colorText[] = {0.25,0.25,0.25,1}; // darker grey - more visible on the light header band
@@ -467,10 +470,10 @@ class NEO_resourceRadio
                 class NEO_radioGridEdit : NEO_RscEdit
                 {
                         idc = 655636;
-                        x = 0.5518 * safezoneW + safezoneX;
-                        y = 0.10 * safezoneH + safezoneY; // extend up from the button row (bottom stays aligned at 0.136) for a taller, readable box
-                        w = 0.086 * safezoneW;
-                        h = 0.036 * safezoneH;
+                        x = 0.5518 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.10 * GUI_GRID_HAbs + GUI_GRID_Y; // extend up from the button row (bottom stays aligned at 0.136) for a taller, readable box
+                        w = 0.086 * GUI_GRID_WAbs;
+                        h = 0.036 * GUI_GRID_HAbs;
                         text = "";
                         sizeEx = 0.034; // larger, comfortably readable
                         colorText[] = {0.1,0.1,0.1,1}; // dark - readable on the light input box
@@ -482,10 +485,10 @@ class NEO_resourceRadio
                 class NEO_radioGridButton : NEO_radioTerrainButton
                 {
                         idc = 655637;
-                        x = 0.640 * safezoneW + safezoneX;
-                        y = 0.108 * safezoneH + safezoneY;
-                        w = 0.043 * safezoneW;
-                        h = 0.028 * safezoneH;
+                        x = 0.640 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.108 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.043 * GUI_GRID_WAbs;
+                        h = 0.028 * GUI_GRID_HAbs;
                         text = "Set";
                         period = 1e10; // freeze the focus blink (the inherited period 0.4 pulses while the button holds focus)
                         action = "[] call NEO_fnc_radioGridSetButton";
@@ -495,10 +498,10 @@ class NEO_resourceRadio
                 class NEO_radioCasTaskList : NEO_radioCasUnitList
                 {
                         idc = 655587;
-                        x = 0.269865 * safezoneW + safezoneX;
-                        y = 0.4272 * safezoneH + safezoneY;
-                        w = 0.242507 * safezoneW;
-                        h = 0.084 * safezoneH;
+                        x = 0.269865 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.4272 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.242507 * GUI_GRID_WAbs;
+                        h = 0.084 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         colorActive[] = {0.384,0.439,0.341,1};
                 sizeEx = CS_LIST_SIZE;
@@ -509,10 +512,10 @@ class NEO_resourceRadio
                 class NEO_radioCasTaskText : NEO_radioCasUnitText
                 {
                         idc = 655588;
-                        x = 0.271103 * safezoneW + safezoneX;
-                        y = 0.3936 * safezoneH + safezoneY;
-                        w = 0.0742373 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.271103 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.3936 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.0742373 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorText[] = {0.706,0.706,0.706,1};
                         colorBackground[] = {0,0,0,0};
                         sizeEx = CS_BTN_SIZE;
@@ -523,10 +526,10 @@ class NEO_resourceRadio
                 class NEO_radioCasHelpTaskText : NEO_radioCasHelpUnitText
                 {
                         idc = 655589;
-                        x = 0.351525 * safezoneW + safezoneX;
-                        y = 0.3936 * safezoneH + safezoneY;
-                        w = 0.160845 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.351525 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.3936 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.160845 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         sizeEx = 0.6 * GUI_GRID_H;
                         text = "";
@@ -536,10 +539,10 @@ class NEO_resourceRadio
                 class NEO_radioCasFlyHeightSlider : NEO_radioTransportCircleSlider
                 {
                         idc = 655590;
-                        x = 0.402708 * safezoneW + safezoneX;
-                        y = 0.5508 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.402708 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.5508 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
             colorActive[] = {0.384,0.439,0.341,1};
                         color[] = {0.384,0.439,0.341,1};
                         colorDisabled[] = {0.384,0.439,0.341,1};
@@ -549,10 +552,10 @@ class NEO_resourceRadio
                 class NEO_radioCasFlyHeightText : NEO_radioTransportCircleSliderText
                 {
                         idc = 655591;
-                        x = 0.402708 * safezoneW + safezoneX;
-                        y = 0.5508 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.402708 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.5508 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         colorText[] = {0.706,0.706,0.706,1};
                         colorActive[] = {0.384,0.439,0.341,1};
                         sizeEx = CS_BTN_SIZE;
@@ -563,10 +566,10 @@ class NEO_resourceRadio
                 class NEO_radioCasRadiusSlider : NEO_radioTransportCircleSlider
                 {
                         idc = 655592;
-                        x = 0.281002 * safezoneW + safezoneX;
-                        y = 0.5504 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.281002 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.5504 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         colorText[] = {0.384,0.439,0.341,1};
                         colorActive[] = {0.384,0.439,0.341,1};
                         color[] = {0.384,0.439,0.341,1};
@@ -578,10 +581,10 @@ class NEO_resourceRadio
                 class NEO_radioCasRadiusText : NEO_radioTransportCircleSliderText
                 {
                         idc = 655593;
-                        x = 0.280111 * safezoneW + safezoneX;
-                        y = 0.514 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.280111 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.514 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         text = "";
                         colorText[] = {0.706,0.706,0.706,1};
                         colorBackground[] = {0,0,0,0};
@@ -591,10 +594,10 @@ class NEO_resourceRadio
                 class NEO_radioCasWeaponList : NEO_radioCasUnitList
                 {
                         idc = 655613;
-                        x = 0.269865 * safezoneW + safezoneX;
-                        y = 0.615 * safezoneH + safezoneY;
-                        w = 0.125 * safezoneW;
-                        h = 0.12 * safezoneH;
+                        x = 0.269865 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.615 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.125 * GUI_GRID_WAbs;
+                        h = 0.12 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         colorActive[] = {0.384,0.439,0.341,1};
                 sizeEx = CS_LIST_SIZE;
@@ -605,10 +608,10 @@ class NEO_resourceRadio
                 class NEO_radioCasWeaponText : NEO_radioCasUnitText
                 {
                         idc = 655614;
-                        x = 0.271103 * safezoneW + safezoneX;
-                        y = 0.59 * safezoneH + safezoneY;
-                        w = 0.028 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.271103 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.59 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.028 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorText[] = {0.706,0.706,0.706,1};
                         colorBackground[] = {0,0,0,0};
                         sizeEx = CS_BTN_SIZE;
@@ -618,10 +621,10 @@ class NEO_resourceRadio
                 class NEO_radioCasROEList : NEO_radioCasUnitList
                 {
                         idc = 655615;
-                        x = 0.392 * safezoneW + safezoneX;
-                        y = 0.615 * safezoneH + safezoneY;
-                        w = 0.125 * safezoneW;
-                        h = 0.12 * safezoneH;
+                        x = 0.392 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.615 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.125 * GUI_GRID_WAbs;
+                        h = 0.12 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         colorActive[] = {0.384,0.439,0.341,1};
                 sizeEx = CS_LIST_SIZE;
@@ -632,10 +635,10 @@ class NEO_resourceRadio
                 class NEO_radioCasROEText : NEO_radioCasUnitText
                 {
                         idc = 655616;
-                        x = 0.402708 * safezoneW + safezoneX;
-                        y = 0.59 * safezoneH + safezoneY;
-                        w = 0.028 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.402708 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.59 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.028 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorText[] = {0.706,0.706,0.706,1};
                         colorBackground[] = {0,0,0,0};
                         sizeEx = CS_BTN_SIZE;
@@ -644,10 +647,10 @@ class NEO_resourceRadio
                 class NEO_radioArtyUnitList : NEO_RscGUIListBox
                 {
                         idc = 655594;
-                        x = 0.269865 * safezoneW + safezoneX;
-                        y = 0.3068 * safezoneH + safezoneY;
-                        w = 0.242507 * safezoneW;
-                        h = 0.084 * safezoneH;
+                        x = 0.269865 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.3068 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.242507 * GUI_GRID_WAbs;
+                        h = 0.084 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         colorActive[] = {0.384,0.439,0.341,1};
                         sizeEx = CS_LIST_SIZE;
@@ -656,10 +659,10 @@ class NEO_resourceRadio
                 class NEO_radioArtyUnitText : NEO_RscText
                 {
                         idc = 655595;
-                        x = 0.271103 * safezoneW + safezoneX;
-                        y = 0.2732 * safezoneH + safezoneY;
-                        w = 0.0779492 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.271103 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.2732 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.0779492 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorText[] = {0.706,0.706,0.706,1};
                         colorBackground[] = {0,0,0,0};
                         sizeEx = CS_BTN_SIZE;
@@ -668,10 +671,10 @@ class NEO_resourceRadio
                 class NEO_radioArtyHelpUnitText : NEO_radioArtyUnitText
                 {
                         idc = 655596;
-                        x = 0.351527 * safezoneW + safezoneX;
-                        y = 0.2732 * safezoneH + safezoneY;
-                        w = 0.160845 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.351527 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.2732 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.160845 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         sizeEx = CS_LIST_SIZE;
                         rowHeight = CS_LIST_ROW;
@@ -680,10 +683,10 @@ class NEO_resourceRadio
                 class NEO_radioArtyConfirmButton : NEO_radioTransportConfirmButton
                 {
                         idc = 655597;
-                        x = 0.519796 * safezoneW + safezoneX;
-                        y = 0.6848 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.6848 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         text = "Confirm";
                         colorBackground[] = {0.384,0.439,0.341,1};
                         colorBackgroundFocused[] = {0.384,0.439,0.341,1};
@@ -693,10 +696,10 @@ class NEO_resourceRadio
                 class NEO_radioArtyBaseButton : NEO_radioArtyConfirmButton
                 {
                         idc = 655610;
-                        x = 0.519796 * safezoneW + safezoneX;
-                        y = 0.6512 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.6512 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         text = "Order Unit RTB";
                         colorBackground[] = {0.173,0.173,0.173,1};
                         sizeEx = CS_BTN_SIZE;
@@ -704,10 +707,10 @@ class NEO_resourceRadio
                 class NEO_radioArtyOrdnanceTypeText : NEO_radioArtyUnitText
                 {
                         idc = 655600;
-                        x = 0.271103 * safezoneW + safezoneX;
-                        y = 0.3936 * safezoneH + safezoneY;
-                        w = 0.0742373 * safezoneW;
-                        h = 0.0308 * safezoneH;
+                        x = 0.271103 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.3936 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.0742373 * GUI_GRID_WAbs;
+                        h = 0.0308 * GUI_GRID_HAbs;
                         colorText[] = {0.706,0.706,0.706,1};
                         colorBackground[] = {0,0,0,0};
                         colorBackgroundFocused[] = {0,0,0,0};
@@ -718,10 +721,10 @@ class NEO_resourceRadio
                 class NEO_radioArtyOrdnanceTypeLb : NEO_radioArtyUnitList
                 {
                         idc = 655601;
-                        x = 0.269865 * safezoneW + safezoneX;
-                        y = 0.4272 * safezoneH + safezoneY;
-                        w = 0.242507 * safezoneW;
-                        h = 0.084 * safezoneH;
+                        x = 0.269865 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.4272 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.242507 * GUI_GRID_WAbs;
+                        h = 0.084 * GUI_GRID_HAbs;
                         colorBackground[] = {0,0,0,0};
                         colorActive[] = {0.384,0.439,0.341,1};
                 sizeEx = CS_LIST_SIZE;
@@ -730,40 +733,40 @@ class NEO_resourceRadio
                 class NEO_radioArtyRateOfFireText : NEO_radioArtyOrdnanceTypeText
                 {
                         idc = 655602;
-                        x = 0.271103 * safezoneW + safezoneX;
-                        y = 0.52 * safezoneH + safezoneY;
-                        w = 0.080931 * safezoneW;
-                        h = 0.0280024 * safezoneH;
+                        x = 0.271103 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.52 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.080931 * GUI_GRID_WAbs;
+                        h = 0.0280024 * GUI_GRID_HAbs;
                 };
 
                 //Arty Rate Of Fire Lb
                 class NEO_radioArtyRateOfFireLb : NEO_radioArtyOrdnanceTypeLb
                 {
                         idc = 655603;
-                        x = 0.282108 * safezoneW + safezoneX;
-                        y = 0.55 * safezoneH + safezoneY;
-                        w = 0.0859113 * safezoneW;
-                        h = 0.0560048 * safezoneH;
+                        x = 0.282108 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.55 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.0859113 * GUI_GRID_WAbs;
+                        h = 0.0560048 * GUI_GRID_HAbs;
                 };
 
                 //Arty Round Count Text
                 class NEO_radioArtyRoundCountText : NEO_radioArtyOrdnanceTypeText
                 {
                         idc = 655604;
-                        x = 0.406618 * safezoneW + safezoneX;
-                        y = 0.52 * safezoneH + safezoneY;
-                        w = 0.080931 * safezoneW;
-                        h = 0.0280024 * safezoneH;
+                        x = 0.406618 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.52 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.080931 * GUI_GRID_WAbs;
+                        h = 0.0280024 * GUI_GRID_HAbs;
                 };
 
                 //Arty Round Count Lb
                 class NEO_radioArtyRoundCountLb : NEO_radioArtyOrdnanceTypeLb
                 {
                         idc = 655605;
-                        x = 0.404129 * safezoneW + safezoneX;
-                        y = 0.55 * safezoneH + safezoneY;
-                        w = 0.0859114 * safezoneW;
-                        h = 0.140012 * safezoneH;
+                        x = 0.404129 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.55 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.0859114 * GUI_GRID_WAbs;
+                        h = 0.140012 * GUI_GRID_HAbs;
                 };
                 class NEO_radioArtyMoveButton : NEO_radioTransportSmokeFoundButton
                 {
@@ -785,20 +788,20 @@ class NEO_resourceRadio
                 {
                         idc = 655608;
                         text = "";
-                        x = 0.270903 * safezoneW + safezoneX;
-                        y = 0.68 * safezoneH + safezoneY;
-                        w = 0.12 * safezoneW;
-                        h = 0.0280024 * safezoneH;
+                        x = 0.270903 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.68 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.12 * GUI_GRID_WAbs;
+                        h = 0.0280024 * GUI_GRID_HAbs;
                 };
 
                 //Arty Dispersion Slider
                 class NEO_radioArtyDispersionSlider : NEO_radioCasRadiusSlider
                 {
                         idc = 655609;
-                        x = 0.270903 * safezoneW + safezoneX;
-                        y = 0.710018 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.270903 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.710018 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         colorText[] = {0.384,0.439,0.341,1};
                         colorActive[] = {0.384,0.439,0.341,1};
                         color[] = {0.384,0.439,0.341,1};
@@ -809,20 +812,20 @@ class NEO_resourceRadio
                 {
                         idc = 655611;
                         text = "";
-                        x = 0.404129 * safezoneW + safezoneX;
-                        y = 0.68 * safezoneH + safezoneY;
-                        w = 0.105833 * safezoneW;
-                        h = 0.0280024 * safezoneH;
+                        x = 0.404129 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.68 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = 0.105833 * GUI_GRID_WAbs;
+                        h = 0.0280024 * GUI_GRID_HAbs;
                 };
 
                 //Arty Dispersion Slider
                 class NEO_radioArtyRateDelaySlider : NEO_radioCasRadiusSlider
                 {
                         idc = 655612;
-                        x = 0.404129 * safezoneW + safezoneX;
-                        y = 0.710018 * safezoneH + safezoneY;
-                        w = safeZoneW / 1000;
-                        h = safeZoneH / 1000;
+                        x = 0.404129 * GUI_GRID_WAbs + GUI_GRID_X;
+                        y = 0.710018 * GUI_GRID_HAbs + GUI_GRID_Y;
+                        w = GUI_GRID_WAbs / 1000;
+                        h = GUI_GRID_HAbs / 1000;
                         colorText[] = {0.384,0.439,0.341,1};
                         colorActive[] = {0.384,0.439,0.341,1};
                         color[] = {0.384,0.439,0.341,1};

--- a/addons/sup_command/data/ui/common.hpp
+++ b/addons/sup_command/data/ui/common.hpp
@@ -1,9 +1,9 @@
-#define GUI_GRID_X  (0)
-#define GUI_GRID_Y  (0)
-#define GUI_GRID_W  (0.025)
-#define GUI_GRID_H  (0.04)
-#define GUI_GRID_WAbs (1)
-#define GUI_GRID_HAbs (1)
+#define GUI_GRID_HAbs        (1.14 * safezoneH)
+#define GUI_GRID_WAbs        (1.2 * GUI_GRID_HAbs)
+#define GUI_GRID_W           (GUI_GRID_WAbs / 40)
+#define GUI_GRID_H           (GUI_GRID_HAbs / 25)
+#define GUI_GRID_X           (safezoneX + (safezoneW - GUI_GRID_WAbs) / 2)
+#define GUI_GRID_Y           (safezoneY + (safezoneH - GUI_GRID_HAbs) / 2)
 
 class SCOMTablet_RscBackground
 {
@@ -31,7 +31,7 @@ class SCOMTablet_RscEdit
     y = "1";
     w = "safeZoneW / 25";
     h = "safeZoneH / 30";
-    sizeEx = 0.03;
+    sizeEx = 0.75 * GUI_GRID_H;
     font = "PuristaMedium";
     text = "";
     colorText[] = {1,1,1,1};
@@ -46,7 +46,7 @@ class SCOMTablet_RscText
     type = 13;
     style = 0x00;
     colorBackground[] = { 0, 0, 0, 0 };
-    size = "((safeZoneW / 75) + (safeZoneH / 225))";
+    size = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 6)";
     y = "safeZoneY + (safeZoneH / 6)";
     w = "safeZoneW / 5";
@@ -122,7 +122,7 @@ class SCOMTablet_RscRealButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};
@@ -186,7 +186,7 @@ class SCOMTablet_RscButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};
@@ -228,7 +228,7 @@ class SCOMTablet_RscListNBox {
     type = 102;
     shadow = 0;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -269,7 +269,7 @@ class SCOMTablet_RscListBox {
     type = 5;
     style = 0 + 0x10;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -312,7 +312,7 @@ class SCOMTablet_RscGUIListBox : SCOMTablet_RscListBox {
     colorSelectBackground[] = {0.333,0.333,0.333,1};
     colorSelectBackground2[] = {0.333,0.333,0.333,1};
     period = 0;
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     class ListScrollBar
     {
         color[] = {1, 1, 1, 0.6};
@@ -362,7 +362,7 @@ class SCOMTablet_RscComboBox
     colorActive[] = {0,0,0,1};
     colorDisabled[] = {0,0,0,0.3};
     font = "PuristaMedium";
-    sizeEx = "(safeZoneH / 100) + (safeZoneH / 100)";
+    sizeEx = 0.5 * GUI_GRID_H;
 };
 
 class SCOMTablet_RscMap

--- a/addons/sup_command/data/ui/main.hpp
+++ b/addons/sup_command/data/ui/main.hpp
@@ -13,10 +13,10 @@ class SCOMTablet
         class SCOMTablet_background : SCOMTablet_RscPicture
         {
             idc = 12002;
-            x = 0.142424 * safezoneW + safezoneX;
-            y = 0.0632 * safezoneH + safezoneY;
-            w = 0.73 * safezoneW;
-            h = 0.84 * safezoneH;
+            x = 0.142424 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.0632 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.73 * GUI_GRID_WAbs;
+            h = 0.84 * GUI_GRID_HAbs;
             text = "x\alive\addons\main\data\ui\ALiVE_toughbook.paa";
             moving = 0;
             colorBackground[] = {0,0,0,0};
@@ -30,10 +30,10 @@ class SCOMTablet
         {
             idc = 12007;
             text = "";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.1430 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1430 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -52,11 +52,11 @@ class SCOMTablet
             idc = 12006;
             text = "Back";
             style = 0x02;
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.7000 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.7350 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.376,0.196,0.204,1};
             colorText[] = {0.706,0.706,0.706,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
@@ -68,11 +68,11 @@ class SCOMTablet
             idc = 12010;
             text = "Close";
             style = 0x02;
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.7350 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.7350 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.376,0.196,0.204,1};
             colorText[] = {0.706,0.706,0.706,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
@@ -81,14 +81,14 @@ class SCOMTablet
         };
 
         // #698 Terrain toggle - top-right of the header bezel (same toughbook as the other tablets),
-        // toggles the main map (12022) between the textured satellite view and the plain schematic.
+        // toggles every map used by the current view between satellite and schematic terrain.
         class SCOMTablet_TerrainButton : SCOMTablet_RscRealButton
         {
             idc = 12050;
-            x = 0.686 * safezoneW + safezoneX;
-            y = 0.098 * safezoneH + safezoneY;
-            w = 0.0597643 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.686 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.098 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0597643 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Terrain";
             periodFocus = 1e10;
             periodOver = 1e10;
@@ -97,18 +97,18 @@ class SCOMTablet
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.384,0.439,0.341,1};
             colorFocused[] = {0.706,0.706,0.706,1};
-            sizeEx = 0.9 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
         };
 
         class SCOMTablet_1ButtonL : SCOMTablet_RscButton
         {
             idc = 12014;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6150 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6150 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button1";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -117,12 +117,12 @@ class SCOMTablet
         class SCOMTablet_2ButtonL : SCOMTablet_RscButton
         {
             idc = 12015;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6480 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6480 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button2";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -131,12 +131,12 @@ class SCOMTablet
         class SCOMTablet_3ButtonL : SCOMTablet_RscButton
         {
             idc = 12016;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6810 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6810 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button3";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -145,12 +145,12 @@ class SCOMTablet
         class SCOMTablet_1ButtonR : SCOMTablet_RscButton
         {
             idc = 12017;
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.6150 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6150 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button1";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -159,12 +159,12 @@ class SCOMTablet
         class SCOMTablet_2ButtonR : SCOMTablet_RscButton
         {
             idc = 12018;
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.6480 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6480 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button2";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -173,12 +173,12 @@ class SCOMTablet
         class SCOMTablet_3ButtonR : SCOMTablet_RscButton
         {
             idc = 12019;
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.6810 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6810 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button3";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -187,156 +187,156 @@ class SCOMTablet
         class SCOMTablet_right_map : SCOMTablet_RscMap
         {
             idc = 12021;
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.45 * safezoneH;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.45 * GUI_GRID_HAbs;
         };
 
         class SCOMTablet_main_map : SCOMTablet_RscMap
         {
             idc = 12022;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.5 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.5 * GUI_GRID_HAbs;
         };
 
         class SCOMTablet_renderTarget : SCOMTablet_RscPicture
         {
             idc = 12033;
             text = "";
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.5 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.5 * GUI_GRID_HAbs;
         };
 
         class SCOMTablet_editList : SCOMTablet_RscListBox
         {
             idc = 12027;
             text = "";
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.14 * safezoneW;
-            h = 0.45 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.17 * GUI_GRID_WAbs;
+            h = 0.45 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorSelectBackground[] = {0.3,0.3,0.3,1};
             colorSelectBackground2[] = {0.3,0.3,0.3,1};
             colorText[] = {0.6,0.6,0.6,1};
             color[] = {0.6,0.6,0.6,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class SCOMTablet_waypointList : SCOMTablet_RscListBox
         {
             idc = 12028;
             text = "";
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.14 * safezoneW;
-            h = 0.13 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.17 * GUI_GRID_WAbs;
+            h = 0.13 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorSelectBackground[] = {0.3,0.3,0.3,1};
             colorSelectBackground2[] = {0.3,0.3,0.3,1};
             colorText[] = {0.6,0.6,0.6,1};
             color[] = {0.6,0.6,0.6,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class SCOMTablet_waypointTypeList : SCOMTablet_RscListBox
         {
             idc = 12029;
             text = "";
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.296 * safezoneH + safezoneY;
-            w = 0.14 * safezoneW;
-            h = 0.103 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.296 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.17 * GUI_GRID_WAbs;
+            h = 0.103 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorSelectBackground[] = {0.3,0.3,0.3,1};
             colorSelectBackground2[] = {0.3,0.3,0.3,1};
             colorText[] = {0.6,0.6,0.6,1};
             color[] = {0.6,0.6,0.6,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class SCOMTablet_waypointSpeedList : SCOMTablet_RscListBox
         {
             idc = 12030;
             text = "";
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.405 * safezoneH + safezoneY;
-            w = 0.14 * safezoneW;
-            h = 0.1 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.405 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.17 * GUI_GRID_WAbs;
+            h = 0.1 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorSelectBackground[] = {0.3,0.3,0.3,1};
             colorSelectBackground2[] = {0.3,0.3,0.3,1};
             colorText[] = {0.6,0.6,0.6,1};
             color[] = {0.6,0.6,0.6,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class SCOMTablet_waypointFormationList : SCOMTablet_RscListBox
         {
             idc = 12031;
             text = "";
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.51 * safezoneH + safezoneY;
-            w = 0.14 * safezoneW;
-            h = 0.1 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.51 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.17 * GUI_GRID_WAbs;
+            h = 0.1 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorSelectBackground[] = {0.3,0.3,0.3,1};
             colorSelectBackground2[] = {0.3,0.3,0.3,1};
             colorText[] = {0.6,0.6,0.6,1};
             color[] = {0.6,0.6,0.6,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class SCOMTablet_waypointBehavourList : SCOMTablet_RscListBox
         {
             idc = 12032;
             text = "";
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.616 * safezoneH + safezoneY;
-            w = 0.14 * safezoneW;
-            h = 0.1 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.616 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.17 * GUI_GRID_WAbs;
+            h = 0.1 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorSelectBackground[] = {0.3,0.3,0.3,1};
             colorSelectBackground2[] = {0.3,0.3,0.3,1};
             colorText[] = {0.6,0.6,0.6,1};
             color[] = {0.6,0.6,0.6,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class SCOMTablet_edit_map : SCOMTablet_RscMap
         {
             idc = 12026;
-            x = 0.415 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.323 * safezoneW;
-            h = 0.45 * safezoneH;
+            x = 0.445 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.293 * GUI_GRID_WAbs;
+            h = 0.45 * GUI_GRID_HAbs;
         };
 
         class SCOMTablet_intelTypeTitle : SCOMTablet_RscText
         {
             idc = 12023;
             text = "Intel Type";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6596 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0208 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6596 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0208 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -353,24 +353,24 @@ class SCOMTablet
         class SCOMTablet_intelTypeList : SCOMTablet_RscGUIListBox
         {
             idc = 12024;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6810 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.082 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6810 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.082 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class SCOMTablet_intelStatus : SCOMTablet_RscText
         {
             idc = 12025;
             text = "";
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.6596 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0208 * safezoneH;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6596 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0208 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {

--- a/addons/sup_command/fnc_SCOM.sqf
+++ b/addons/sup_command/fnc_SCOM.sqf
@@ -408,7 +408,16 @@ switch (_operation) do {
             // ops state
 
             [_commandState,"opsGroupInstantJoin",false] call ALIVE_fnc_hashSet;
+            [_commandState,"opsGroupInstantJoinContinuation",false] call ALIVE_fnc_hashSet;
+            [_commandState,"opsGroupInstantJoinPlayerID",getPlayerUID player] call ALIVE_fnc_hashSet;
+            [_commandState,"opsGroupInstantJoinProfileID",""] call ALIVE_fnc_hashSet;
             [_commandState,"opsGroupInstantJoinPlayerPosition",position player] call ALIVE_fnc_hashSet;
+            [_commandState,"opsGroupInstantJoinOriginalPlayer",player] call ALIVE_fnc_hashSet;
+            [_commandState,"opsGroupInstantJoinOriginalGroup",group player] call ALIVE_fnc_hashSet;
+            [_commandState,"opsGroupInstantJoinOriginalGroupSide",side group player] call ALIVE_fnc_hashSet;
+            [_commandState,"opsGroupInstantJoinOriginalWasLeader",(leader group player) isEqualTo player] call ALIVE_fnc_hashSet;
+            [_commandState,"opsGroupInstantJoinCandidates",[]] call ALIVE_fnc_hashSet;
+            [_commandState,"opsGroupInstantJoinSelectedIndex",DEFAULT_SELECTED_INDEX] call ALIVE_fnc_hashSet;
 
             [_commandState,"opsGroupSpectate",false] call ALIVE_fnc_hashSet;
             [_commandState,"opsGroupSpectatePlayerPosition",position player] call ALIVE_fnc_hashSet;
@@ -424,6 +433,7 @@ switch (_operation) do {
             [_commandState,"opsGroupsValues",[]] call ALIVE_fnc_hashSet;
             [_commandState,"opsGroupsSelectedIndex",DEFAULT_SELECTED_INDEX] call ALIVE_fnc_hashSet;
             [_commandState,"opsGroupsSelectedValue",DEFAULT_SELECTED_VALUE] call ALIVE_fnc_hashSet;
+            [_commandState,"opsGroupsReturnProfileID",""] call ALIVE_fnc_hashSet;
 
             [_commandState,"opsGroupSelectedProfile",[]] call ALIVE_fnc_hashSet;
             [_commandState,"opsGroupWaypoints",[]] call ALIVE_fnc_hashSet;
@@ -443,7 +453,7 @@ switch (_operation) do {
 
             [_commandState,"opsWPProfiledTypeOptions",["Move","Cycle"]] call ALIVE_fnc_hashSet;
             [_commandState,"opsWPProfiledTypeValues",["MOVE","CYCLE"]] call ALIVE_fnc_hashSet;
-            [_commandState,"opsWPNonProfiledTypeOptions",["Move","SAD","Cycle","Load","Land - Engines Off","Land - Engines On","TR Unload"]] call ALIVE_fnc_hashSet;
+            [_commandState,"opsWPNonProfiledTypeOptions",["Move","Attack / Search & Destroy","Cycle","Load","Land - Engines Off","Land - Engines On","Transport Unload"]] call ALIVE_fnc_hashSet;
             [_commandState,"opsWPNonProfiledTypeValues",["MOVE","SAD","CYCLE","LOAD","LAND OFF","LAND HOVER","TR UNLOAD"]] call ALIVE_fnc_hashSet;
             [_commandState,"opsWPTypeOptions",[]] call ALIVE_fnc_hashSet;
             [_commandState,"opsWPTypeValues",[]] call ALIVE_fnc_hashSet;
@@ -466,6 +476,56 @@ switch (_operation) do {
             [_commandState,"opsWPBehaviourSelectedValue",DEFAULT_SELECTED_VALUE] call ALIVE_fnc_hashSet;
 
             [_logic,"commandState",_commandState] call MAINCLASS;
+
+            if (isNil {missionNamespace getVariable "ALiVE_SCOMJoinDeathPending"}) then {
+                missionNamespace setVariable ["ALiVE_SCOMJoinDeathPending",false];
+            };
+            if (isNil {missionNamespace getVariable "ALiVE_SCOMJoinRespawnRequested"}) then {
+                missionNamespace setVariable ["ALiVE_SCOMJoinRespawnRequested",false];
+            };
+            [_logic,"installOpsJoinPlayerHandlers",[]] call MAINCLASS;
+
+            // Use mission event handlers so the continuation survives the
+            // engine replacing the local player object during multiplayer
+            // respawn. No UI or player code is installed on a headless server.
+            if ((missionNamespace getVariable ["ALiVE_SCOMJoinKilledEH",-1]) < 0) then {
+                private _killedEH = addMissionEventHandler ["EntityKilled",{
+                    params ["_killed"];
+                    if (hasInterface && {!isNil "ALIVE_SUP_COMMAND"}) then {
+                        private _commandState = [ALIVE_SUP_COMMAND,"commandState"] call ALIVE_fnc_SCOM;
+                        private _joinedPlayer = [_commandState,"opsGroupInstantJoinOriginalPlayer",objNull] call ALiVE_fnc_hashGet;
+                        if (_killed isEqualTo _joinedPlayer) then {
+                            [ALIVE_SUP_COMMAND,"handleOpsJoinKilled",[_killed]] call ALIVE_fnc_SCOM;
+                        };
+                    };
+                }];
+                missionNamespace setVariable ["ALiVE_SCOMJoinKilledEH",_killedEH];
+            };
+
+            if ((missionNamespace getVariable ["ALiVE_SCOMJoinRespawnEH",-1]) < 0) then {
+                private _respawnEH = addMissionEventHandler ["EntityRespawned",{
+                    params ["_newUnit","_corpse"];
+                    if (hasInterface && {missionNamespace getVariable ["ALiVE_SCOMJoinDeathPending",false]} && {!isNil "ALIVE_SUP_COMMAND"}) then {
+                        private _commandState = [ALIVE_SUP_COMMAND,"commandState"] call ALIVE_fnc_SCOM;
+                        private _joinedPlayer = [_commandState,"opsGroupInstantJoinOriginalPlayer",objNull] call ALiVE_fnc_hashGet;
+                        if (_corpse isEqualTo _joinedPlayer) then {
+                            [_newUnit,_corpse] spawn {
+                                params ["_newUnit","_corpse"];
+                                private _deadline = diag_tickTime + 15;
+                                waitUntil {
+                                    sleep 0.05;
+                                    (_newUnit isEqualTo player && {local _newUnit}) || {diag_tickTime >= _deadline}
+                                };
+                                if (_newUnit isEqualTo player && {local _newUnit} && {!isNil "ALIVE_SUP_COMMAND"}) then {
+                                    [ALIVE_SUP_COMMAND,"installOpsJoinPlayerHandlers",[]] call ALIVE_fnc_SCOM;
+                                    [ALIVE_SUP_COMMAND,"handleOpsJoinRespawn",[_newUnit,_corpse]] spawn ALIVE_fnc_SCOM;
+                                };
+                            };
+                        };
+                    };
+                }];
+                missionNamespace setVariable ["ALiVE_SCOMJoinRespawnEH",_respawnEH];
+            };
 
             // DEBUG -------------------------------------------------------------------------------------
 
@@ -576,13 +636,85 @@ switch (_operation) do {
 
                 case "OPS_PROFILE_WAYPOINTS_UPDATED": {
 
-                    [_logic,"enableGroupWaypointEdit", _data] call MAINCLASS;
+                    // Applying is a completed action. Return to the group list
+                    // instead of leaving the player trapped in the editor.
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+                    private _selectedProfile = [_commandState,"opsGroupsSelectedValue",[]] call ALiVE_fnc_hashGet;
+                    private _groups = [_commandState,"opsGroups",[]] call ALiVE_fnc_hashGet;
+
+                    if (count _selectedProfile >= 2) then {
+                        private _profileID = _selectedProfile select 0;
+                        [_commandState,"opsGroupsReturnProfileID",_profileID] call ALiVE_fnc_hashSet;
+                        {
+                            private _category = _x;
+                            private _categoryIndex = _forEachIndex;
+                            private _groupIndex = _category findIf {count _x >= 2 && {(_x select 0) == _profileID}};
+                            if (_groupIndex >= 0) exitWith {
+                                private _groupData = _category select _groupIndex;
+                                if (count _groupData > 2) then {_groupData set [2,true]} else {_groupData pushBack true};
+                                _category set [_groupIndex,_groupData];
+                                _groups set [_categoryIndex,_category];
+                            };
+                        } forEach _groups;
+                        [_commandState,"opsGroups",_groups] call ALiVE_fnc_hashSet;
+                        [_logic,"commandState",_commandState] call MAINCLASS;
+                    };
+
+                    ["OPS_CANCEL_EDIT_WAYPOINTS",[]] call ALIVE_fnc_SCOMTabletOnAction;
 
                 };
 
                 case "OPS_GROUP_JOIN_READY": {
 
-                    [_logic,"enableOpsJoinGroup", _data] spawn MAINCLASS;
+                    [_logic,"renderOpsJoinSelection", _data] call MAINCLASS;
+
+                };
+
+                case "OPS_JOIN_HANDOFF": {
+
+                    [_logic,"applyOpsJoinHandoff", _data] spawn MAINCLASS;
+
+                };
+
+                case "OPS_JOIN_HANDOFF_RESULT": {
+
+                    missionNamespace setVariable ["ALiVE_SCOMJoinHandoffResult",_data];
+
+                };
+
+                case "OPS_APPLY_GROUP_LEADERSHIP": {
+
+                    [_logic,"applyOpsGroupLeadership",_data] call MAINCLASS;
+
+                };
+
+                case "OPS_APPLY_TAKEOVER_WAYPOINTS": {
+
+                    [_logic,"applyOpsTakeoverWaypoints",_data] call MAINCLASS;
+
+                };
+
+                case "OPS_RECREATE_TAKEOVER_UNIT": {
+
+                    [_logic,"applyOpsRecreateTakeoverUnit",_data] call MAINCLASS;
+
+                };
+
+                case "OPS_JOIN_RESTORE": {
+
+                    [_logic,"applyOpsJoinRestore", _data] spawn MAINCLASS;
+
+                };
+
+                case "OPS_JOIN_RESTORE_RESULT": {
+
+                    missionNamespace setVariable ["ALiVE_SCOMJoinRestoreResult",_data];
+
+                };
+
+                case "OPS_JOIN_RESPAWN_READY": {
+
+                    [_logic,"resumeOpsJoinAfterRespawn",_data] spawn MAINCLASS;
 
                 };
 
@@ -685,6 +817,33 @@ switch (_operation) do {
 
             _commandState = [_logic,"commandState"] call MAINCLASS;
 
+            // Closing the tablet while the Instant Join chooser is preparing or
+            // open must never leave the original player hidden at the profile.
+            private _opsViewMode = [_commandState,"opsViewMode","GROUPS"] call ALiVE_fnc_hashGet;
+            if (_opsViewMode in ["JOIN_UNIT_WAIT","JOIN_UNIT_SELECT"]) then {
+                private _originalPlayer = [_commandState,"opsGroupInstantJoinOriginalPlayer",player] call ALiVE_fnc_hashGet;
+                private _initialPosition = [_commandState,"opsGroupInstantJoinPlayerPosition",[]] call ALiVE_fnc_hashGet;
+                private _playerID = [_commandState,"opsGroupInstantJoinPlayerID",getPlayerUID player] call ALiVE_fnc_hashGet;
+                private _isContinuation = [_commandState,"opsGroupInstantJoinContinuation",false] call ALiVE_fnc_hashGet;
+
+                if (!isNull _originalPlayer) then {
+                    if (!_isContinuation && {_initialPosition isEqualType []} && {count _initialPosition >= 2}) then {
+                        _originalPlayer setPos _initialPosition;
+                    };
+                    [_originalPlayer,false] call ALIVE_fnc_adminGhost;
+                    if (!_isContinuation) then {_originalPlayer allowDamage true};
+                };
+
+                [_commandState,"opsGroupInstantJoin",false] call ALiVE_fnc_hashSet;
+                [_commandState,"opsGroupInstantJoinContinuation",false] call ALiVE_fnc_hashSet;
+                [_commandState,"opsGroupInstantJoinCandidates",[]] call ALiVE_fnc_hashSet;
+                if (_isContinuation) then {
+                    ["OPS_CANCEL_JOIN_ACTIVE",[_playerID]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+                } else {
+                    ["OPS_CANCEL_JOIN_PREP",[_playerID,_initialPosition]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+                };
+            };
+
             // reset IMINT
 
             [_commandState,"intelListValues",[]] call ALiVE_fnc_hashSet;
@@ -748,13 +907,17 @@ switch (_operation) do {
 
                         case "Mapbag01": {
                             createDialog "SCOMTablet";
+                            private _uiW = (safezoneW / safezoneH) min 1.2;
+                            private _uiH = _uiW / 1.2;
+                            private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+                            private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                             private _ctrlBackground = ((findDisplay 12001) displayCtrl 12002);
                             _ctrlBackground ctrlsettext "x\alive\addons\main\data\ui\ALiVE_mapbag.paa";
                             _ctrlBackground ctrlSetPosition [
-                                0.15 * safezoneW + safezoneX,
-                                -0.242 * safezoneH + safezoneY,
-                                0.72 * safezoneW,
-                                1.372 * safezoneH
+                                0.15 * _uiW + _uiX,
+                                -0.242 * _uiH + _uiY,
+                                0.72 * _uiW,
+                                1.372 * _uiH
                             ];
                             _ctrlBackground ctrlCommit 0;
                         };
@@ -783,13 +946,17 @@ switch (_operation) do {
 
                         case "Mapbag01": {
                             createDialog "SCOMTablet";
+                            private _uiW = (safezoneW / safezoneH) min 1.2;
+                            private _uiH = _uiW / 1.2;
+                            private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+                            private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                             private _ctrlBackground = ((findDisplay 12001) displayCtrl 12002);
                             _ctrlBackground ctrlsettext "x\alive\addons\main\data\ui\ALiVE_mapbag.paa";
                             _ctrlBackground ctrlSetPosition [
-                                0.15 * safezoneW + safezoneX,
-                                -0.242 * safezoneH + safezoneY,
-                                0.72 * safezoneW,
-                                1.372 * safezoneH
+                                0.15 * _uiW + _uiX,
+                                -0.242 * _uiH + _uiY,
+                                0.72 * _uiW,
+                                1.372 * _uiH
                             ];
                             _ctrlBackground ctrlCommit 0;
                         };
@@ -1210,34 +1377,46 @@ switch (_operation) do {
                     _selectedList = _args select 0 select 0;
                     _selectedIndex = _args select 0 select 1;
 
-                    if(_selectedIndex >= 0) then {
+                    _listOptions = [_commandState,"opsGroupsOptions"] call ALIVE_fnc_hashGet;
+                    _listValues = [_commandState,"opsGroupsValues"] call ALIVE_fnc_hashGet;
 
-                        // store the selected item in the state
+                    if(_selectedIndex >= 0 && {_selectedIndex < count _listValues}) then {
 
-                        _listOptions = [_commandState,"opsGroupsOptions"] call ALIVE_fnc_hashGet;
-                        _listValues = [_commandState,"opsGroupsValues"] call ALIVE_fnc_hashGet;
+                        // Section headers use an empty value and are not groups.
                         _selectedOption = _listOptions select _selectedIndex;
                         _selectedValue = _listValues select _selectedIndex;
 
-                        [_commandState,"opsGroupsSelectedIndex",_selectedIndex] call ALIVE_fnc_hashSet;
-                        [_commandState,"opsGroupsSelectedValue",_selectedValue] call ALIVE_fnc_hashSet;
+                        if (_selectedValue isEqualTo []) then {
+                            [_commandState,"opsGroupsSelectedIndex",DEFAULT_SELECTED_INDEX] call ALIVE_fnc_hashSet;
+                            [_commandState,"opsGroupsSelectedValue",DEFAULT_SELECTED_VALUE] call ALIVE_fnc_hashSet;
+                            [_logic,"commandState",_commandState] call MAINCLASS;
 
-                        [_logic,"commandState",_commandState] call MAINCLASS;
+                            {
+                                private _control = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,_x);
+                                _control ctrlShow false;
+                            } forEach [SCOMTablet_CTRL_BL1,SCOMTablet_CTRL_BL2,SCOMTablet_CTRL_BL3,SCOMTablet_CTRL_BR1,SCOMTablet_CTRL_BR2];
+                        } else {
+                            [_commandState,"opsGroupsSelectedIndex",_selectedIndex] call ALIVE_fnc_hashSet;
+                            [_commandState,"opsGroupsSelectedValue",_selectedValue] call ALIVE_fnc_hashSet;
 
-                        // move the map to the selected profile
+                            [_logic,"commandState",_commandState] call MAINCLASS;
 
-                        _map = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+                            // move the map to the selected profile
 
-                        ctrlMapAnimClear _map;
-                        _map ctrlMapAnimAdd [0.5, ctrlMapScale _map, _selectedValue select 1];
-                        ctrlMapAnimCommit _map;
+                            _map = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
 
-                        [_logic,"enableGroupSelected"] call MAINCLASS;
+                            ctrlMapAnimClear _map;
+                            _map ctrlMapAnimAdd [0.5, ctrlMapScale _map, _selectedValue select 1];
+                            ctrlMapAnimCommit _map;
+
+                            [_logic,"enableGroupSelected"] call MAINCLASS;
+                        };
 
                     };
                 };
 
-                case "OP_EDIT_MAP_CLICK": {
+                case "OP_EDIT_MAP_CLICK";
+                case "OP_EDIT_MAP_DOUBLE_CLICK": {
 
                     // on right map click
 
@@ -1273,15 +1452,17 @@ switch (_operation) do {
                         _dist = ((ctrlMapScale _map) * worldSize) / 100;
 
                         {
-                            _position = _x select 1;
-                            if(_cursorPosition distance2D _position < _dist) exitWith {
-                                _selectedIndex = _forEachIndex;
+                            if (count _x >= 2) then {
+                                _position = _x select 1;
+                                if(_cursorPosition distance2D _position < _dist) exitWith {
+                                    _selectedIndex = _forEachIndex;
+                                };
                             };
                         } foreach _listValues;
 
                         // if profile found set the list to the selected profile
 
-                        if(_selectedIndex > 0) then {
+                        if(_selectedIndex >= 0) then {
 
                             _editList lbSetCurSel _selectedIndex;
 
@@ -1291,6 +1472,12 @@ switch (_operation) do {
                             [_commandState,"opsGroupsSelectedIndex",_selectedIndex] call ALIVE_fnc_hashSet;
                             [_commandState,"opsGroupsSelectedValue",_selectedValue] call ALIVE_fnc_hashSet;
 
+                            [_logic,"commandState",_commandState] call MAINCLASS;
+
+                            if (_action == "OP_EDIT_MAP_DOUBLE_CLICK") then {
+                                ["OPS_EDIT_WAYPOINTS",[]] call ALIVE_fnc_SCOMTabletOnAction;
+                            };
+
                         };
 
                     };
@@ -1299,41 +1486,148 @@ switch (_operation) do {
 
                 case "OPS_JOIN_GROUP": {
 
-                    // a group has been selected for instant join
-
                     private _commandState = [_logic,"commandState"] call MAINCLASS;
-
-                    private _selectedProfile = [_commandState,"opsGroupsSelectedValue"] call ALIVE_fnc_hashGet;
+                    private _selectedProfile = [_commandState,"opsGroupsSelectedValue",[]] call ALIVE_fnc_hashGet;
+                    if (count _selectedProfile < 2) exitWith {};
 
                     [_commandState,"opsGroupInstantJoin",true] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupInstantJoinContinuation",false] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupInstantJoinPlayerID",getPlayerUID player] call ALIVE_fnc_hashSet;
                     [_commandState,"opsGroupInstantJoinPlayerPosition",position player] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupInstantJoinOriginalPlayer",player] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupInstantJoinOriginalGroup",group player] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupInstantJoinOriginalGroupSide",side group player] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupInstantJoinOriginalWasLeader",(leader group player) isEqualTo player] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupInstantJoinCandidates",[]] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupInstantJoinSelectedIndex",DEFAULT_SELECTED_INDEX] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsViewMode","JOIN_UNIT_WAIT"] call ALIVE_fnc_hashSet;
 
                     [_logic,"commandState",_commandState] call MAINCLASS;
 
                     private _profileID = _selectedProfile select 0;
+                    [_commandState,"opsGroupInstantJoinProfileID",_profileID] call ALIVE_fnc_hashSet;
+                    [_logic,"commandState",_commandState] call MAINCLASS;
 
-                    private _faction = [_logic,"faction"] call MAINCLASS;
+                    private _editMap = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+                    _editMap ctrlSetEventHandler ["MouseButtonDblClick", ""];
 
                     private _playerID = getPlayerUID player;
 
-                    // display text to player
-
-                    private _line1 = "<t size='1.5' color='#68a7b7' align='center'>Moving position...</t><br/><br/>";
-                    ["openSplash",0.25] call ALIVE_fnc_displayMenu;
-                    ["setSplashText",_line1] call ALIVE_fnc_displayMenu;
-
-                    // must be locally executed, protect player from explosives
-                    // invisibility is done serverside
-
+                    // Keep the tablet open while the server activates the profile
+                    // and returns every unit that can be controlled.
                     player allowDamage false;
+                    [_logic,"setOpsStatus","Preparing group units..."] call MAINCLASS;
 
-                    // send the event to get further data from the command handler
+                    {
+                        private _control = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,_x);
+                        _control ctrlShow false;
+                    } forEach [SCOMTablet_CTRL_BL1,SCOMTablet_CTRL_BL2,SCOMTablet_CTRL_BL3,SCOMTablet_CTRL_BR1,SCOMTablet_CTRL_BR2,SCOMTablet_CTRL_BR3];
+
+                    private _title = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_Title);
+                    _title ctrlSetText "Operations: Preparing Instant Join";
+
+                    private _back = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
+                    _back ctrlShow true;
+                    _back ctrlSetText "Back to Groups";
+                    _back ctrlSetEventHandler ["MouseButtonClick","['OPS_CANCEL_JOIN_SELECTION',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+                    private _abort = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuAbort);
+                    _abort ctrlSetText "Cancel";
+                    _abort buttonSetAction "['OPS_CANCEL_JOIN_SELECTION',[]] call ALIVE_fnc_SCOMTabletOnAction";
 
                     ["OPS_JOIN_GROUP", [_playerID,_profileID]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer", 2];
 
-                    // close the tablet
+                };
 
-                    closeDialog 0;
+                case "OPS_JOIN_UNIT_LIST_SELECT": {
+
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+                    private _selectedIndex = _args select 0 select 1;
+                    private _candidates = [_commandState,"opsGroupInstantJoinCandidates",[]] call ALiVE_fnc_hashGet;
+
+                    if (_selectedIndex >= 0 && {_selectedIndex < count _candidates}) then {
+                        [_commandState,"opsGroupInstantJoinSelectedIndex",_selectedIndex] call ALIVE_fnc_hashSet;
+                        [_logic,"commandState",_commandState] call MAINCLASS;
+
+                        private _buttonL1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL1);
+                        _buttonL1 ctrlShow true;
+                        _buttonL1 ctrlSetText "Take Control";
+                        _buttonL1 ctrlSetEventHandler ["MouseButtonClick","['OPS_JOIN_SELECTED_UNIT',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+                        private _unit = _candidates select _selectedIndex;
+                        private _map = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+                        ctrlMapAnimClear _map;
+                        _map ctrlMapAnimAdd [0.3,0.1,position _unit];
+                        ctrlMapAnimCommit _map;
+                    };
+
+                };
+
+                case "OPS_JOIN_SELECTED_UNIT": {
+
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+                    private _candidates = [_commandState,"opsGroupInstantJoinCandidates",[]] call ALiVE_fnc_hashGet;
+                    private _selectedIndex = [_commandState,"opsGroupInstantJoinSelectedIndex",DEFAULT_SELECTED_INDEX] call ALiVE_fnc_hashGet;
+                    if (_selectedIndex < 0 && {_args isEqualType []} && {count _args > 0} && {(_args select 0) isEqualType []} && {count (_args select 0) > 1}) then {
+                        _selectedIndex = _args select 0 select 1;
+                    };
+
+                    if (_selectedIndex >= 0 && {_selectedIndex < count _candidates}) then {
+                        private _unit = _candidates select _selectedIndex;
+                        if (!isNull _unit && {alive _unit} && {!isPlayer _unit}) then {
+                            [_commandState,"opsGroupInstantJoinContinuation",false] call ALiVE_fnc_hashSet;
+                            [_commandState,"opsViewMode","JOIN_ACTIVE"] call ALIVE_fnc_hashSet;
+                            [_logic,"commandState",_commandState] call MAINCLASS;
+
+                            private _line1 = "<t size='1.5' color='#68a7b7' align='center'>Taking control...</t><br/><br/>";
+                            ["openSplash",0.25] call ALIVE_fnc_displayMenu;
+                            ["setSplashText",_line1] call ALIVE_fnc_displayMenu;
+                            closeDialog 0;
+
+                            [_logic,"enableOpsJoinGroup",[getPlayerUID player,[_unit]]] spawn MAINCLASS;
+                        };
+                    };
+
+                };
+
+                case "OPS_CANCEL_JOIN_SELECTION": {
+
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+                    private _originalPlayer = [_commandState,"opsGroupInstantJoinOriginalPlayer",player] call ALiVE_fnc_hashGet;
+                    private _initialPosition = [_commandState,"opsGroupInstantJoinPlayerPosition",[]] call ALiVE_fnc_hashGet;
+                    private _playerID = [_commandState,"opsGroupInstantJoinPlayerID",getPlayerUID player] call ALiVE_fnc_hashGet;
+                    private _isContinuation = [_commandState,"opsGroupInstantJoinContinuation",false] call ALiVE_fnc_hashGet;
+
+                    [_commandState,"opsGroupInstantJoin",false] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupInstantJoinContinuation",false] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupInstantJoinCandidates",[]] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupInstantJoinSelectedIndex",DEFAULT_SELECTED_INDEX] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsViewMode","GROUPS"] call ALIVE_fnc_hashSet;
+                    [_logic,"commandState",_commandState] call MAINCLASS;
+
+                    if (!isNull _originalPlayer) then {
+                        if (!_isContinuation && {_initialPosition isEqualType []} && {count _initialPosition >= 2}) then {
+                            _originalPlayer setPos _initialPosition;
+                        };
+                        [_originalPlayer,false] call ALIVE_fnc_adminGhost;
+                        if (!_isContinuation) then {_originalPlayer allowDamage true};
+                    };
+
+                    if (_isContinuation) then {
+                        ["OPS_CANCEL_JOIN_ACTIVE",[_playerID]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+                    } else {
+                        ["OPS_CANCEL_JOIN_PREP",[_playerID,_initialPosition]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+                    };
+
+                    private _abort = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuAbort);
+                    _abort ctrlSetText "Close";
+                    _abort buttonSetAction "closeDialog 0";
+
+                    private _groups = [_commandState,"opsGroups",[]] call ALiVE_fnc_hashGet;
+                    private _selectedOpcom = [_commandState,"opsOPCOMSelectedValue",[]] call ALiVE_fnc_hashGet;
+                    if (count _selectedOpcom >= 3) then {
+                        ["OPS_GROUPS",[getPlayerUID _originalPlayer,_selectedOpcom select 2,_groups]] call ALIVE_fnc_SCOMTabletEventToClient;
+                    };
 
                 };
 
@@ -1341,15 +1635,14 @@ switch (_operation) do {
 
                     private ["_commandState","_initialPosition","_line1","_playerID","_requestID","_event","_faction","_buttonL1"];
 
-                    // close the tablet
-
-                    closeDialog 0;
-
                     _commandState = [_logic,"commandState"] call MAINCLASS;
 
                     [_commandState,"opsGroupInstantJoin",false] call ALIVE_fnc_hashSet;
 
                     [_logic,"commandState",_commandState] call MAINCLASS;
+
+                    // The active join loop restores the original player body.
+                    closeDialog 0;
 
                 };
 
@@ -1476,22 +1769,28 @@ switch (_operation) do {
 
                     private _commandState = [_logic,"commandState"] call MAINCLASS;
 
-                    private _selectedProfile = [_commandState,"opsGroupsSelectedValue"] call ALIVE_fnc_hashGet;
+                    private _selectedProfile = [_commandState,"opsGroupsSelectedValue",[]] call ALIVE_fnc_hashGet;
+                    if (count _selectedProfile < 2) exitWith {};
+
+                    [_commandState,"opsViewMode","WAYPOINTS"] call ALIVE_fnc_hashSet;
+                    [_logic,"commandState",_commandState] call MAINCLASS;
 
                     private _profileID = _selectedProfile select 0;
 
-                    private _buttonL1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL1);
-                    _buttonL1 ctrlShow false;
+                    {
+                        private _button = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,_x);
+                        _button ctrlShow false;
+                    } foreach [SCOMTablet_CTRL_BL1,SCOMTablet_CTRL_BL2,SCOMTablet_CTRL_BL3,SCOMTablet_CTRL_BR1,SCOMTablet_CTRL_BR2,SCOMTablet_CTRL_BR3];
 
-                    private _buttonL2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL2);
-                    _buttonL2 ctrlShow false;
+                    private _title = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_Title);
+                    _title ctrlSetText "Operations: Orders - click map to add; select an order to edit";
 
-                    private _buttonL3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL3);
-                    _buttonL3 ctrlShow false;
+                    private _editMap = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+                    _editMap ctrlSetEventHandler ["MouseButtonDblClick",""];
 
                     private _back = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
                     _back ctrlShow true;
-                    _back ctrlSetText "Back";
+                    _back ctrlSetText "Back to Groups";
                     _back ctrlSetEventHandler ["MouseButtonClick", "['OPS_CANCEL_EDIT_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                     // show waiting until response comes back
@@ -1509,8 +1808,10 @@ switch (_operation) do {
                 case "OPS_CANCEL_EDIT_WAYPOINTS": {
 
                     _commandState = [_logic,"commandState"] call MAINCLASS;
+                    [_commandState,"opsViewMode","GROUPS"] call ALIVE_fnc_hashSet;
                     _groups = [_commandState,"opsGroups", []] call ALiVE_fnc_hashGet;
-                    _side = [_commandState,"opsOPCOMSelectedValue"] call ALiVE_fnc_hashGet;
+                    private _selectedOpcom = [_commandState,"opsOPCOMSelectedValue"] call ALiVE_fnc_hashGet;
+                    _side = _selectedOpcom select 2;
 
                     // enable/disable interface controls
 
@@ -1542,9 +1843,25 @@ switch (_operation) do {
                     [_commandState,"opsGroupWaypoints", []] call ALIVE_fnc_hashSet;
                     [_commandState,"opsGroupPlannedWaypoints", []] call ALIVE_fnc_hashSet;
                     [_commandState,"opsGroupWaypointsPlanned", false] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupWaypointsSelectedOptions", []] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupWaypointsSelectedValues", []] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupWaypointsSelectedIndex", DEFAULT_SELECTED_INDEX] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupWaypointsSelectedValue", DEFAULT_SELECTED_VALUE] call ALIVE_fnc_hashSet;
 
                     [_commandState,"opsGroupsSelectedIndex", DEFAULT_SELECTED_INDEX] call ALIVE_fnc_hashSet;
                     [_commandState,"opsGroupsSelectedValue", DEFAULT_SELECTED_VALUE] call ALIVE_fnc_hashSet;
+
+                    // Back means abandon the local edit session. Clear the list and
+                    // restore the shared left button before the Groups view reuses it.
+                    lbClear _waypointList;
+                    private _buttonL1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL1);
+                    private _buttonL1DefaultPosition = _buttonL1 getVariable ["SCOM_defaultPosition",[]];
+                    if (count _buttonL1DefaultPosition == 4) then {
+                        _buttonL1 ctrlSetPosition _buttonL1DefaultPosition;
+                        _buttonL1 ctrlCommit 0;
+                    };
+                    _buttonL1 ctrlSetTooltip "";
+                    _buttonL1 ctrlShow false;
 
                     // delete profile markers, they are created again once list is reshown
 
@@ -1594,7 +1911,7 @@ switch (_operation) do {
                         _waypointOptions = [_commandState,"opsGroupWaypointsSelectedOptions"] call ALIVE_fnc_hashGet;
                         _waypoints = [_commandState,"opsGroupWaypointsSelectedValues"] call ALIVE_fnc_hashGet;
 
-                        _newWaypointOption = format["Waypoint %1 [%2]",count(_waypoints),"MOVE"];
+                        _newWaypointOption = format["Order %1: %2",count(_waypoints) + 1,"Move"];
                         _newWaypointValue = [_position, 100] call ALIVE_fnc_createProfileWaypoint;
 
                         //_newWaypointValue call ALIVE_fnc_inspectHash;
@@ -1613,21 +1930,28 @@ switch (_operation) do {
                         [_commandState,"opsGroupPlannedWaypoints",_plannedWaypoints] call ALIVE_fnc_hashSet;
                         [_commandState,"opsGroupWaypointsPlanned",true] call ALIVE_fnc_hashSet;
 
+                        private _newWaypointIndex = count(_waypoints) - 1;
+                        [_commandState,"opsGroupWaypointsSelectedIndex",_newWaypointIndex] call ALIVE_fnc_hashSet;
+                        [_commandState,"opsGroupWaypointsSelectedValue",_newWaypointValue select 2] call ALIVE_fnc_hashSet;
+
                         [_logic,"commandState",_commandState] call MAINCLASS;
+
+                        _waypointList lbSetCurSel _newWaypointIndex;
+                        [_logic,"enableWaypointSelected"] call MAINCLASS;
 
                         private["_backButton","_buttonR2","_buttonR3"];
 
                         _backButton = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
-                        _backButton ctrlShow false;
+                        _backButton ctrlShow true;
 
                         _buttonR2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR2);
                         _buttonR2 ctrlShow true;
-                        _buttonR2 ctrlSetText "Clear Waypoint Changes";
+                        _buttonR2 ctrlSetText "Discard Order Changes";
                         _buttonR2 ctrlSetEventHandler ["MouseButtonClick", "['OPS_CANCEL_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                         _buttonR3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR3);
                         _buttonR3 ctrlShow true;
-                        _buttonR3 ctrlSetText "Apply Waypoint Changes";
+                        _buttonR3 ctrlSetText "Apply Orders";
                         _buttonR3 ctrlSetEventHandler ["MouseButtonClick", "['OPS_APPLY_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                     };
@@ -1658,6 +1982,7 @@ switch (_operation) do {
 
                     private _editMap = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
                     _editMap ctrlSetEventHandler ["MouseButtonDown", "['OP_MAP_CLICK_NULL',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+                    _editMap ctrlSetEventHandler ["MouseButtonDblClick",""];
 
                     private _editList = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditList);
                     lbClear _editList;
@@ -1895,7 +2220,7 @@ switch (_operation) do {
 
                         // move the map to the selected profile
 
-                        _map = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditRight);
+                        _map = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
 
                         ctrlMapAnimClear _map;
                         _map ctrlMapAnimAdd [0.5, ctrlMapScale _map, _selectedValue select 0];
@@ -1904,6 +2229,85 @@ switch (_operation) do {
                         [_logic, "enableWaypointSelected"] call MAINCLASS;
 
                     };
+                };
+
+                case "OPS_DELETE_WAYPOINT": {
+
+                    private _commandState = [_logic,"commandState"] call MAINCLASS;
+                    private _selectedIndex = [_commandState,"opsGroupWaypointsSelectedIndex",-1] call ALIVE_fnc_hashGet;
+                    private _waypoints = [_commandState,"opsGroupWaypointsSelectedValues",[]] call ALIVE_fnc_hashGet;
+
+                    if (_selectedIndex >= 0 && {_selectedIndex < count _waypoints}) then {
+
+                        _waypoints deleteAt _selectedIndex;
+
+                        private _typeOptions = [_commandState,"opsWPTypeOptions",[]] call ALIVE_fnc_hashGet;
+                        private _typeValues = [_commandState,"opsWPTypeValues",[]] call ALIVE_fnc_hashGet;
+                        private _waypointOptions = [];
+
+                        {
+                            private _typeValue = _x select 2;
+                            private _typeIndex = _typeValues find _typeValue;
+                            private _typeLabel = if (_typeIndex >= 0) then {
+                                _typeOptions select _typeIndex
+                            } else {
+                                _typeValue
+                            };
+
+                            _waypointOptions pushBack format["Order %1: %2",_forEachIndex + 1,_typeLabel];
+                        } forEach _waypoints;
+
+                        // The editable arrays are authoritative until Apply. Rebuild the
+                        // drawn chain so removing an active or planned order immediately
+                        // removes the matching segment.
+                        private _groupWaypoints = _waypoints apply {_x select 0};
+
+                        [_commandState,"opsGroupWaypointsSelectedOptions",_waypointOptions] call ALIVE_fnc_hashSet;
+                        [_commandState,"opsGroupWaypointsSelectedValues",_waypoints] call ALIVE_fnc_hashSet;
+                        [_commandState,"opsGroupWaypoints",_groupWaypoints] call ALIVE_fnc_hashSet;
+                        [_commandState,"opsGroupPlannedWaypoints",[]] call ALIVE_fnc_hashSet;
+                        [_commandState,"opsGroupWaypointsPlanned",true] call ALIVE_fnc_hashSet;
+
+                        private _waypointList = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_WaypointList);
+                        lbClear _waypointList;
+                        {
+                            _waypointList lbAdd _x;
+                        } forEach _waypointOptions;
+
+                        if (count _waypoints > 0) then {
+                            private _newIndex = _selectedIndex min (count _waypoints - 1);
+                            [_commandState,"opsGroupWaypointsSelectedIndex",_newIndex] call ALIVE_fnc_hashSet;
+                            [_commandState,"opsGroupWaypointsSelectedValue",_waypoints select _newIndex] call ALIVE_fnc_hashSet;
+                            [_logic,"commandState",_commandState] call MAINCLASS;
+
+                            _waypointList lbSetCurSel _newIndex;
+                            [_logic,"enableWaypointSelected"] call MAINCLASS;
+                        } else {
+                            [_commandState,"opsGroupWaypointsSelectedIndex",-1] call ALIVE_fnc_hashSet;
+                            [_commandState,"opsGroupWaypointsSelectedValue",[]] call ALIVE_fnc_hashSet;
+                            [_logic,"commandState",_commandState] call MAINCLASS;
+
+                            {
+                                private _control = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,_x);
+                                _control ctrlShow false;
+                            } forEach [SCOMTablet_CTRL_BL1,SCOMTablet_CTRL_WaypointTypeList,SCOMTablet_CTRL_WaypointSpeedList,SCOMTablet_CTRL_WaypointFormationList,SCOMTablet_CTRL_WaypointBehavourList];
+                        };
+
+                        private _backButton = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
+                        _backButton ctrlShow true;
+
+                        private _buttonR2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR2);
+                        _buttonR2 ctrlShow true;
+                        _buttonR2 ctrlSetText "Discard Order Changes";
+                        _buttonR2 ctrlSetEventHandler ["MouseButtonClick", "['OPS_CANCEL_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+                        private _buttonR3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR3);
+                        _buttonR3 ctrlShow true;
+                        _buttonR3 ctrlSetText "Apply Orders";
+                        _buttonR3 ctrlSetEventHandler ["MouseButtonClick", "['OPS_APPLY_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+                    };
+
                 };
 
                 case "OPS_WP_TYPE_LIST_SELECT": {
@@ -1938,19 +2342,27 @@ switch (_operation) do {
                         _waypoints set [_waypointSelectedIndex,_waypointSelected];
                         [_commandState,"opsGroupWaypointsSelectedValues",_waypoints] call ALIVE_fnc_hashSet;
 
+                        private _waypointOptions = [_commandState,"opsGroupWaypointsSelectedOptions"] call ALIVE_fnc_hashGet;
+                        private _updatedOption = format["Order %1: %2",_waypointSelectedIndex + 1,_selectedOption];
+                        _waypointOptions set [_waypointSelectedIndex,_updatedOption];
+                        [_commandState,"opsGroupWaypointsSelectedOptions",_waypointOptions] call ALIVE_fnc_hashSet;
+
+                        private _waypointList = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_WaypointList);
+                        _waypointList lbSetText [_waypointSelectedIndex,_updatedOption];
+
                         [_logic,"commandState",_commandState] call MAINCLASS;
 
                         _backButton = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
-                        _backButton ctrlShow false;
+                        _backButton ctrlShow true;
 
                         _buttonR2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR2);
                         _buttonR2 ctrlShow true;
-                        _buttonR2 ctrlSetText "Clear Waypoint Changes";
+                        _buttonR2 ctrlSetText "Discard Order Changes";
                         _buttonR2 ctrlSetEventHandler ["MouseButtonClick", "['OPS_CANCEL_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                         _buttonR3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR3);
                         _buttonR3 ctrlShow true;
-                        _buttonR3 ctrlSetText "Apply Waypoint Changes";
+                        _buttonR3 ctrlSetText "Apply Orders";
                         _buttonR3 ctrlSetEventHandler ["MouseButtonClick", "['OPS_APPLY_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                     };
@@ -1991,16 +2403,16 @@ switch (_operation) do {
                         [_logic,"commandState",_commandState] call MAINCLASS;
 
                         _backButton = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
-                        _backButton ctrlShow false;
+                        _backButton ctrlShow true;
 
                         _buttonR2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR2);
                         _buttonR2 ctrlShow true;
-                        _buttonR2 ctrlSetText "Clear Waypoint Changes";
+                        _buttonR2 ctrlSetText "Discard Order Changes";
                         _buttonR2 ctrlSetEventHandler ["MouseButtonClick", "['OPS_CANCEL_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                         _buttonR3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR3);
                         _buttonR3 ctrlShow true;
-                        _buttonR3 ctrlSetText "Apply Waypoint Changes";
+                        _buttonR3 ctrlSetText "Apply Orders";
                         _buttonR3 ctrlSetEventHandler ["MouseButtonClick", "['OPS_APPLY_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                     };
@@ -2041,16 +2453,16 @@ switch (_operation) do {
                         [_logic,"commandState",_commandState] call MAINCLASS;
 
                         _backButton = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
-                        _backButton ctrlShow false;
+                        _backButton ctrlShow true;
 
                         _buttonR2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR2);
                         _buttonR2 ctrlShow true;
-                        _buttonR2 ctrlSetText "Clear Waypoint Changes";
+                        _buttonR2 ctrlSetText "Discard Order Changes";
                         _buttonR2 ctrlSetEventHandler ["MouseButtonClick", "['OPS_CANCEL_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                         _buttonR3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR3);
                         _buttonR3 ctrlShow true;
-                        _buttonR3 ctrlSetText "Apply Waypoint Changes";
+                        _buttonR3 ctrlSetText "Apply Orders";
                         _buttonR3 ctrlSetEventHandler ["MouseButtonClick", "['OPS_APPLY_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                     };
@@ -2091,16 +2503,16 @@ switch (_operation) do {
                         [_logic,"commandState",_commandState] call MAINCLASS;
 
                         _backButton = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
-                        _backButton ctrlShow false;
+                        _backButton ctrlShow true;
 
                         _buttonR2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR2);
                         _buttonR2 ctrlShow true;
-                        _buttonR2 ctrlSetText "Clear Waypoint Changes";
+                        _buttonR2 ctrlSetText "Discard Order Changes";
                         _buttonR2 ctrlSetEventHandler ["MouseButtonClick", "['OPS_CANCEL_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                         _buttonR3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR3);
                         _buttonR3 ctrlShow true;
-                        _buttonR3 ctrlSetText "Apply Waypoint Changes";
+                        _buttonR3 ctrlSetText "Apply Orders";
                         _buttonR3 ctrlSetEventHandler ["MouseButtonClick", "['OPS_APPLY_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                     };
@@ -2177,8 +2589,14 @@ switch (_operation) do {
                     private _buttonR2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR2);
                     _buttonR2 ctrlShow false;
 
+                    private _buttonR3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR3);
+                    _buttonR3 ctrlShow false;
+
                     private _buttonR1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR1);
                     _buttonR1 ctrlShow false;
+
+                    private _buttonL1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL1);
+                    _buttonL1 ctrlShow false;
 
                     // show waiting until response comes back
 
@@ -2291,6 +2709,14 @@ switch (_operation) do {
         _rightMap ctrlShow false;
 
         _buttonL1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL1);
+        private _buttonL1DefaultPosition = _buttonL1 getVariable ["SCOM_defaultPosition",[]];
+        if (_buttonL1DefaultPosition isEqualTo []) then {
+            _buttonL1 setVariable ["SCOM_defaultPosition",ctrlPosition _buttonL1];
+        } else {
+            _buttonL1 ctrlSetPosition _buttonL1DefaultPosition;
+            _buttonL1 ctrlCommit 0;
+        };
+        _buttonL1 ctrlSetTooltip "";
         _buttonL1 ctrlShow false;
 
         _buttonL2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL2);
@@ -3155,6 +3581,14 @@ switch (_operation) do {
         _intelTypeList ctrlShow false;
 
         _buttonL1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL1);
+        private _buttonL1DefaultPosition = _buttonL1 getVariable ["SCOM_defaultPosition",[]];
+        if (_buttonL1DefaultPosition isEqualTo []) then {
+            _buttonL1 setVariable ["SCOM_defaultPosition",ctrlPosition _buttonL1];
+        } else {
+            _buttonL1 ctrlSetPosition _buttonL1DefaultPosition;
+            _buttonL1 ctrlCommit 0;
+        };
+        _buttonL1 ctrlSetTooltip "";
         _buttonL1 ctrlShow false;
 
         _buttonL2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL2);
@@ -3258,14 +3692,13 @@ switch (_operation) do {
         // once the list of opcom instances has been loaded
         // display the available OPCOM sides
 
-        // display the reset button so the user can restart
+        private _title = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_Title);
+        _title ctrlSetText "Operations: Select Commander";
+
+        // this is the first page; Close already provides the exit action
 
         _back = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
-        _back ctrlShow true;
-
-        _back ctrlSetText "Back";
-
-        _back ctrlSetEventHandler ["MouseButtonClick", "['OPS_RESET',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+        _back ctrlShow false;
 
         if(typeName _args == "ARRAY") then {
 
@@ -3311,6 +3744,12 @@ switch (_operation) do {
 
                 _opsTypeList ctrlSetEventHandler ["LBSelChanged", "['OPS_OPCOM_LIST_SELECT',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
+                // Most missions expose one commander. Skip a redundant choice
+                // while preserving the list for missions that expose several.
+                if (count(_opcomOptions) == 1) then {
+                    _opsTypeList lbSetCurSel 0;
+                };
+
             } else {
 
                 [_logic,"setOpsStatus", "No OPCOM instances found"] call MAINCLASS;
@@ -3334,6 +3773,14 @@ switch (_operation) do {
 
             _selectedSide = _args select 1;
             _groupData = _args select 2;
+
+            private _title = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_Title);
+            _title ctrlSetText "Operations: Groups - double-click a group to issue orders";
+
+            private _back = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
+            _back ctrlShow true;
+            _back ctrlSetText "Change Commander";
+            _back ctrlSetEventHandler ["MouseButtonClick", "['OPS_RESET',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
             if(count(_groupData) > 0) then {
 
@@ -3362,7 +3809,7 @@ switch (_operation) do {
                 _editList ctrlShow true;
 
                 lbClear _editList;
-                _editList lbSetCurSel 0;
+                _editList lbSetCurSel -1;
 
                 _options = [];
                 _values = [];
@@ -3396,213 +3843,72 @@ switch (_operation) do {
                     };
                 };
 
+                private _categories = [
+                    [_infantry,"Infantry","%1_inf"],
+                    [_motorised,"Motorised","%1_motor_inf"],
+                    [_mechanized,"Mechanized","%1_mech_inf"],
+                    [_armor,"Armor","%1_armor"],
+                    [_air,"Air","%1_air"],
+                    [_sea,"Naval","%1_unknown"],
+                    [_artillery,"Artillery","%1_art"],
+                    [_AAA,"Anti-Air","%1_mech_inf"]
+                ];
+
+                private _unlockedCount = 0;
+                private _lockedCount = 0;
                 {
-                    _profileID = _x select 0;
-                    _position = _x select 1;
-                    _label = _profileID splitString "_";
-                    _label = _label select ((count _label) - 1);
+                    {
+                        private _locked = if (count _x > 2) then {_x select 2} else {false};
+                        if (_locked) then {_lockedCount = _lockedCount + 1} else {_unlockedCount = _unlockedCount + 1};
+                    } forEach (_x select 0);
+                } forEach _categories;
 
-                    _option = format ["Infantry Group %1", _label];
-                    _options pushBack (_option);
-                    _values pushBack (_x);
-
-                    _editList lbAdd _option;
-
-                    _profileMarker = format["%1_inf",_typePrefix];
-
-                    _m = createMarkerLocal [format[MTEMPLATE,_label], _position];
-                    _m setMarkerShapeLocal "ICON";
-                    _m setMarkerSizeLocal [0.5,0.5];
-                    _m setMarkerTypeLocal _profileMarker;
-                    _m setMarkerColorLocal _color;
-                    _m setMarkerAlphaLocal _alpha;
-                    _m setMarkerTextLocal format["e%1",_label];
-
-                    _markers pushback _m;
-
-                } forEach _infantry;
-
+                // Render unlocked commander groups first and locked player-owned
+                // groups in their own persistent battlegroup section, listed
+                // first so the player's assigned formations are immediately visible.
                 {
-                    _profileID = _x select 0;
-                    _position = _x select 1;
-                    _label = _profileID splitString "_";
-                    _label = _label select ((count _label) - 1);
+                    _x params ["_sectionLocked","_sectionTitle","_sectionCount"];
 
-                    _option = format ["Motorised Group %1", _label];
-                    _options pushBack (_option);
-                    _values pushBack (_x);
+                    if (_sectionCount > 0) then {
+                        private _headerIndex = _editList lbAdd _sectionTitle;
+                        _editList lbSetColor [_headerIndex, if (_sectionLocked) then {[1,0.65,0.15,1]} else {[0.75,0.85,0.75,1]}];
+                        _options pushBack _sectionTitle;
+                        _values pushBack [];
 
-                    _editList lbAdd _option;
+                        {
+                            _x params ["_categoryGroups","_categoryLabel","_markerTemplate"];
 
-                    _profileMarker = format["%1_motor_inf",_typePrefix];
+                            {
+                                private _locked = if (count _x > 2) then {_x select 2} else {false};
 
-                    _m = createMarkerLocal [format[MTEMPLATE, format["%1", _label]], _position];
-                    _m setMarkerShapeLocal "ICON";
-                    _m setMarkerSizeLocal [0.5,0.5];
-                    _m setMarkerTypeLocal _profileMarker;
-                    _m setMarkerColorLocal _color;
-                    _m setMarkerAlphaLocal _alpha;
-                    _m setMarkerTextLocal format["e%1",_label];
+                                if (_locked == _sectionLocked) then {
+                                    _profileID = _x select 0;
+                                    _position = _x select 1;
+                                    _label = _profileID splitString "_";
+                                    _label = _label select ((count _label) - 1);
 
-                    _markers pushback _m;
+                                    _option = format ["  %1 Group %2",_categoryLabel,_label];
+                                    _options pushBack _option;
+                                    _values pushBack _x;
+                                    _editList lbAdd _option;
 
-                } forEach _motorised;
-
-                {
-                    _profileID = _x select 0;
-                    _position = _x select 1;
-                    _label = _profileID splitString "_";
-                    _label = _label select ((count _label) - 1);
-
-                    _option = format ["Mechanized Group %1", _label];
-                    _options pushBack (_option);
-                    _values pushBack (_x);
-
-                    _editList lbAdd _option;
-
-                    _profileMarker = format["%1_mech_inf",_typePrefix];
-
-                    _m = createMarkerLocal [format[MTEMPLATE, format["%1", _label]], _position];
-                    _m setMarkerShapeLocal "ICON";
-                    _m setMarkerSizeLocal [0.5,0.5];
-                    _m setMarkerTypeLocal _profileMarker;
-                    _m setMarkerColorLocal _color;
-                    _m setMarkerAlphaLocal _alpha;
-                    _m setMarkerTextLocal format["e%1",_label];
-
-                    _markers pushback _m;
-
-                } forEach _mechanized;
-
-                {
-                    _profileID = _x select 0;
-                    _position = _x select 1;
-                    _label = _profileID splitString "_";
-                    _label = _label select ((count _label) - 1);
-
-                    _option = format ["Armor Group %1", _label];
-                    _options pushBack (_option);
-                    _values pushBack (_x);
-
-                    _editList lbAdd _option;
-
-                    _profileMarker = format["%1_armor",_typePrefix];
-
-                    _m = createMarkerLocal [format[MTEMPLATE, format["%1", _label]], _position];
-                    _m setMarkerShapeLocal "ICON";
-                    _m setMarkerSizeLocal [0.5,0.5];
-                    _m setMarkerTypeLocal _profileMarker;
-                    _m setMarkerColorLocal _color;
-                    _m setMarkerAlphaLocal _alpha;
-                    _m setMarkerTextLocal format["e%1",_label];
-
-                    _markers pushback _m;
-
-                } forEach _armor;
-
-                {
-                    _profileID = _x select 0;
-                    _position = _x select 1;
-                    _label = _profileID splitString "_";
-                    _label = _label select ((count _label) - 1);
-
-                    _option = format ["Air Group %1", _label];
-                    _options pushBack (_option);
-                    _values pushBack (_x);
-
-                    _editList lbAdd _option;
-
-                    _profileMarker = format["%1_air",_typePrefix];
-
-                    _m = createMarkerLocal [format[MTEMPLATE, format["%1", _label]], _position];
-                    _m setMarkerShapeLocal "ICON";
-                    _m setMarkerSizeLocal [0.5,0.5];
-                    _m setMarkerTypeLocal _profileMarker;
-                    _m setMarkerColorLocal _color;
-                    _m setMarkerAlphaLocal _alpha;
-                    _m setMarkerTextLocal format["e%1",_label];
-
-                    _markers pushback _m;
-
-                } forEach _air;
-
-                {
-                    _profileID = _x select 0;
-                    _position = _x select 1;
-                    _label = _profileID splitString "_";
-                    _label = _label select ((count _label) - 1);
-
-                    _option = format ["Naval Group %1", _label];
-                    _options pushBack (_option);
-                    _values pushBack (_x);
-
-                    _editList lbAdd _option;
-
-                    _profileMarker = format["%1_unknown",_typePrefix];
-
-                    _m = createMarkerLocal [format[MTEMPLATE, format["%1", _label]], _position];
-                    _m setMarkerShapeLocal "ICON";
-                    _m setMarkerSizeLocal [0.5,0.5];
-                    _m setMarkerTypeLocal _profileMarker;
-                    _m setMarkerColorLocal _color;
-                    _m setMarkerAlphaLocal _alpha;
-                    _m setMarkerTextLocal format["e%1",_label];
-
-                    _markers pushback _m;
-
-                } forEach _sea;
-
-                {
-                    _profileID = _x select 0;
-                    _position = _x select 1;
-                    _label = _profileID splitString "_";
-                    _label = _label select ((count _label) - 1);
-
-                    _option = format ["Artillery Group %1", _label];
-                    _options pushBack (_option);
-                    _values pushBack (_x);
-
-                    _editList lbAdd _option;
-
-                    _profileMarker = format["%1_art",_typePrefix];
-
-                    _m = createMarkerLocal [format[MTEMPLATE, format["%1", _label]], _position];
-                    _m setMarkerShapeLocal "ICON";
-                    _m setMarkerSizeLocal [0.5,0.5];
-                    _m setMarkerTypeLocal _profileMarker;
-                    _m setMarkerColorLocal _color;
-                    _m setMarkerAlphaLocal _alpha;
-                    _m setMarkerTextLocal format["e%1",_label];
-
-                    _markers pushback _m;
-
-                } forEach _artillery;
-
-                {
-                    _profileID = _x select 0;
-                    _position = _x select 1;
-                    _label = _profileID splitString "_";
-                    _label = _label select ((count _label) - 1);
-
-                    _option = format ["Anti-Air Group %1", _forEachIndex + 1];
-                    _options pushBack (_option);
-                    _values pushBack (_x);
-
-                    _editList lbAdd _option;
-
-                    _profileMarker = format["%1_mech_inf",_typePrefix];
-
-                    _m = createMarkerLocal [format[MTEMPLATE, format["%1", _label]], _position];
-                    _m setMarkerShapeLocal "ICON";
-                    _m setMarkerSizeLocal [0.5,0.5];
-                    _m setMarkerTypeLocal _profileMarker;
-                    _m setMarkerColorLocal _color;
-                    _m setMarkerAlphaLocal _alpha;
-                    _m setMarkerTextLocal format["e%1",_label];
-
-                    _markers pushback _m;
-
-                } forEach _AAA;
+                                    _profileMarker = format[_markerTemplate,_typePrefix];
+                                    _m = createMarkerLocal [format[MTEMPLATE,_profileID],_position];
+                                    _m setMarkerShapeLocal "ICON";
+                                    _m setMarkerSizeLocal [0.5,0.5];
+                                    _m setMarkerTypeLocal _profileMarker;
+                                    _m setMarkerColorLocal (if (_sectionLocked) then {"ColorOrange"} else {_color});
+                                    _m setMarkerAlphaLocal _alpha;
+                                    _m setMarkerTextLocal format["%1%2",if (_sectionLocked) then {"P"} else {"e"},_label];
+                                    _markers pushback _m;
+                                };
+                            } forEach _categoryGroups;
+                        } forEach _categories;
+                    };
+                } forEach [
+                    [true,"PLAYER BATTLEGROUP (LOCKED)",_lockedCount],
+                    [false,"AI COMMANDER GROUPS",_unlockedCount]
+                ];
 
 
                 // store the marker state for clearing later
@@ -3617,12 +3923,32 @@ switch (_operation) do {
                 // set the event handler for the list selection event
 
                 _editList ctrlSetEventHandler ["LBSelChanged", "['OPS_GROUP_LIST_SELECT',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+                _editList ctrlSetEventHandler ["LBDblClick", "['OPS_EDIT_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+                _editList ctrlSetTooltip "Select for group actions. Double-click to issue orders.";
+
+                private _returnProfileID = [_commandState,"opsGroupsReturnProfileID",""] call ALiVE_fnc_hashGet;
+                private _returnGroupIndex = if (_returnProfileID != "") then {
+                    _values findIf {count _x >= 2 && {(_x select 0) == _returnProfileID}}
+                } else {
+                    -1
+                };
+                private _groupIndexToSelect = if (_returnGroupIndex >= 0) then {
+                    _returnGroupIndex
+                } else {
+                    _values findIf {count _x >= 2}
+                };
+
+                [_commandState,"opsGroupsReturnProfileID",""] call ALiVE_fnc_hashSet;
+                [_logic,"commandState",_commandState] call MAINCLASS;
+
+                if (_groupIndexToSelect >= 0) then {_editList lbSetCurSel _groupIndexToSelect};
 
                 // set the event handler for the map selection event
 
                 _editMap = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
 
                 _editMap ctrlSetEventHandler ["MouseButtonDown", "['OP_EDIT_MAP_CLICK',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+                _editMap ctrlSetEventHandler ["MouseButtonDblClick", "['OP_EDIT_MAP_DOUBLE_CLICK',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                 // hide the loading status text
 
@@ -3679,6 +4005,9 @@ switch (_operation) do {
         // list order = array order = the commander's priority queue
 
         private _commandState = [_logic,"commandState"] call MAINCLASS;
+
+        private _title = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_Title);
+        _title ctrlSetText "Operations: Commander Objectives";
 
         private _objectiveData = [_commandState,"opsObjectivesData"] call ALIVE_fnc_hashGet;
         private _meta = [_commandState,"opsObjectivesMeta"] call ALIVE_fnc_hashGet;
@@ -3747,6 +4076,7 @@ switch (_operation) do {
 
         private _editMap = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
         _editMap ctrlSetEventHandler ["MouseButtonDown", "['OP_MAP_CLICK_NULL',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+        _editMap ctrlSetEventHandler ["MouseButtonDblClick",""];
 
         // buttons
 
@@ -3874,6 +4204,11 @@ switch (_operation) do {
 
             private _commandState = [_logic,"commandState"] call MAINCLASS;
 
+            // A double-click can open the order editor while the single-click
+            // profile request is still in flight. Do not let that stale reply
+            // replace the editor with the group-action buttons.
+            if (([_commandState,"opsViewMode","GROUPS"] call ALIVE_fnc_hashGet) != "GROUPS") exitwith {};
+
             private _profileData = _args select 1;
 
             if !(_profileData isEqualTo []) then {
@@ -3912,7 +4247,7 @@ switch (_operation) do {
 
         private _buttonL1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL1);
         _buttonL1 ctrlShow true;
-        _buttonL1 ctrlSetText "Edit Group Waypoints";
+        _buttonL1 ctrlSetText "Issue Orders";
         _buttonL1 ctrlSetEventHandler ["MouseButtonClick", "['OPS_EDIT_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
         private _allowSpectate = [_logic,"scomOpsAllowSpectate"] call MAINCLASS;
@@ -3952,9 +4287,7 @@ switch (_operation) do {
         };
 
         private _buttonL3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL3);
-        _buttonL3 ctrlShow true;
-        _buttonL3 ctrlSetText "More actions...";
-        _buttonL3 ctrlSetEventHandler ["MouseButtonClick", "['OPS_MORE_OPTIONS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+        _buttonL3 ctrlShow false;
 
     };
 
@@ -3970,6 +4303,13 @@ switch (_operation) do {
         if(typeName _args == "ARRAY") then {
 
             _commandState = [_logic,"commandState"] call MAINCLASS;
+
+            // Ignore a delayed waypoint response after the player has already
+            // returned to the group or objective view.
+            if (([_commandState,"opsViewMode","GROUPS"] call ALIVE_fnc_hashGet) != "WAYPOINTS") exitwith {};
+
+            private _title = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_Title);
+            _title ctrlSetText "Operations: Orders - click map to add; select an order to edit";
 
             // hide the loading status text
 
@@ -4020,7 +4360,14 @@ switch (_operation) do {
                 _waypointsValues = [];
 
                 {
-                    _option = format["Waypoint %1 [%2]",_forEachIndex,_x select 2];
+                    private _orderTypeValue = _x select 2;
+                    private _orderTypeLabel = switch (_orderTypeValue) do {
+                        case "MOVE": {"Move"};
+                        case "SAD": {"Attack / Search & Destroy"};
+                        case "TR UNLOAD": {"Transport Unload"};
+                        default {_orderTypeValue};
+                    };
+                    _option = format["Order %1: %2",_forEachIndex + 1,_orderTypeLabel];
 
                     _waypointsOptions pushBack _option;
                     _waypointsValues pushBack _x;
@@ -4063,6 +4410,14 @@ switch (_operation) do {
                 [_commandState,"opsGroupSelectedProfile",_profile] call ALIVE_fnc_hashSet;
                 [_commandState,"opsGroupWaypoints",_groupWaypoints] call ALIVE_fnc_hashSet;
 
+                private _lastWaypointIndex = count(_waypointsValues) - 1;
+                if (_lastWaypointIndex >= 0) then {
+                    [_commandState,"opsGroupWaypointsSelectedIndex",_lastWaypointIndex] call ALIVE_fnc_hashSet;
+                    [_commandState,"opsGroupWaypointsSelectedValue",_waypointsValues select _lastWaypointIndex] call ALIVE_fnc_hashSet;
+                };
+
+                [_logic,"commandState",_commandState] call MAINCLASS;
+
 /*
                 // move profile marker to refreshed position
                 _selectedIndex = [_commandState,"opsGroupsSelectedIndex"] call ALIVE_fnc_hashGet;
@@ -4082,17 +4437,22 @@ switch (_operation) do {
 
                 // enable interface elements for interacting with profile
 
-                private["_buttonR1","_buttonL2","_buttonR2","_buttonR3","_waypointTypeList","_waypointSpeedList","_waypointFormationList","_waypointBehaviourList"];
+                private["_buttonR1","_buttonL1","_buttonL2","_buttonR2","_buttonR3","_waypointTypeList","_waypointSpeedList","_waypointFormationList","_waypointBehaviourList"];
 
                 _buttonR1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR1);
                 _buttonR1 ctrlShow true;
-                _buttonR1 ctrlSetText "Clear All Waypoints";
+                _buttonR1 ctrlSetText "Clear All Orders";
                 _buttonR1 ctrlSetEventHandler ["MouseButtonClick", "['OPS_CLEAR_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                 _backButton = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
                 _backButton ctrlShow true;
+                _backButton ctrlSetText "Back to Groups";
+                _backButton ctrlSetEventHandler ["MouseButtonClick", "['OPS_CANCEL_EDIT_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
                 // disable interface elements for interacting with profile
+
+                _buttonL1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL1);
+                _buttonL1 ctrlShow false;
 
                 _buttonL2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL2);
                 _buttonL2 ctrlShow false;
@@ -4131,6 +4491,13 @@ switch (_operation) do {
                 _waypointBehaviourList lbSetCurSel -1;
                 _waypointBehaviourList ctrlSetEventHandler ["LBSelChanged", ""];
 
+                // Put the most recent order straight into the editor. New map
+                // clicks do the same, so changing Move to Attack takes one click.
+                if (_lastWaypointIndex >= 0) then {
+                    _waypointList lbSetCurSel _lastWaypointIndex;
+                    [_logic,"enableWaypointSelected"] call MAINCLASS;
+                };
+
 
             } else {
 
@@ -4149,27 +4516,35 @@ switch (_operation) do {
         _eventData params ["_profileID","_lock"];
 
         private _commandState = [_logic,"commandState"] call MAINCLASS;
-        private _selectedProfileData = [_commandState,"opsGroupsSelectedValue"] call ALiVE_fnc_hashGet;
-        private _selectedProfileID = _selectedProfileData select 0;
+        private _groups = [_commandState,"opsGroups",[]] call ALiVE_fnc_hashGet;
 
-        if (_profileID == _selectedProfileID) then {
-
-            private _buttonL2 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL2);
-            _buttonL2 ctrlShow true;
-
-            if (_lock) then {
-
-                _buttonL2 ctrlSetText "Unlock Group for AI Commander Control";
-                _buttonL2 ctrlSetEventHandler ["MouseButtonClick", "['OPS_LOCK_GROUP',[_this,false]] call ALIVE_fnc_SCOMTabletOnAction"];
-
-            } else {
-
-                _buttonL2 ctrlSetText "Lock Group from AI Commander Control";
-                _buttonL2 ctrlSetEventHandler ["MouseButtonClick", "['OPS_LOCK_GROUP',[_this,true]] call ALIVE_fnc_SCOMTabletOnAction"];
-
+        {
+            private _category = _x;
+            private _categoryIndex = _forEachIndex;
+            private _groupIndex = _category findIf {count _x >= 2 && {(_x select 0) == _profileID}};
+            if (_groupIndex >= 0) exitWith {
+                private _groupData = _category select _groupIndex;
+                if (count _groupData > 2) then {
+                    _groupData set [2,_lock];
+                } else {
+                    _groupData pushBack _lock;
+                };
+                _category set [_groupIndex,_groupData];
+                _groups set [_categoryIndex,_category];
             };
+        } forEach _groups;
 
-        };
+        [_commandState,"opsGroups",_groups] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupsSelectedIndex",DEFAULT_SELECTED_INDEX] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupsSelectedValue",DEFAULT_SELECTED_VALUE] call ALiVE_fnc_hashSet;
+        [_logic,"commandState",_commandState] call MAINCLASS;
+
+        // Re-render immediately so the group visibly moves between the AI
+        // Commander and Player Battlegroup sections.
+        private _playerID = getPlayerUID player;
+        private _selectedOpcom = [_commandState,"opsOPCOMSelectedValue"] call ALiVE_fnc_hashGet;
+        private _side = _selectedOpcom select 2;
+        ["OPS_GROUPS",[_playerID,_side,_groups]] call ALiVE_fnc_SCOMTabletEventToClient;
 
     };
 
@@ -4246,6 +4621,20 @@ switch (_operation) do {
                     };
                 };
             } foreach _plannedWaypoints;
+
+            // Overlay the incoming segment for the selected order so the map
+            // selection is as obvious as the highlighted row in the list.
+            private _selectedOrderIndex = [_commandState,"opsGroupWaypointsSelectedIndex",DEFAULT_SELECTED_INDEX] call ALiVE_fnc_hashGet;
+            private _editableOrders = [_commandState,"opsGroupWaypointsSelectedValues",[]] call ALiVE_fnc_hashGet;
+            if (_selectedOrderIndex >= 0 && {_selectedOrderIndex < count _editableOrders}) then {
+                private _selectedStart = if (_selectedOrderIndex > 0) then {
+                    (_editableOrders select (_selectedOrderIndex - 1)) select 0
+                } else {
+                    _profilePos
+                };
+                private _selectedEnd = (_editableOrders select _selectedOrderIndex) select 0;
+                _map drawLine [_selectedStart,_selectedEnd,[1,0.65,0.15,1]];
+            };
         };
 
     };
@@ -4292,7 +4681,7 @@ switch (_operation) do {
             if(_selectedWaypointType == _x) then {
                 _selectedWaypointTypeIndex = _forEachIndex;
             };
-            _waypointTypeList lbAdd format["%1", _opsWPTypeOptions select _forEachIndex];
+            _waypointTypeList lbAdd format["Order: %1", _opsWPTypeOptions select _forEachIndex];
         } forEach _opsWPTypeValues;
 
         _waypointTypeList lbSetCurSel _selectedWaypointTypeIndex;
@@ -4311,7 +4700,7 @@ switch (_operation) do {
             if(_selectedWaypointSpeed == _x) then {
                 _selectedWaypointSpeedIndex = _forEachIndex;
             };
-            _waypointSpeedList lbAdd format["%1", _opsWPSpeedOptions select _forEachIndex];
+            _waypointSpeedList lbAdd format["Speed: %1", _opsWPSpeedOptions select _forEachIndex];
         } forEach _opsWPSpeedValues;
 
         _waypointSpeedList lbSetCurSel _selectedWaypointSpeedIndex;
@@ -4330,7 +4719,7 @@ switch (_operation) do {
             if(_selectedWaypointFormation == _x) then {
                 _selectedWaypointFormationIndex = _forEachIndex;
             };
-            _waypointFormationList lbAdd format["%1", _opsWPFormationOptions select _forEachIndex];
+            _waypointFormationList lbAdd format["Formation: %1", _opsWPFormationOptions select _forEachIndex];
         } forEach _opsWPFormationValues;
 
         _waypointFormationList lbSetCurSel _selectedWaypointFormationIndex;
@@ -4349,7 +4738,7 @@ switch (_operation) do {
             if(_selectedWaypointBehaviour == _x) then {
                 _selectedWaypointBehaviourIndex = _forEachIndex;
             };
-            _waypointBehaviourList lbAdd format["%1", _opsWPBehaviourOptions select _forEachIndex];
+            _waypointBehaviourList lbAdd format["Behaviour: %1", _opsWPBehaviourOptions select _forEachIndex];
         } forEach _opsWPBehaviourValues;
 
         _waypointBehaviourList lbSetCurSel _selectedWaypointBehaviourIndex;
@@ -4358,100 +4747,789 @@ switch (_operation) do {
 
         _waypointBehaviourList ctrlSetEventHandler ["LBSelChanged", "['OPS_WP_BEHAVIOUR_LIST_SELECT',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
 
+        private _buttonL1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BL1);
+        if ((_buttonL1 getVariable ["SCOM_defaultPosition",[]]) isEqualTo []) then {
+            _buttonL1 setVariable ["SCOM_defaultPosition",ctrlPosition _buttonL1];
+        };
+
+        // The Behavior list occupies the normal BL1 slot. Reuse BL1 as a compact
+        // delete button in the otherwise empty column before the right-side actions.
+        private _buttonR1 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR1);
+        private _buttonR3 = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_BR3);
+        private _behaviourPosition = ctrlPosition _waypointBehaviourList;
+        private _buttonR1Position = ctrlPosition _buttonR1;
+        private _buttonR3Position = ctrlPosition _buttonR3;
+        private _deleteLeft = (_behaviourPosition select 0) + (_behaviourPosition select 2);
+        private _deleteAvailableWidth = (_buttonR1Position select 0) - _deleteLeft;
+        private _deleteAvailableHeight = ((_buttonR3Position select 1) + (_buttonR3Position select 3)) - (_buttonR1Position select 1);
+        private _deleteHorizontalGap = _deleteAvailableWidth * 0.12;
+        private _deleteVerticalGap = (_buttonR1Position select 3) * 0.18;
+        private _deleteX = _deleteLeft + _deleteHorizontalGap;
+        private _deleteY = (_buttonR1Position select 1) + _deleteVerticalGap;
+        private _deleteWidth = (_deleteAvailableWidth - (2 * _deleteHorizontalGap)) max 0.001;
+        private _deleteHeight = (_deleteAvailableHeight - (2 * _deleteVerticalGap)) max 0.001;
+        _buttonL1 ctrlSetPosition [_deleteX,_deleteY,_deleteWidth,_deleteHeight];
+        _buttonL1 ctrlCommit 0;
+        _buttonL1 ctrlShow true;
+        _buttonL1 ctrlSetText "Delete";
+        _buttonL1 ctrlSetTooltip "Delete Selected Order";
+        _buttonL1 ctrlSetEventHandler ["MouseButtonClick", "['OPS_DELETE_WAYPOINT',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+        private _backButton = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
+        _backButton ctrlShow true;
+        _backButton ctrlSetText "Back to Groups";
+        _backButton ctrlSetEventHandler ["MouseButtonClick", "['OPS_CANCEL_EDIT_WAYPOINTS',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+    };
+
+    case "renderOpsJoinSelection": {
+
+        private _commandState = [_logic,"commandState"] call MAINCLASS;
+        if !([_commandState,"opsGroupInstantJoin",false] call ALiVE_fnc_hashGet) exitWith {};
+        if (([_commandState,"opsViewMode","GROUPS"] call ALiVE_fnc_hashGet) != "JOIN_UNIT_WAIT") exitWith {};
+
+        private _candidates = [];
+        if (_args isEqualType [] && {count _args > 1} && {(_args select 1) isEqualType []}) then {
+            _candidates = (_args select 1) select {!isNull _x && {alive _x} && {!isPlayer _x}};
+        };
+
+        if (_candidates isEqualTo []) exitWith {
+            private _originalPlayer = [_commandState,"opsGroupInstantJoinOriginalPlayer",player] call ALiVE_fnc_hashGet;
+            private _initialPosition = [_commandState,"opsGroupInstantJoinPlayerPosition",[]] call ALiVE_fnc_hashGet;
+            private _playerID = [_commandState,"opsGroupInstantJoinPlayerID",getPlayerUID player] call ALiVE_fnc_hashGet;
+            private _isContinuation = [_commandState,"opsGroupInstantJoinContinuation",false] call ALiVE_fnc_hashGet;
+                if (!isNull _originalPlayer) then {
+                    if (!_isContinuation && {_initialPosition isEqualType []} && {count _initialPosition >= 2}) then {_originalPlayer setPos _initialPosition};
+                    [_originalPlayer,false] call ALIVE_fnc_adminGhost;
+                    _originalPlayer allowDamage true;
+            };
+
+            if (_isContinuation) then {
+                ["OPS_CANCEL_JOIN_ACTIVE",[_playerID]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+            } else {
+                ["OPS_CANCEL_JOIN_PREP",[_playerID,_initialPosition]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+            };
+
+            [_commandState,"opsGroupInstantJoin",false] call ALIVE_fnc_hashSet;
+            [_commandState,"opsGroupInstantJoinContinuation",false] call ALIVE_fnc_hashSet;
+            [_commandState,"opsViewMode","GROUPS"] call ALIVE_fnc_hashSet;
+            [_logic,"commandState",_commandState] call MAINCLASS;
+
+            private _abort = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuAbort);
+            _abort ctrlSetText "Close";
+            _abort buttonSetAction "closeDialog 0";
+
+            private _groups = [_commandState,"opsGroups",[]] call ALiVE_fnc_hashGet;
+            private _selectedOpcom = [_commandState,"opsOPCOMSelectedValue",[]] call ALiVE_fnc_hashGet;
+            if (count _selectedOpcom >= 3) then {
+                ["OPS_GROUPS",[getPlayerUID _originalPlayer,_selectedOpcom select 2,_groups]] call ALIVE_fnc_SCOMTabletEventToClient;
+                [_logic,"setOpsStatus","No available units in this group"] call MAINCLASS;
+            };
+        };
+
+        [_commandState,"opsGroupInstantJoinCandidates",_candidates] call ALIVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinSelectedIndex",DEFAULT_SELECTED_INDEX] call ALIVE_fnc_hashSet;
+        [_commandState,"opsViewMode","JOIN_UNIT_SELECT"] call ALIVE_fnc_hashSet;
+        [_logic,"commandState",_commandState] call MAINCLASS;
+
+        [_logic,"setOpsStatus","Select a unit or double-click to take control"] call MAINCLASS;
+
+        private _title = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_Title);
+        _title ctrlSetText "Operations: Choose Instant Join Unit";
+
+        private _list = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditList);
+        _list ctrlShow true;
+        lbClear _list;
+
+        {
+            private _candidateUnit = _x;
+            private _unitClass = typeOf _candidateUnit;
+            private _unitName = getText (configFile >> "CfgVehicles" >> _unitClass >> "displayName");
+            if (_unitName == "") then {_unitName = _unitClass};
+
+            private _positionText = "On foot";
+            private _assignedVehicle = vehicle _candidateUnit;
+            if (_assignedVehicle != _candidateUnit) then {
+                private _vehicleClass = typeOf _assignedVehicle;
+                private _vehicleName = getText (configFile >> "CfgVehicles" >> _vehicleClass >> "displayName");
+                if (_vehicleName == "") then {_vehicleName = _vehicleClass};
+
+                private _seatText = "Crew";
+                private _crewEntries = (fullCrew [_assignedVehicle,"",true]) select {(_x select 0) isEqualTo _candidateUnit};
+                if !(_crewEntries isEqualTo []) then {
+                    private _crewEntry = _crewEntries select 0;
+                    private _crewRole = toLower (_crewEntry select 1);
+                    _seatText = switch (_crewRole) do {
+                        case "driver": {"Driver"};
+                        case "commander": {"Commander"};
+                        case "gunner": {"Gunner"};
+                        case "cargo": {format ["Passenger %1",(_crewEntry select 2) + 1]};
+                        case "turret": {"Turret"};
+                        default {"Crew"};
+                    };
+                };
+                _positionText = format ["%1 in %2",_seatText,_vehicleName];
+            };
+
+            private _isGroupLeader = (leader group _candidateUnit) isEqualTo _candidateUnit;
+            private _label = format ["%1%2 (%3) - %4",if (_isGroupLeader) then {"[LEADER] "} else {""},_unitName,_unitClass,_positionText];
+            private _index = _list lbAdd _label;
+            _list lbSetTooltip [_index,_label];
+            if (_isGroupLeader) then {_list lbSetColor [_index,[1,0.65,0.15,1]]};
+        } forEach _candidates;
+
+        _list lbSetCurSel -1;
+        _list ctrlSetEventHandler ["LBSelChanged","['OPS_JOIN_UNIT_LIST_SELECT',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+        _list ctrlSetEventHandler ["LBDblClick","['OPS_JOIN_SELECTED_UNIT',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+        private _map = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_EditMap);
+        _map ctrlShow true;
+        _map ctrlSetEventHandler ["MouseButtonDown",""];
+        _map ctrlSetEventHandler ["MouseButtonDblClick",""];
+        ctrlMapAnimClear _map;
+        _map ctrlMapAnimAdd [0.3,0.1,position (_candidates select 0)];
+        ctrlMapAnimCommit _map;
+
+        {
+            private _control = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,_x);
+            _control ctrlShow false;
+        } forEach [SCOMTablet_CTRL_BL1,SCOMTablet_CTRL_BL2,SCOMTablet_CTRL_BL3,SCOMTablet_CTRL_BR1,SCOMTablet_CTRL_BR2,SCOMTablet_CTRL_BR3];
+
+        private _back = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuBack);
+        _back ctrlShow true;
+        _back ctrlSetText "Back to Groups";
+        _back ctrlSetEventHandler ["MouseButtonClick","['OPS_CANCEL_JOIN_SELECTION',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+
+        private _abort = SCOM_getControl(SCOMTablet_CTRL_MainDisplay,SCOMTablet_CTRL_SubMenuAbort);
+        _abort ctrlSetText "Cancel";
+        _abort buttonSetAction "['OPS_CANCEL_JOIN_SELECTION',[]] call ALIVE_fnc_SCOMTabletOnAction";
+
     };
 
     case "enableOpsJoinGroup": {
 
-        private["_commandState","_unit","_faction","_nearestTown","_factionName","_title","_text","_line1","_group","_initialPosition",
-        "_instantJoinState"];
-
-        _commandState = [_logic,"commandState"] call MAINCLASS;
-
-        // once the data has returned from the command handler
-        // enable remote controlled join of the group
-
-        if(typeName _args == "ARRAY") then {
-
+        private _commandState = [_logic,"commandState"] call MAINCLASS;
+        private _unit = objNull;
+        if (_args isEqualType [] && {count _args > 1} && {(_args select 1) isEqualType []} && {count (_args select 1) > 0}) then {
             _unit = _args select 1 select 0;
+        };
 
-            //_unit = call compile format["%1",_unit];
+        private _originalPlayer = [_commandState,"opsGroupInstantJoinOriginalPlayer",player] call ALiVE_fnc_hashGet;
+        private _playerID = [_commandState,"opsGroupInstantJoinPlayerID",getPlayerUID player] call ALiVE_fnc_hashGet;
+        private _handoffSucceeded = false;
+        private _deathContinuation = false;
 
-            _group = group _unit;
+        private _readyDeadline = diag_tickTime + 15;
+        waitUntil {
+            sleep 0.1;
+            (!isNull _unit && {alive _unit} && {!isNull group _unit} && {simulationEnabled _unit}) || {diag_tickTime >= _readyDeadline}
+        };
 
-            //_duration = 1000;
+        if (!isNull _unit && {alive _unit} && {!isNull _originalPlayer}) then {
+            private _group = group _unit;
+            private _faction = faction _unit;
+            private _nearestTown = [position _unit] call ALIVE_fnc_taskGetNearestLocationName;
+            private _factionName = getText((_faction call ALiVE_fnc_configGetFactionClass) >> "displayName");
+            private _title = "<t size='1.5' color='#68a7b7' shadow='1'>Joining Group</t><br/>";
+            private _text = format["%1<t>%2 group %3 near %4</t>",_title,_factionName,_group,_nearestTown];
 
-            if!(isNil "_unit") then {
+            ["openSideTopSmall"] call ALIVE_fnc_displayMenu;
+            ["setSideTopSmallText",_text] call ALIVE_fnc_displayMenu;
 
-                //[_logic,"commandState",_commandState] call MAINCLASS;
+            // Use the real player object for the target role. This is the same
+            // body-replacement model as WS_PlayerTakeover: the server joins the
+            // player to the AI group and the client applies the reserved role.
+            missionNamespace setVariable ["ALiVE_SCOMJoinHandoffResult",[false,"PENDING"]];
+            ["OPS_TAKEOVER_UNIT",[_playerID,_unit]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
 
-                _faction = faction _unit;
-                _nearestTown = [position _unit] call ALIVE_fnc_taskGetNearestLocationName;
-                _factionName = getText((_faction call ALiVE_fnc_configGetFactionClass) >> "displayName");
+            private _controlDeadline = diag_tickTime + 30;
+            waitUntil {
+                sleep 0.1;
+                private _result = missionNamespace getVariable ["ALiVE_SCOMJoinHandoffResult",[false,"PENDING"]];
+                (_result param [1,"PENDING"] != "PENDING") || {diag_tickTime >= _controlDeadline}
+            };
 
-                _title = "<t size='1.5' color='#68a7b7' shadow='1'>Joining Group</t><br/>";
-                _text = format["%1<t>%2 group %3 near %4</t>",_title,_factionName,_group,_nearestTown];
-
-                ["openSideTopSmall"] call ALIVE_fnc_displayMenu;
-                ["setSideTopSmallText",_text] call ALIVE_fnc_displayMenu;
-
-                player remoteControl _unit;
-                //_unit enableFatigue false;
-
-                [_unit,"FIRST_PERSON"] call ALIVE_fnc_switchCamera;
-
-                //player hideObjectGlobal true; // done serverside
-
+            private _handoffResult = missionNamespace getVariable ["ALiVE_SCOMJoinHandoffResult",[false,"PENDING"]];
+            if (_handoffResult param [0,false]) then {
+                _handoffSucceeded = true;
+                sleep 0.25;
                 ["closeSplash"] call ALIVE_fnc_displayMenu;
 
-                waitUntil{
-                    sleep 1;
-                    if((player distance _unit) > 100) then {
-                        //_newPosition = (getpos _unit) getpos [10, random 360];
-                        player setPos (position _unit);
-                    };
-                    !(alive player) || {!(alive _unit)} || {!([_commandState,"opsGroupInstantJoin"] call ALIVE_fnc_hashGet)}
+                waitUntil {
+                    sleep 0.25;
+                    !(alive _originalPlayer) || {isNull _originalPlayer} || {!([_commandState,"opsGroupInstantJoin",false] call ALIVE_fnc_hashGet)} || {missionNamespace getVariable ["ALiVE_SCOMJoinDeathPending",false]}
                 };
 
-                if(alive player) then {
-
-                    // player is alive, move them back to initial position and notify them of what's happening
-
-                    _initialPosition = [_commandState,"opsGroupInstantJoinPlayerPosition"] call ALIVE_fnc_hashGet;
-                    _instantJoinState = [_commandState,"opsGroupInstantJoin"] call ALIVE_fnc_hashGet;
-
-                    if(_instantJoinState) then {
-                        _line1 = "<t size='1.5' color='#68a7b7' align='center'>You have been killed...</t><br/><br/>";
-                    }else{
-                        _line1 = "<t size='1.5' color='#68a7b7' align='center'>Reverting...</t><br/><br/>";
-                    };
+                private _instantJoinState = [_commandState,"opsGroupInstantJoin",false] call ALIVE_fnc_hashGet;
+                if (_instantJoinState && {isNull _originalPlayer || {!alive _originalPlayer} || {missionNamespace getVariable ["ALiVE_SCOMJoinDeathPending",false]}}) then {
+                    [_logic,"handleOpsJoinKilled",[_originalPlayer]] call MAINCLASS;
+                    _deathContinuation = true;
+                } else {
+                    private _line1 = "<t size='1.5' color='#68a7b7' align='center'>Returning to your body...</t><br/><br/>";
 
                     ["openSplash",0.25] call ALIVE_fnc_displayMenu;
                     ["setSplashText",_line1] call ALIVE_fnc_displayMenu;
 
-                    player setPos _initialPosition;
-
+                    missionNamespace setVariable ["ALiVE_SCOMJoinRestoreResult",[false,"PENDING"]];
+                    ["OPS_CANCEL_JOIN_ACTIVE",[_playerID]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+                    private _restoreDeadline = diag_tickTime + 30;
+                    waitUntil {
+                        sleep 0.1;
+                        private _result = missionNamespace getVariable ["ALiVE_SCOMJoinRestoreResult",[false,"PENDING"]];
+                        (_result param [1,"PENDING"] != "PENDING") || {diag_tickTime >= _restoreDeadline}
+                    };
+                    ["closeSplash"] call ALIVE_fnc_displayMenu;
                 };
+            };
+        };
 
-                sleep 2;
+        // The respawn event handler owns the next phase. Keep the takeover
+        // profile pinned and preserve the chooser state until a new body exists.
+        if (_deathContinuation) exitWith {};
 
-                // revert camera and control back to player unit
-
-                ["closeSplash"] call ALIVE_fnc_displayMenu;
-
-                [player,false] call ALIVE_fnc_adminGhost;
-                player allowDamage true;
-
-                objNull remoteControl _unit;
-
-                [true] call ALIVE_fnc_revertCamera;
-
-                // store state
-
-                [_commandState,"opsGroupInstantJoin",false] call ALIVE_fnc_hashSet;
-
+        // Roll back a partially completed transaction as well as a clean reject.
+        if (!_handoffSucceeded) then {
+            if (!isNull _originalPlayer) then {
+                missionNamespace setVariable ["ALiVE_SCOMJoinRestoreResult",[false,"PENDING"]];
+                ["OPS_CANCEL_JOIN_ACTIVE",[_playerID]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+                private _restoreDeadline = diag_tickTime + 20;
+                waitUntil {
+                    sleep 0.1;
+                    private _result = missionNamespace getVariable ["ALiVE_SCOMJoinRestoreResult",[false,"PENDING"]];
+                    (_result param [1,"PENDING"] != "PENDING") || {diag_tickTime >= _restoreDeadline}
+                };
             };
 
+            private _failureText = "<t size='1.5' color='#d68b7c' align='center'>Unable to join this unit.</t><br/><br/>";
+            ["setSplashText",_failureText] call ALIVE_fnc_displayMenu;
+            sleep 2;
+            ["closeSplash"] call ALIVE_fnc_displayMenu;
         };
+
+        [_commandState,"opsGroupInstantJoin",false] call ALIVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinContinuation",false] call ALIVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinCandidates",[]] call ALIVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinSelectedIndex",DEFAULT_SELECTED_INDEX] call ALIVE_fnc_hashSet;
+        [_commandState,"opsViewMode","GROUPS"] call ALIVE_fnc_hashSet;
+        [_logic,"commandState",_commandState] call MAINCLASS;
+
+    };
+
+    case "installOpsJoinPlayerHandlers": {
+
+        if (!hasInterface || {isNull player}) exitWith {};
+        private _registeredPlayer = missionNamespace getVariable ["ALiVE_SCOMJoinEHPlayer",objNull];
+        if (_registeredPlayer isEqualTo player) exitWith {};
+
+        if (!isNull _registeredPlayer) then {
+            private _oldKilledEH = missionNamespace getVariable ["ALiVE_SCOMJoinPlayerKilledEH",-1];
+            private _oldRespawnEH = missionNamespace getVariable ["ALiVE_SCOMJoinPlayerRespawnEH",-1];
+            if (_oldKilledEH >= 0) then {_registeredPlayer removeEventHandler ["Killed",_oldKilledEH]};
+            if (_oldRespawnEH >= 0) then {_registeredPlayer removeEventHandler ["Respawn",_oldRespawnEH]};
+        };
+
+        private _killedEH = player addEventHandler ["Killed",{
+            params ["_unit"];
+            if (_unit isEqualTo player && {!isNil "ALIVE_SUP_COMMAND"}) then {
+                [ALIVE_SUP_COMMAND,"handleOpsJoinKilled",[_unit]] call ALIVE_fnc_SCOM;
+            };
+        }];
+        private _respawnEH = player addEventHandler ["Respawn",{
+            params ["_newUnit","_corpse"];
+            [_newUnit,_corpse] spawn {
+                params ["_newUnit","_corpse"];
+                private _deadline = diag_tickTime + 15;
+                waitUntil {
+                    sleep 0.05;
+                    (_newUnit isEqualTo player && {local _newUnit}) || {diag_tickTime >= _deadline}
+                };
+                if (_newUnit isEqualTo player && {local _newUnit} && {!isNil "ALIVE_SUP_COMMAND"}) then {
+                    [ALIVE_SUP_COMMAND,"installOpsJoinPlayerHandlers",[]] call ALIVE_fnc_SCOM;
+                    [ALIVE_SUP_COMMAND,"handleOpsJoinRespawn",[_newUnit,_corpse]] spawn ALIVE_fnc_SCOM;
+                };
+            };
+        }];
+
+        missionNamespace setVariable ["ALiVE_SCOMJoinEHPlayer",player];
+        missionNamespace setVariable ["ALiVE_SCOMJoinPlayerKilledEH",_killedEH];
+        missionNamespace setVariable ["ALiVE_SCOMJoinPlayerRespawnEH",_respawnEH];
+
+    };
+
+    case "handleOpsJoinKilled": {
+
+        if (!hasInterface) exitWith {};
+        private _commandState = [_logic,"commandState"] call MAINCLASS;
+        if !([_commandState,"opsGroupInstantJoin",false] call ALiVE_fnc_hashGet) exitWith {};
+        if (([_commandState,"opsViewMode","GROUPS"] call ALiVE_fnc_hashGet) != "JOIN_ACTIVE") exitWith {};
+        if (missionNamespace getVariable ["ALiVE_SCOMJoinDeathPending",false]) exitWith {};
+
+        private _killed = if (_args isEqualType [] && {count _args > 0}) then {_args select 0} else {player};
+        private _joinedPlayer = [_commandState,"opsGroupInstantJoinOriginalPlayer",objNull] call ALiVE_fnc_hashGet;
+        if (isNull _killed || {!(_killed isEqualTo _joinedPlayer)}) exitWith {};
+        private _playerID = [_commandState,"opsGroupInstantJoinPlayerID",getPlayerUID player] call ALiVE_fnc_hashGet;
+
+        // This only affects the next respawn. BASE/INSTANT modes bypass the
+        // mission delay; GROUP/SIDE modes still complete through their normal
+        // engine path and are caught by EntityRespawned below.
+        setPlayerRespawnTime 0;
+        missionNamespace setVariable ["ALiVE_SCOMJoinDeathPending",true];
+        missionNamespace setVariable ["ALiVE_SCOMJoinRespawnRequested",false];
+        [_commandState,"opsGroupInstantJoinContinuation",true] call ALiVE_fnc_hashSet;
+        [_commandState,"opsViewMode","JOIN_DEAD"] call ALiVE_fnc_hashSet;
+        [_logic,"commandState",_commandState] call MAINCLASS;
+
+        private _line1 = "<t size='1.5' color='#68a7b7' align='center'>You have been killed...</t><br/><br/><t align='center'>Preparing another unit from this group.</t>";
+        ["openSplash",0.25] call ALIVE_fnc_displayMenu;
+        ["setSplashText",_line1] call ALIVE_fnc_displayMenu;
+        ["OPS_JOIN_PLAYER_KILLED",[_playerID,_killed]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+
+    };
+
+    case "handleOpsJoinRespawn": {
+
+        if (!hasInterface || {!(missionNamespace getVariable ["ALiVE_SCOMJoinDeathPending",false])}) exitWith {};
+        if (missionNamespace getVariable ["ALiVE_SCOMJoinRespawnRequested",false]) exitWith {};
+        _args params ["_newPlayer","_corpse"];
+        if (isNull _newPlayer) exitWith {};
+
+        private _deadline = diag_tickTime + 15;
+        waitUntil {
+            sleep 0.05;
+            (_newPlayer isEqualTo player && {local _newPlayer} && {getPlayerUID _newPlayer != ""}) || {diag_tickTime >= _deadline}
+        };
+        if !(_newPlayer isEqualTo player && {local _newPlayer}) exitWith {};
+
+        missionNamespace setVariable ["ALiVE_SCOMJoinRespawnRequested",true];
+        _newPlayer allowDamage false;
+        _newPlayer hideObject true;
+        sleep 0.2;
+        private _commandState = [_logic,"commandState"] call MAINCLASS;
+        private _playerID = [_commandState,"opsGroupInstantJoinPlayerID",getPlayerUID _newPlayer] call ALiVE_fnc_hashGet;
+        ["OPS_JOIN_PLAYER_RESPAWNED",[_playerID,_newPlayer,_corpse]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+
+    };
+
+    case "resumeOpsJoinAfterRespawn": {
+
+        if (!hasInterface || {!(_args isEqualType [])} || {count _args < 4}) exitWith {};
+        _args params ["_playerID","_profileID","_newPlayer","_candidates"];
+        if (isNull _newPlayer) exitWith {};
+        private _playerDeadline = diag_tickTime + 20;
+        waitUntil {
+            sleep 0.05;
+            (_newPlayer isEqualTo player && {local _newPlayer} && {getPlayerUID player == _playerID}) || {diag_tickTime >= _playerDeadline}
+        };
+        if (!(_newPlayer isEqualTo player) || {!local _newPlayer} || {getPlayerUID player != _playerID}) exitWith {};
+
+        private _commandState = [_logic,"commandState"] call MAINCLASS;
+        [_commandState,"opsGroupInstantJoin",true] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinContinuation",true] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinPlayerID",_playerID] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinProfileID",_profileID] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinPlayerPosition",position _newPlayer] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinOriginalPlayer",_newPlayer] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinOriginalGroup",group _newPlayer] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinOriginalGroupSide",side group _newPlayer] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinOriginalWasLeader",(leader group _newPlayer) isEqualTo _newPlayer] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinCandidates",[]] call ALiVE_fnc_hashSet;
+        [_commandState,"opsGroupInstantJoinSelectedIndex",DEFAULT_SELECTED_INDEX] call ALiVE_fnc_hashSet;
+        [_commandState,"opsViewMode","JOIN_UNIT_WAIT"] call ALiVE_fnc_hashSet;
+        [_commandState,"commandInterface","OPS"] call ALiVE_fnc_hashSet;
+        [_logic,"commandState",_commandState] call MAINCLASS;
+
+        _newPlayer allowDamage false;
+        private _displayDeadline = diag_tickTime + 12;
+        waitUntil {
+            if (isNull (findDisplay SCOMTablet_CTRL_MainDisplay)) then {
+                ["OPEN_OPS",[]] call ALIVE_fnc_SCOMTabletOnAction;
+            };
+            sleep 0.25;
+            !isNull (findDisplay SCOMTablet_CTRL_MainDisplay) || {diag_tickTime >= _displayDeadline}
+        };
+
+        if (isNull (findDisplay SCOMTablet_CTRL_MainDisplay)) exitWith {
+            missionNamespace setVariable ["ALiVE_SCOMJoinDeathPending",false];
+            missionNamespace setVariable ["ALiVE_SCOMJoinRespawnRequested",false];
+            [_commandState,"opsGroupInstantJoin",false] call ALiVE_fnc_hashSet;
+            [_commandState,"opsGroupInstantJoinContinuation",false] call ALiVE_fnc_hashSet;
+            [_commandState,"opsViewMode","GROUPS"] call ALiVE_fnc_hashSet;
+            [_logic,"commandState",_commandState] call MAINCLASS;
+            ["OPS_CANCEL_JOIN_ACTIVE",[_playerID]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+            ["closeSplash"] call ALIVE_fnc_displayMenu;
+        };
+
+        sleep 0.1;
+        missionNamespace setVariable ["ALiVE_SCOMJoinDeathPending",false];
+        missionNamespace setVariable ["ALiVE_SCOMJoinRespawnRequested",false];
+        [_logic,"renderOpsJoinSelection",[_playerID,_candidates]] call MAINCLASS;
+        ["closeSplash"] call ALIVE_fnc_displayMenu;
+
+    };
+
+    case "applyOpsGroupLeadership": {
+
+        if (_args isEqualType [] && {count _args >= 2}) then {
+            _args params ["_targetGroup","_leader",["_forceFollow",false]];
+            if (!isNull _targetGroup && {!isNull _leader} && {local _targetGroup} && {_leader in units _targetGroup}) then {
+                _targetGroup selectLeader _leader;
+                if (_forceFollow) then {
+                    {
+                        if (!(_x isEqualTo _leader) && {alive _x} && {!isPlayer _x}) then {
+                            doStop _x;
+                            _x doFollow _leader;
+                        };
+                    } forEach units _targetGroup;
+                };
+            };
+        };
+
+    };
+
+    case "applyOpsTakeoverWaypoints": {
+
+        if (_args isEqualType [] && {count _args >= 2}) then {
+            _args params ["_targetGroup","_mode",["_snapshot",[]]];
+            if (!isNull _targetGroup && {local _targetGroup}) then {
+                private _waypointCount = count waypoints _targetGroup;
+                if (_waypointCount > 0) then {
+                    for "_i" from (_waypointCount - 1) to 0 step -1 do {
+                        deleteWaypoint [_targetGroup,_i];
+                    };
+                };
+                if (_mode == "RESTORE" && {!(_snapshot isEqualTo [])}) then {
+                    [_snapshot,_targetGroup] call ALiVE_fnc_profileWaypointsToWaypoints;
+                };
+            };
+        };
+
+    };
+
+    case "applyOpsRecreateTakeoverUnit": {
+
+        _args params ["_resultKey","_targetGroup","_snapshot","_profileID","_profileIndex","_wasLeader"];
+        private _publish = {
+            params ["_value"];
+            if (isServer) then {
+                missionNamespace setVariable [_resultKey,_value];
+            } else {
+                missionNamespace setVariable [_resultKey,_value,2];
+            };
+        };
+
+        if (_resultKey == "" || {isNull _targetGroup} || {!local _targetGroup} || {!(_snapshot isEqualType [])} || {count _snapshot < 11}) exitWith {
+            [[false,"RECREATE_GROUP_NOT_LOCAL",objNull]] call _publish;
+        };
+
+        _snapshot params [
+            "_class","_position","_direction","_identity","_loadout","_savedDamage",
+            "_vehicle","_vehicleRole","_savedSkill","_savedUnitPos","_ignoreHC"
+        ];
+        if (_class == "" || {!isClass (configFile >> "CfgVehicles" >> _class)} || {!(_class isKindOf "CAManBase")} || {count _position < 2}) exitWith {
+            [[false,"RECREATE_CLASS_OR_POSITION_INVALID",objNull]] call _publish;
+        };
+
+        private _spawnPos = +_position;
+        private _candidatePos = _position findEmptyPosition [1,20,_class];
+        if (count _candidatePos >= 2) then {_spawnPos = _candidatePos};
+        private _replacement = _targetGroup createUnit [_class,_spawnPos,[],0,"NONE"];
+        if (isNull _replacement) exitWith {
+            [[false,"RECREATE_CREATEUNIT_FAILED",objNull]] call _publish;
+        };
+
+        _replacement allowDamage false;
+        _identity params [
+            ["_rank","PRIVATE",[""]],["_name","",[""]],["_face","",[""]],
+            ["_speaker","",[""]],["_pitch",1,[0]]
+        ];
+        if (_face != "") then {_replacement setFace _face};
+        if (_speaker != "") then {_replacement setSpeaker _speaker};
+        _replacement setPitch _pitch;
+        if (_name != "") then {_replacement setName _name};
+        _replacement setRank _rank;
+        if (count _loadout > 0) then {_replacement setUnitLoadout _loadout};
+        _replacement setSkill _savedSkill;
+        _replacement setUnitPos _savedUnitPos;
+        _replacement setDir _direction;
+        _replacement setPosATL _position;
+        _replacement setDamage (_savedDamage min 0.95);
+        _replacement setVariable ["profileID",_profileID,true];
+        _replacement setVariable ["profileIndex",_profileIndex,true];
+        _replacement setVariable ["ALiVE_ignore_HC",_ignoreHC,true];
+        _replacement setVariable ["ALiVE_SCOMTakeoverUID",nil,true];
+        _replacement addMPEventHandler ["MPKilled",ALIVE_fnc_profileKilledEventHandler];
+
+        if (!isNull _vehicle && {alive _vehicle} && {count _vehicleRole > 0}) then {
+            switch (toLower (_vehicleRole param [0,"",[""]])) do {
+                case "driver": {_replacement assignAsDriver _vehicle; _replacement moveInDriver _vehicle};
+                case "gunner": {_replacement assignAsGunner _vehicle; _replacement moveInGunner _vehicle};
+                case "commander": {_replacement assignAsCommander _vehicle; _replacement moveInCommander _vehicle};
+                case "turret": {
+                    private _turretPath = _vehicleRole param [2,[],[[]]];
+                    _replacement assignAsTurret [_vehicle,_turretPath];
+                    _replacement moveInTurret [_vehicle,_turretPath];
+                };
+                case "cargo": {
+                    private _cargoIndex = _vehicleRole param [1,-1,[0]];
+                    if (_cargoIndex >= 0) then {
+                        _replacement assignAsCargoIndex [_vehicle,_cargoIndex];
+                        _replacement moveInCargo [_vehicle,_cargoIndex];
+                    } else {
+                        _replacement assignAsCargo _vehicle;
+                        _replacement moveInCargo _vehicle;
+                    };
+                };
+            };
+            [_replacement] orderGetIn true;
+        };
+
+        if (_wasLeader) then {
+            _targetGroup selectLeader _replacement;
+            {
+                if (!(_x isEqualTo _replacement) && {alive _x} && {!isPlayer _x}) then {
+                    doStop _x;
+                    _x doFollow _replacement;
+                };
+            } forEach units _targetGroup;
+        } else {
+            _replacement doFollow leader _targetGroup;
+        };
+        _replacement allowDamage true;
+
+        private _success = alive _replacement && {group _replacement isEqualTo _targetGroup} && {(!_wasLeader) || {leader _targetGroup isEqualTo _replacement}};
+        [[_success,if (_success) then {""} else {"RECREATE_STATE_NOT_APPLIED"},_replacement]] call _publish;
+
+    };
+
+    case "applyOpsJoinHandoff": {
+
+        _args params ["_playerID","_handoffPlayer","_selectedUnit","_targetGroup","_targetState"];
+        if (!hasInterface || {isNull _handoffPlayer} || {!(_handoffPlayer isEqualTo player)} || {getPlayerUID player != _playerID}) exitWith {};
+
+        _targetState params ["_position","_direction","_identity","_loadout","_damage","_vehicle","_vehicleRole"];
+        private _deadline = diag_tickTime + 10;
+        waitUntil {
+            sleep 0.1;
+            (group player isEqualTo _targetGroup) || {diag_tickTime >= _deadline}
+        };
+
+        private _success = group player isEqualTo _targetGroup;
+        private _failureReason = if (_success) then {""} else {"GROUP_JOIN_FAILED"};
+        if (_success) then {
+            player allowDamage false;
+            moveOut player;
+            unassignVehicle player;
+
+            private _unlockTakeoverVehicle = {
+                params ["_vehicle"];
+                if (isNull _vehicle) exitWith {};
+                _vehicle setVehicleLock "UNLOCKED";
+                if (local _vehicle) then {
+                    _vehicle lockDriver false;
+                    _vehicle lockCargo false;
+                    {_vehicle lockTurret [_x,false]} forEach (allTurrets [_vehicle,true]);
+                };
+            };
+
+            private _crewRowMatchesRole = {
+                params ["_crewRow","_expectedRole"];
+                private _expectedKind = toLower (_expectedRole param [0,"",[""]]);
+                private _actualKind = toLower (_crewRow param [1,"",[""]]);
+
+                switch (_expectedKind) do {
+                    case "driver": {_actualKind == "driver"};
+                    case "gunner": {_actualKind == "gunner"};
+                    case "commander": {_actualKind == "commander"};
+                    case "turret": {
+                        private _expectedTurretPath = _expectedRole param [2,[],[[]]];
+                        private _actualTurretPath = _crewRow param [3,[],[[]]];
+                        _actualTurretPath isEqualTo _expectedTurretPath
+                    };
+                    case "cargo": {
+                        private _expectedCargoIndex = _expectedRole param [1,-1,[0]];
+                        private _actualCargoIndex = _crewRow param [2,-1,[0]];
+                        _expectedCargoIndex >= 0 && {_actualKind == "cargo"} && {_actualCargoIndex == _expectedCargoIndex}
+                    };
+                    default {false};
+                };
+            };
+
+            private _unitOccupiesExactRole = {
+                params ["_unit","_expectedVehicle","_expectedRole"];
+                if (isNull _unit || {isNull _expectedVehicle} || {!(vehicle _unit isEqualTo _expectedVehicle)}) exitWith {false};
+
+                private _crewRows = fullCrew [_expectedVehicle,"",false];
+                (_crewRows findIf {
+                    (_x param [0,objNull,[objNull]]) isEqualTo _unit && {
+                        [_x,_expectedRole] call _crewRowMatchesRole
+                    }
+                }) >= 0
+            };
+
+            if (count _identity >= 5) then {
+                _identity params ["_rank","_name","_face","_speaker","_pitch"];
+                if (_face != "") then {player setFace _face};
+                if (_speaker != "") then {player setSpeaker _speaker};
+                player setPitch _pitch;
+                if (_name != "") then {player setName _name};
+                player setRank _rank;
+            };
+            if (count _loadout > 0) then {player setUnitLoadout _loadout};
+            player setDir _direction;
+
+            if (!isNull _vehicle && {alive _vehicle} && {count _vehicleRole > 0}) then {
+                [_vehicle] call _unlockTakeoverVehicle;
+                private _oldOccupantVacated = !([_selectedUnit,_vehicle,_vehicleRole] call _unitOccupiesExactRole);
+                if (!_oldOccupantVacated) then {
+                    diag_log format [
+                        "[TAKEOVER] SEAT_VACATE_WAIT selectedOwner=%1 vehicleOwner=%2 role=%3",
+                        owner _selectedUnit,
+                        owner _vehicle,
+                        _vehicleRole
+                    ];
+
+                    private _vacateDeadline = diag_tickTime + 3;
+                    waitUntil {
+                        _oldOccupantVacated = !([_selectedUnit,_vehicle,_vehicleRole] call _unitOccupiesExactRole);
+                        private _done = _oldOccupantVacated || {diag_tickTime >= _vacateDeadline};
+                        if (!_done) then {sleep 0.05};
+                        _done
+                    };
+                };
+
+                private _moveIssued = false;
+                if (_oldOccupantVacated) then {
+                    private _roleKind = toLower (_vehicleRole param [0,"",[""]]);
+                    switch (_roleKind) do {
+                        case "driver": {
+                            player assignAsDriver _vehicle;
+                            player moveInDriver _vehicle;
+                            _moveIssued = true;
+                        };
+                        case "gunner": {
+                            player assignAsGunner _vehicle;
+                            player moveInGunner _vehicle;
+                            _moveIssued = true;
+                        };
+                        case "commander": {
+                            player assignAsCommander _vehicle;
+                            player moveInCommander _vehicle;
+                            _moveIssued = true;
+                        };
+                        case "turret": {
+                            private _turretPath = _vehicleRole param [2,[],[[]]];
+                            player assignAsTurret [_vehicle,_turretPath];
+                            player moveInTurret [_vehicle,_turretPath];
+                            _moveIssued = true;
+                        };
+                        case "cargo": {
+                            private _cargoIndex = _vehicleRole param [1,-1,[0]];
+                            if (_cargoIndex >= 0) then {
+                                player assignAsCargoIndex [_vehicle,_cargoIndex];
+                                player moveInCargo [_vehicle,_cargoIndex];
+                                _moveIssued = true;
+                            };
+                        };
+                    };
+                };
+
+                private _seatApplied = _moveIssued && {[player,_vehicle,_vehicleRole] call _unitOccupiesExactRole};
+                if (_moveIssued && {!_seatApplied}) then {
+                    diag_log format [
+                        "[TAKEOVER] SEAT_APPLY_WAIT playerOwner=%1 vehicleOwner=%2 role=%3",
+                        owner player,
+                        owner _vehicle,
+                        _vehicleRole
+                    ];
+
+                    private _seatDeadline = diag_tickTime + 3;
+                    waitUntil {
+                        _seatApplied = [player,_vehicle,_vehicleRole] call _unitOccupiesExactRole;
+                        private _done = _seatApplied || {diag_tickTime >= _seatDeadline};
+                        if (!_done) then {sleep 0.05};
+                        _done
+                    };
+                };
+
+                _success = _seatApplied;
+                if (_seatApplied) then {
+                    [_vehicle] call _unlockTakeoverVehicle;
+                } else {
+                    _failureReason = "SEAT_MOVE_FAILED";
+                };
+            } else {
+                player setPosATL _position;
+                _success = (player distance2D _position) < 15;
+                if (!_success) then {_failureReason = "POSITION_APPLY_FAILED"};
+            };
+
+            if (_success) then {player setDamage (_damage min 0.95)};
+            player allowDamage true;
+        };
+
+        ["OPS_JOIN_HANDOFF_COMPLETE",[_playerID,_selectedUnit,_success,_failureReason]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
+
+    };
+
+    case "applyOpsJoinRestore": {
+
+        _args params ["_playerID","_handoffPlayer","_originalGroup","_originalState"];
+        if (!hasInterface || {isNull _handoffPlayer} || {!(_handoffPlayer isEqualTo player)} || {getPlayerUID player != _playerID}) exitWith {};
+
+        _originalState params ["_position","_direction","_identity","_loadout","_damage","_vehicle","_vehicleRole"];
+        private _deadline = diag_tickTime + 10;
+        waitUntil {
+            sleep 0.1;
+            (group player isEqualTo _originalGroup) || {diag_tickTime >= _deadline}
+        };
+
+        private _success = group player isEqualTo _originalGroup;
+        moveOut player;
+        unassignVehicle player;
+        player allowDamage false;
+
+        if (count _identity >= 5) then {
+            _identity params ["_rank","_name","_face","_speaker","_pitch"];
+            if (_face != "") then {player setFace _face};
+            if (_speaker != "") then {player setSpeaker _speaker};
+            player setPitch _pitch;
+            if (_name != "") then {player setName _name};
+            player setRank _rank;
+        };
+        if (count _loadout > 0) then {player setUnitLoadout _loadout};
+        player setDir _direction;
+
+        private _placedInVehicle = false;
+        if (!isNull _vehicle && {alive _vehicle} && {count _vehicleRole > 0}) then {
+            private _roleKind = toLower (_vehicleRole param [0,"",[""]]);
+            switch (_roleKind) do {
+                case "driver": {player assignAsDriver _vehicle; player moveInDriver _vehicle};
+                case "gunner": {player assignAsGunner _vehicle; player moveInGunner _vehicle};
+                case "commander": {player assignAsCommander _vehicle; player moveInCommander _vehicle};
+                case "turret": {
+                    private _turretPath = _vehicleRole param [2,[],[[]]];
+                    player assignAsTurret [_vehicle,_turretPath];
+                    player moveInTurret [_vehicle,_turretPath];
+                };
+                case "cargo": {
+                    private _cargoIndex = _vehicleRole param [1,-1,[0]];
+                    if (_cargoIndex >= 0) then {
+                        player assignAsCargoIndex [_vehicle,_cargoIndex];
+                        player moveInCargo [_vehicle,_cargoIndex];
+                    } else {
+                        player assignAsCargo _vehicle;
+                        player moveInCargo _vehicle;
+                    };
+                };
+            };
+            _placedInVehicle = vehicle player isEqualTo _vehicle;
+        };
+        if (!_placedInVehicle) then {player setPosATL _position};
+
+        player setDamage (_damage min 0.95);
+        player allowDamage true;
+        [player,false] call ALIVE_fnc_adminGhost;
+        ["OPS_JOIN_RESTORE_COMPLETE",[_playerID,_success]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToServer",2];
 
     };
 

--- a/addons/sup_command/fnc_SCOMSetTerrainMode.sqf
+++ b/addons/sup_command/fnc_SCOMSetTerrainMode.sqf
@@ -1,11 +1,9 @@
 #include "\x\alive\addons\sup_command\script_component.hpp"
 /*
     ALIVE_fnc_SCOMSetTerrainMode
-    #698: SCOM (command) tablet terrain toggle. Swaps the main map (12022) between the satellite class
-    and the schematic class via the shared ALIVE_fnc_tabletSetTerrainMode engine, restoring whichever
-    map-click handler was live before the swap (recorded by fnc_SCOM at each attach site).
-
-    Scope: main map only (the right map and edit map are per-view and out of scope for the toggle).
+    #698: SCOM (command) tablet terrain toggle. Swaps every tablet map between the satellite class
+    and the schematic class via the shared ALIVE_fnc_tabletSetTerrainMode engine, restoring the
+    operation editor handlers on its recreated map control.
 
     Params: 0: _terrainOn <BOOL> (default true = satellite)
     Author: Jman
@@ -14,14 +12,55 @@ params [["_terrainOn", true]];
 
 [
     12001,                          // SCOMTablet display idd
-    [12022],                        // main map idc
+    [12021,12022,12026],            // right, main, and operations/edit maps
     "SCOMTablet_RscMap",            // satellite class
     "SCOMTablet_RscMapSchematic",   // schematic class
     "SCOMTerrainMode",              // uinamespace session flag
     _terrainOn,
     {
         params ["_newMap"];
-        // #698 restore the main map's recorded click handler (INTEL focus-select, or empty when disabled).
-        _newMap ctrlSetEventHandler ["MouseButtonDown", uinamespace getVariable ["SCOMMainMapClick", ""]];
+        private _idc = ctrlIDC _newMap;
+
+        if (_idc == 12022) then {
+            // Restore the main Intel map's recorded focus-select handler.
+            _newMap ctrlSetEventHandler ["MouseButtonDown",uinamespace getVariable ["SCOMMainMapClick",""]];
+        };
+
+        if (_idc == 12026) then {
+            private _commandState = [ALiVE_SUP_COMMAND,"commandState"] call ALiVE_fnc_SCOM;
+            private _viewMode = [_commandState,"opsViewMode","GROUPS"] call ALiVE_fnc_hashGet;
+
+            _newMap ctrlSetEventHandler ["MouseButtonDblClick",""];
+
+            switch (_viewMode) do {
+                case "GROUPS": {
+                    _newMap ctrlSetEventHandler ["MouseButtonDown","['OP_EDIT_MAP_CLICK',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+                    _newMap ctrlSetEventHandler ["MouseButtonDblClick","['OP_EDIT_MAP_DOUBLE_CLICK',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+                };
+                case "WAYPOINTS": {
+                    _newMap ctrlSetEventHandler ["MouseButtonDown","['OP_EDIT_WAYPOINT_MAP_CLICK',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+                };
+                case "OBJECTIVES": {
+                    private _display = findDisplay 12001;
+                    private _placingObjective = ctrlText (_display displayCtrl 12017) == "Confirm Position";
+                    private _clickHandler = if (_placingObjective) then {
+                        "['OP_OBJECTIVE_MAP_CLICK',[_this]] call ALIVE_fnc_SCOMTabletOnAction"
+                    } else {
+                        "['OP_MAP_CLICK_NULL',[_this]] call ALIVE_fnc_SCOMTabletOnAction"
+                    };
+                    _newMap ctrlSetEventHandler ["MouseButtonDown",_clickHandler];
+                };
+                default {
+                    _newMap ctrlSetEventHandler ["MouseButtonDown","['OP_MAP_CLICK_NULL',[_this]] call ALIVE_fnc_SCOMTabletOnAction"];
+                };
+            };
+
+            // ctrlDelete removes the original Draw EH. Reattach exactly one
+            // waypoint-chain renderer to the replacement control.
+            private _drawEH = _newMap ctrlAddEventHandler ["Draw",{
+                [ALiVE_SUP_COMMAND,"opsDrawWaypoints",_this] call ALiVE_fnc_SCOM;
+            }];
+            _newMap setVariable ["SCOM_opsDrawEH",_drawEH];
+        };
     }
 ] call ALIVE_fnc_tabletSetTerrainMode;

--- a/addons/sup_command/fnc_commandHandler.sqf
+++ b/addons/sup_command/fnc_commandHandler.sqf
@@ -94,6 +94,70 @@ switch(_operation) do {
                 waituntil {!(isnil "ALiVE_profileSystemInit")};
             };
 
+            // The handler is authoritative on dedicated servers as well as a
+            // hosted session. UID ownership lets disconnect cleanup release only
+            // this player's pin when several players use the same profile.
+            if ((missionNamespace getVariable ["ALiVE_SCOMDisconnectEH",-1]) < 0) then {
+                private _disconnectEH = addMissionEventHandler ["HandleDisconnect",{
+                    params ["_unit","_id","_uid"];
+                    if (_uid != "" && {!isNil "ALIVE_commandHandler"}) then {
+                        // Capture the occupied role before the engine retires the
+                        // disconnected player object. The asynchronous cleanup may
+                        // otherwise run after that object has already become null.
+                        private _disconnectState = [];
+                        if (!isNull _unit) then {
+                            private _vehicle = vehicle _unit;
+                            private _vehicleRole = [];
+                            if !(_vehicle isEqualTo _unit) then {
+                                private _rowIndex = (fullCrew [_vehicle,"",false]) findIf {(_x select 0) isEqualTo _unit};
+                                if (_rowIndex >= 0) then {
+                                    private _row = (fullCrew [_vehicle,"",false]) select _rowIndex;
+                                    _vehicleRole = [toLower (_row param [1,"",[""]]),_row param [2,-1,[0]],_row param [3,[],[[]]]];
+                                };
+                            } else {
+                                _vehicle = objNull;
+                            };
+                            _disconnectState = [getPosATL _unit,getDir _unit,getUnitLoadout _unit,damage _unit,_vehicle,_vehicleRole,alive _unit];
+                        };
+                        [ALIVE_commandHandler,"opsCleanupJoin",[_uid,_unit,_disconnectState]] spawn ALiVE_fnc_commandHandler;
+                    };
+                    false
+                }];
+                missionNamespace setVariable ["ALiVE_SCOMDisconnectEH",_disconnectEH];
+            };
+
+            // Dedicated-server fallback for missions whose client respawn event
+            // is delayed or replaced. The server waits until the new object has
+            // a UID, then resumes any takeover session already owned by that UID.
+            if ((missionNamespace getVariable ["ALiVE_SCOMSelectedPlayerEH",-1]) < 0) then {
+                private _selectedPlayerEH = addMissionEventHandler ["OnUserSelectedPlayer",{
+                    params ["_networkID","_playerObject"];
+                    if (!isNull _playerObject && {!isNil "ALIVE_commandHandler"}) then {
+                        [_playerObject] spawn {
+                            params ["_playerObject"];
+                            private _deadline = diag_tickTime + 20;
+                            waitUntil {
+                                sleep 0.05;
+                                isNull _playerObject || {getPlayerUID _playerObject != ""} || {diag_tickTime >= _deadline}
+                            };
+                            if (!isNull _playerObject && {getPlayerUID _playerObject != ""} && {!isNil "ALIVE_commandHandler"}) then {
+                                private _playerID = getPlayerUID _playerObject;
+                                private _sessionKey = format ["opsInstantJoinSession_%1",_playerID];
+                                private _session = [ALIVE_commandHandler,_sessionKey,[]] call ALiVE_fnc_hashGet;
+                                if !(_session isEqualTo []) then {
+                                    private _sessionPlayer = [_session,"player",objNull] call ALiVE_fnc_hashGet;
+                                    private _status = [_session,"status",""] call ALiVE_fnc_hashGet;
+                                    if (!(_playerObject isEqualTo _sessionPlayer) || {_status in ["AWAITING_RESPAWN","RESPAWN_PROCESSING","CHOOSING_REPLACEMENT"]}) then {
+                                        [ALIVE_commandHandler,"opsJoinPlayerRespawned",[_playerID,_playerObject,objNull]] spawn ALiVE_fnc_commandHandler;
+                                    };
+                                };
+                            };
+                        };
+                    };
+                }];
+                missionNamespace setVariable ["ALiVE_SCOMSelectedPlayerEH",_selectedPlayerEH];
+            };
+
             TRACE_1("After module init",_logic);
 
         };
@@ -165,7 +229,55 @@ switch(_operation) do {
 
                 case "OPS_JOIN_GROUP": {
 
+                    private _playerID = if (_data isEqualType [] && {count _data > 0}) then {_data select 0} else {""};
+                    [_logic,format ["opsInstantJoinCancelled_%1",_playerID],false] call ALiVE_fnc_hashSet;
                     [_logic,"opsJoinGroup", _data] spawn MAINCLASS;
+
+                };
+
+                case "OPS_TAKEOVER_UNIT": {
+
+                    [_logic,"opsTakeoverUnit",_data] spawn MAINCLASS;
+
+                };
+
+                case "OPS_JOIN_HANDOFF_COMPLETE": {
+
+                    [_logic,"opsJoinHandoffComplete",_data] spawn MAINCLASS;
+
+                };
+
+                case "OPS_JOIN_PLAYER_KILLED": {
+
+                    [_logic,"opsJoinPlayerKilled",_data] call MAINCLASS;
+
+                };
+
+                case "OPS_JOIN_PLAYER_RESPAWNED": {
+
+                    [_logic,"opsJoinPlayerRespawned",_data] spawn MAINCLASS;
+
+                };
+
+                case "OPS_CANCEL_JOIN_ACTIVE": {
+
+                    private _playerID = if (_data isEqualType [] && {count _data > 0}) then {_data select 0} else {""};
+                    [_logic,format ["opsInstantJoinCancelled_%1",_playerID],true] call ALiVE_fnc_hashSet;
+                    [_logic,"opsCancelJoinActive",_data] spawn MAINCLASS;
+
+                };
+
+                case "OPS_JOIN_RESTORE_COMPLETE": {
+
+                    [_logic,"opsJoinRestoreComplete",_data] spawn MAINCLASS;
+
+                };
+
+                case "OPS_CANCEL_JOIN_PREP": {
+
+                    private _playerID = if (_data isEqualType [] && {count _data > 0}) then {_data select 0} else {""};
+                    [_logic,format ["opsInstantJoinCancelled_%1",_playerID],true] call ALiVE_fnc_hashSet;
+                    [_logic,"opsCancelJoinPrep", _data] call MAINCLASS;
 
                 };
 
@@ -324,8 +436,22 @@ switch(_operation) do {
 							private _profile = [MOD(profileHandler),"getProfile", _x] call ALiVE_fnc_profileHandler;
 
 							if (!isnil "_profile") then {
-								private _position = _profile select 2 select 2;
-								_data pushBack [_x,_position];
+								// Some OPCOM vehicle buckets contain the vehicle profile ID.
+								// Tablet orders operate on entity/group profiles, so resolve the
+								// vehicle to the entity commanding it before exposing it to the UI.
+								if ((_profile select 2 select 5) == "vehicle") then {
+									private _entityIDs = _profile select 2 select 8;
+									if !(_entityIDs isEqualTo []) then {
+										_profile = [MOD(profileHandler),"getProfile", _entityIDs select 0] call ALiVE_fnc_profileHandler;
+									};
+								};
+
+								if (!isnil "_profile" && {(_profile select 2 select 5) == "entity"}) then {
+									private _profileID = _profile select 2 select 4;
+									private _position = _profile select 2 select 2;
+									private _busy = [_profile,"busy",false] call ALiVE_fnc_hashGet;
+									_data pushBackUnique [_profileID,_position,_busy];
+								};
 							};
 						};
 
@@ -358,6 +484,13 @@ switch(_operation) do {
             private _profile = [MOD(profileHandler),"getProfile", _profileID] call ALiVE_fnc_profileHandler;
 
             if (!isnil "_profile") then {
+
+                // Tablet group actions are defined on entity/group profiles.
+                // Reject a stale or crafted vehicle profile ID.
+                if ((_profile select 2 select 5) != "entity") exitWith {
+                    private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
+                    ["OPS_RESET", []] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
+                };
 
                 if !([_logic,"opsCallerAuthorizedForProfile",[_playerID,_profile]] call MAINCLASS) exitwith {
                     private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
@@ -406,6 +539,11 @@ switch(_operation) do {
 
             if !(isnil "_profile") then {
 
+                if ((_profile select 2 select 5) != "entity") exitWith {
+                    private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
+                    ["OPS_RESET", []] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
+                };
+
                 if !([_logic,"opsCallerAuthorizedForProfile",[_playerID,_profile]] call MAINCLASS) exitwith {
                     private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
                     ["OPS_RESET", []] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
@@ -450,6 +588,11 @@ switch(_operation) do {
             private _profile = [MOD(profileHandler), "getProfile", _profileID] call ALiVE_fnc_profileHandler;
 
             if (!isnil "_profile") then {
+
+                if ((_profile select 2 select 5) != "entity") exitWith {
+                    private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
+                    ["OPS_RESET", []] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
+                };
 
                 if !([_logic,"opsCallerAuthorizedForProfile",[_playerID,_profile]] call MAINCLASS) exitwith {
                     private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
@@ -497,6 +640,11 @@ switch(_operation) do {
             private _profile = [MOD(profileHandler), "getProfile", _profileID] call ALiVE_fnc_profileHandler;
 
             if (!isnil "_profile") then {
+
+                if ((_profile select 2 select 5) != "entity") exitWith {
+                    private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
+                    ["OPS_RESET", []] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
+                };
 
                 if !([_logic,"opsCallerAuthorizedForProfile",[_playerID,_profile]] call MAINCLASS) exitwith {
                     private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
@@ -594,71 +742,1193 @@ switch(_operation) do {
 
     };
 
+    case "opsAcquireProfilePin": {
+
+        if (_args isEqualType [] && {count _args >= 3}) then {
+            _args params ["_playerID","_profileID","_profile"];
+            private _pinKey = format ["opsInstantJoinPin_%1",_profileID];
+            private _pin = [_logic,_pinKey,[]] call ALiVE_fnc_hashGet;
+
+            if (_pin isEqualTo []) then {
+                private _priorSpawnType = [_profile,"spawnType"] call ALiVE_fnc_profileEntity;
+                if (isNil "_priorSpawnType" || {!(_priorSpawnType isEqualType [])}) then {_priorSpawnType = []};
+                _pin = [_profile,_priorSpawnType,[]];
+            };
+
+            private _owners = _pin param [2,[],[[]]];
+            _owners pushBackUnique _playerID;
+            _pin set [2,_owners];
+            [_logic,_pinKey,_pin] call ALiVE_fnc_hashSet;
+            [_profile,"spawnType",["preventDespawn"]] call ALiVE_fnc_profileEntity;
+            _result = true;
+        };
+
+    };
+
+    case "opsReleaseProfilePin": {
+
+        if (_args isEqualType [] && {count _args >= 2}) then {
+            _args params ["_playerID","_profileID"];
+            private _pinKey = format ["opsInstantJoinPin_%1",_profileID];
+            private _pin = [_logic,_pinKey,[]] call ALiVE_fnc_hashGet;
+
+            if !(_pin isEqualTo []) then {
+                private _owners = _pin param [2,[],[[]]];
+                _owners = _owners - [_playerID];
+                if (_owners isEqualTo []) then {
+                    private _profile = _pin select 0;
+                    private _priorSpawnType = _pin param [1,[],[[]]];
+                    if !(isNil "_profile") then {[_profile,"spawnType",_priorSpawnType] call ALiVE_fnc_profileEntity};
+                    [_logic,_pinKey,[]] call ALiVE_fnc_hashSet;
+                } else {
+                    _pin set [2,_owners];
+                    [_logic,_pinKey,_pin] call ALiVE_fnc_hashSet;
+                };
+            };
+        };
+
+    };
+
     case "opsJoinGroup": {
 
         if (_args isEqualType []) then {
 
             _args params ["_playerID","_profileID"];
-
-            private _debug = [_logic,"debug"] call ALiVE_fnc_hashGet;
-
-            // get profile
-
+            private _cancelKey = format ["opsInstantJoinCancelled_%1",_playerID];
+            if ([_logic,_cancelKey,false] call ALiVE_fnc_hashGet) exitWith {};
             private _profile = [MOD(profileHandler), "getProfile", _profileID] call ALiVE_fnc_profileHandler;
+            private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
 
-            if (!isnil "_profile") then {
-
-                if !([_logic,"opsCallerAuthorizedForProfile",[_playerID,_profile]] call MAINCLASS) exitwith {
-                    private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
-                    ["OPS_RESET", [_playerID,[]]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
+            private _sendFailure = {
+                if (!isNull _player) then {
+                    ["OPS_GROUP_JOIN_READY",[_playerID,[objNull]]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
                 };
+            };
 
-                // enforce the Instant Join toggle server-side, not just in the UI
-                if !([_logic,"scomOpsAllowInstantJoin",false] call ALiVE_fnc_hashGet) exitwith {
-                    private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
-                    ["OPS_RESET", [_playerID,[]]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
+            if (isnil "_profile") exitWith {call _sendFailure};
+            if ((_profile select 2 select 5) != "entity") exitWith {call _sendFailure};
+            if !([_logic,"opsCallerAuthorizedForProfile",[_playerID,_profile]] call MAINCLASS) exitWith {call _sendFailure};
+            if !([_logic,"scomOpsAllowInstantJoin",false] call ALiVE_fnc_hashGet) exitWith {call _sendFailure};
+            if (isNull _player) exitWith {};
+
+            // Keep the real player body at its saved location. Force-spawn and
+            // temporarily pin the profile instead of using player proximity as
+            // an activation shortcut.
+            private _prepKey = format ["opsInstantJoinPrep_%1",_playerID];
+            private _previousPrep = [_logic,_prepKey,[]] call ALiVE_fnc_hashGet;
+            if (count _previousPrep >= 2) then {
+                [_logic,"opsReleaseProfilePin",[_playerID,_previousPrep select 1]] call MAINCLASS;
+            };
+
+            [_logic,"opsAcquireProfilePin",[_playerID,_profileID,_profile]] call MAINCLASS;
+            [_logic,_prepKey,[_profile,_profileID]] call ALiVE_fnc_hashSet;
+            _player hideObjectGlobal true;
+
+            if !(_profile select 2 select 1) then {
+                [_profile,"spawn"] call ALiVE_fnc_profileEntity;
+            };
+
+            // Activation can fail (for example a profile cannot spawn). Never
+            // strand the player on an endless loading splash.
+            private _deadline = diag_tickTime + 30;
+            waitUntil {
+                sleep 0.5;
+                isNull _player || {[_logic,_cancelKey,false] call ALiVE_fnc_hashGet} || {_profile select 2 select 1} || {diag_tickTime >= _deadline}
+            };
+
+            if ([_logic,_cancelKey,false] call ALiVE_fnc_hashGet) exitWith {};
+            if (isNull _player) exitWith {};
+            if !(_profile select 2 select 1) exitWith {call _sendFailure};
+
+            private _group = _profile select 2 select 13;
+            private _availableUnits = [];
+            private _unitDeadline = diag_tickTime + 20;
+            waitUntil {
+                sleep 0.25;
+                _group = _profile select 2 select 13;
+                if (!isNull _group) then {
+                    _availableUnits = (units _group) select {alive _x && {!isPlayer _x} && {simulationEnabled _x}};
                 };
+                isNull _player || {[_logic,_cancelKey,false] call ALiVE_fnc_hashGet} || {!(_availableUnits isEqualTo [])} || {diag_tickTime >= _unitDeadline}
+            };
 
-                private _faction = _profile select 2 select 29;                 // faction
-                private _position = _profile select 2 select 2;                 // position
-                private _vehiclesInCommandOf = _profile select 2 select 8;      // vehiclesInCommandOf
+            if ([_logic,_cancelKey,false] call ALiVE_fnc_hashGet) exitWith {};
+            if (isNull _player) exitWith {};
+            if (_availableUnits isEqualTo []) exitWith {call _sendFailure};
 
-                if (count _vehiclesInCommandOf == 0) then {
+            ["OPS_GROUP_JOIN_READY",[_playerID,_availableUnits]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+        };
 
-                    private _position = _position getPos [50, random 360];
+    };
 
-                    if (surfaceIsWater _position) then {
-                        _position = [_position] call ALiVE_fnc_getClosestLand;
+    case "opsApplyGroupLeadership": {
+
+        if (_args isEqualType [] && {count _args >= 2}) then {
+            _args params ["_targetGroup","_leader",["_forceFollow",false]];
+            if (!isNull _targetGroup && {!isNull _leader} && {_leader in units _targetGroup}) then {
+                if (local _targetGroup) then {
+                    _targetGroup selectLeader _leader;
+                    if (_forceFollow) then {
+                        {
+                            if (!(_x isEqualTo _leader) && {alive _x} && {!isPlayer _x}) then {
+                                doStop _x;
+                                _x doFollow _leader;
+                            };
+                        } forEach units _targetGroup;
+                    };
+                } else {
+                    private _groupOwner = groupOwner _targetGroup;
+                    if (_groupOwner < 2) then {_groupOwner = 2};
+                    ["OPS_APPLY_GROUP_LEADERSHIP",[_targetGroup,_leader,_forceFollow]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_groupOwner];
+                };
+            };
+        };
+
+    };
+
+    case "opsApplyTakeoverWaypoints": {
+
+        if (_args isEqualType [] && {count _args >= 2}) then {
+            _args params ["_targetGroup","_mode",["_snapshot",[]]];
+            if (!isNull _targetGroup) then {
+                private _event = ["OPS_APPLY_TAKEOVER_WAYPOINTS",[_targetGroup,_mode,_snapshot]];
+                if (local _targetGroup) then {
+                    _event call ALiVE_fnc_SCOMTabletEventToClient;
+                } else {
+                    private _groupOwner = groupOwner _targetGroup;
+                    if (_groupOwner < 2) then {_groupOwner = 2};
+                    _event remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_groupOwner];
+                };
+            };
+        };
+
+    };
+
+    case "opsSuspendProfileWaypoints": {
+
+        _result = false;
+        if (_args isEqualType [] && {count _args >= 4}) then {
+            _args params ["_playerID","_profileID","_profile","_targetGroup"];
+            if (_playerID != "" && {_profileID != ""} && {_profile isEqualType []} && {!(_profile isEqualTo [])} && {!isNull _targetGroup}) then {
+                private _stateKey = format ["opsInstantJoinWaypoints_%1",_profileID];
+                private _state = [_logic,_stateKey,[]] call ALiVE_fnc_hashGet;
+
+                if (_state isEqualTo []) then {
+                    private _engineWaypoints = waypoints _targetGroup;
+                    private _snapshot = [];
+                    private _waypointCount = count _engineWaypoints;
+                    private _currentIndex = (currentWaypoint _targetGroup) max 1;
+                    private _isCycling = (_engineWaypoints findIf {waypointType _x == "CYCLE"}) >= 0;
+                    private _captureWaypoint = {
+                        params ["_index"];
+                        if (_index >= 0 && {_index < _waypointCount}) then {
+                            private _waypoint = _engineWaypoints select _index;
+                            private _position = waypointPosition _waypoint;
+                            if (count _position >= 2 && {!((_position select [0,2]) isEqualTo [0,0])}) then {
+                                _snapshot pushBack ([_waypoint] call ALiVE_fnc_waypointToProfileWaypoint);
+                            };
+                        };
                     };
 
-                    private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
+                    if (_currentIndex < _waypointCount) then {
+                        for "_i" from _currentIndex to (_waypointCount - 1) do {[_i] call _captureWaypoint};
+                    };
+                    if (_isCycling && {_currentIndex > 1}) then {
+                        for "_i" from 1 to ((_currentIndex min _waypointCount) - 1) do {[_i] call _captureWaypoint};
+                    };
 
-                    _player hideObjectGlobal true;
-
-                    _player setPos _position;
-
-                    waitUntil {_profile select 2 select 1}; // active
-
-                    sleep 2;
-
-                    private _group = _profile select 2 select 13;
-                    private _unit = selectRandom (units _group);
-
-                    private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
-                    ["OPS_GROUP_JOIN_READY", [_playerID,[_unit]]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
-
-                } else {
-
-                    private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
-                    ["OPS_RESET", [_playerID,[]]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
-
+                    _state = [_targetGroup,_snapshot,[]];
+                    [_logic,"opsApplyTakeoverWaypoints",[_targetGroup,"CLEAR",[]]] call MAINCLASS;
                 };
 
+                private _owners = _state select 2;
+                _owners pushBackUnique _playerID;
+                _state set [2,_owners];
+                [_logic,_stateKey,_state] call ALiVE_fnc_hashSet;
+                [_profile,"isPlayer",true] call ALiVE_fnc_hashSet;
+                _result = true;
+            };
+        };
+
+    };
+
+    case "opsResumeProfileWaypoints": {
+
+        if (_args isEqualType [] && {count _args >= 4}) then {
+            _args params ["_playerID","_profileID","_profile","_targetGroup"];
+            if (_profileID != "") then {
+                private _stateKey = format ["opsInstantJoinWaypoints_%1",_profileID];
+                private _state = [_logic,_stateKey,[]] call ALiVE_fnc_hashGet;
+                private _stateWasFound = !(_state isEqualTo []);
+                private _stillPlayerControlled = false;
+                if !(_state isEqualTo []) then {
+                    private _owners = _state select 2;
+                    private _ownerIndex = _owners find _playerID;
+                    if (_ownerIndex >= 0) then {_owners deleteAt _ownerIndex};
+                    _stillPlayerControlled = !(_owners isEqualTo []);
+
+                    if (_owners isEqualTo []) then {
+                        private _resumeGroup = _targetGroup;
+                        if (isNull _resumeGroup && {_profile isEqualType []} && {!(_profile isEqualTo [])}) then {
+                            _resumeGroup = [_profile,"group",grpNull] call ALiVE_fnc_hashGet;
+                        };
+                        if (isNull _resumeGroup) then {_resumeGroup = _state select 0};
+                        if (!isNull _resumeGroup) then {
+                            [_logic,"opsApplyTakeoverWaypoints",[_resumeGroup,"RESTORE",_state select 1]] call MAINCLASS;
+                        };
+                        [_logic,_stateKey,[]] call ALiVE_fnc_hashSet;
+                    } else {
+                        _state set [2,_owners];
+                        [_logic,_stateKey,_state] call ALiVE_fnc_hashSet;
+                    };
+                };
+
+                if (_stateWasFound && {_profile isEqualType []} && {!(_profile isEqualTo [])}) then {
+                    [_profile,"isPlayer",_stillPlayerControlled] call ALiVE_fnc_hashSet;
+                };
+            };
+        };
+
+    };
+
+    case "opsRecreateTakeoverUnit": {
+
+        // Unit creation must execute wherever the AI group is local. Dispatch
+        // through the already-global SCOM module, then wait for a narrowly
+        // addressed public result from that owner (server, HC, or player client).
+        _result = [false,"INVALID_RECREATE_REQUEST",objNull];
+        if (_args isEqualType [] && {count _args >= 6}) then {
+            _args params ["_playerID","_targetGroup","_snapshot","_profileID","_profileIndex","_wasLeader"];
+            if (!isNull _targetGroup && {_snapshot isEqualType []} && {count _snapshot >= 11}) then {
+                private _attempt = 0;
+                while {_attempt < 3 && {!(_result select 0)}} do {
+                    _attempt = _attempt + 1;
+                    private _resultKey = format ["ALiVE_SCOMRecreate_%1_%2_%3",_playerID,floor (diag_tickTime * 1000),floor (random 1000000000)];
+                    missionNamespace setVariable [_resultKey,nil];
+                    private _owner = groupOwner _targetGroup;
+                    if (_owner < 2) then {_owner = 2};
+                    private _event = ["OPS_RECREATE_TAKEOVER_UNIT",[
+                        _resultKey,_targetGroup,_snapshot,_profileID,_profileIndex,_wasLeader
+                    ]];
+                    if (local _targetGroup) then {
+                        _event call ALiVE_fnc_SCOMTabletEventToClient;
+                    } else {
+                        _event remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_owner];
+                    };
+
+                    private _deadline = diag_tickTime + 6;
+                    waitUntil {
+                        sleep 0.05;
+                        !isNil {missionNamespace getVariable _resultKey} || {diag_tickTime >= _deadline}
+                    };
+                    private _ownerResult = missionNamespace getVariable [_resultKey,[]];
+                    missionNamespace setVariable [_resultKey,nil];
+                    if (_ownerResult isEqualType [] && {count _ownerResult >= 3}) then {
+                        private _candidate = _ownerResult param [2,objNull,[objNull]];
+                        if ((_ownerResult select 0) && {!isNull _candidate} && {alive _candidate} && {!isPlayer _candidate} && {group _candidate isEqualTo _targetGroup}) then {
+                            _result = [true,"",_candidate];
+                        } else {
+                            _result = [false,_ownerResult param [1,"RECREATE_REJECTED",[""]],objNull];
+                        };
+                    } else {
+                        _result = [false,"RECREATE_OWNER_TIMEOUT",objNull];
+                    };
+                };
+            };
+        };
+
+    };
+
+    case "opsTakeoverUnit": {
+
+        if (_args isEqualType [] && {count _args >= 2}) then {
+            _args params ["_playerID","_selected"];
+            private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
+            private _sessionKey = format ["opsInstantJoinSession_%1",_playerID];
+            private _prepKey = format ["opsInstantJoinPrep_%1",_playerID];
+            private _prep = [_logic,_prepKey,[]] call ALiVE_fnc_hashGet;
+
+            private _sendFailure = {
+                params ["_message"];
+                if (!isNull _player) then {
+                    _player hideObjectGlobal false;
+                    ["OPS_JOIN_HANDOFF_RESULT",[false,_message]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+                };
+            };
+
+            if (isNull _player || {isNull _selected} || {!alive _selected} || {isPlayer _selected}) exitWith {
+                ["INVALID_TARGET"] call _sendFailure;
+            };
+            if (count _prep < 2) exitWith {["PREPARATION_EXPIRED"] call _sendFailure};
+            private _existingSession = [_logic,_sessionKey,[]] call ALiVE_fnc_hashGet;
+            private _continuing = !(_existingSession isEqualTo []) && {
+                ([_existingSession,"status",""] call ALiVE_fnc_hashGet) == "CHOOSING_REPLACEMENT"
+            };
+            if (!(_existingSession isEqualTo []) && {!_continuing}) exitWith {
+                ["SESSION_ALREADY_ACTIVE"] call _sendFailure;
+            };
+
+            private _profile = _prep select 0;
+            private _profileID = _prep select 1;
+            if (isNil "_profile") exitWith {["PROFILE_UNAVAILABLE"] call _sendFailure};
+            private _targetGroup = _profile select 2 select 13;
+            if (isNull _targetGroup || {!(_selected in units _targetGroup)}) exitWith {
+                ["TARGET_NO_LONGER_IN_GROUP"] call _sendFailure;
+            };
+            private _reservation = _selected getVariable ["ALiVE_SCOMTakeoverUID",""];
+            // A death continuation still owns this session. A stale reservation
+            // from that same player must not lock them out of the promoted unit;
+            // reservations belonging to anyone else are still respected.
+            if (_continuing && {_reservation == _playerID}) then {
+                _selected setVariable ["ALiVE_SCOMTakeoverUID",nil,true];
+                _reservation = "";
+            };
+            if (_reservation != "") exitWith {
+                ["TARGET_ALREADY_RESERVED"] call _sendFailure;
+            };
+
+            private _captureVehicleRole = {
+                params ["_unit"];
+                private _vehicle = vehicle _unit;
+                if (_vehicle isEqualTo _unit) exitWith {[objNull,[]]};
+                private _rowIndex = (fullCrew [_vehicle,"",false]) findIf {(_x select 0) isEqualTo _unit};
+                if (_rowIndex < 0) exitWith {[_vehicle,[]]};
+                private _row = (fullCrew [_vehicle,"",false]) select _rowIndex;
+                [_vehicle,[toLower (_row param [1,"",[""]]),_row param [2,-1,[0]],_row param [3,[],[[]]]]]
+            };
+
+            private _targetVehicleRole = [_selected] call _captureVehicleRole;
+            private _originalVehicleRole = [_player] call _captureVehicleRole;
+            private _originalGroup = group _player;
+            private _originalSide = if (isNull _originalGroup) then {side _player} else {side _originalGroup};
+            private _session = if (_continuing) then {_existingSession} else {[] call ALiVE_fnc_hashCreate};
+            [_session,"profile",_profile] call ALiVE_fnc_hashSet;
+            [_session,"profileID",_profileID] call ALiVE_fnc_hashSet;
+            [_session,"player",_player] call ALiVE_fnc_hashSet;
+            [_session,"selected",_selected] call ALiVE_fnc_hashSet;
+            [_session,"targetGroup",_targetGroup] call ALiVE_fnc_hashSet;
+            private _profileLeader = if (_profile isEqualType []) then {[_profile,"leader",objNull] call ALiVE_fnc_hashGet} else {objNull};
+            // Group leadership can take a network frame to settle after the
+            // previous player leader respawns. The profile reference is the
+            // authoritative fallback during that short locality transition.
+            private _targetWasLeader = ((leader _targetGroup) isEqualTo _selected) || {_profileLeader isEqualTo _selected};
+            [_session,"targetWasLeader",_targetWasLeader] call ALiVE_fnc_hashSet;
+            private _profileUnits = [_profile,"units",[]] call ALiVE_fnc_hashGet;
+            private _profileIndex = if (_profileUnits isEqualType []) then {_profileUnits find _selected} else {-1};
+            if (_profileIndex < 0) then {_profileIndex = _selected getVariable ["profileIndex",-1]};
+            [_session,"profileIndex",_profileIndex] call ALiVE_fnc_hashSet;
+            [_session,"selectedDeleted",false] call ALiVE_fnc_hashSet;
+            [_session,"targetState",[
+                getPosATL _selected,
+                getDir _selected,
+                [rank _selected,name _selected,face _selected,speaker _selected,pitch _selected],
+                getUnitLoadout _selected,
+                damage _selected,
+                _targetVehicleRole select 0,
+                _targetVehicleRole select 1
+            ]] call ALiVE_fnc_hashSet;
+            [_session,"targetSnapshot",[
+                typeOf _selected,
+                getPosATL _selected,
+                getDir _selected,
+                [rank _selected,name _selected,face _selected,speaker _selected,pitch _selected],
+                getUnitLoadout _selected,
+                damage _selected,
+                _targetVehicleRole select 0,
+                _targetVehicleRole select 1,
+                skill _selected,
+                unitPos _selected,
+                _selected getVariable ["ALiVE_ignore_HC",false]
+            ]] call ALiVE_fnc_hashSet;
+            [_session,"originalGroup",_originalGroup] call ALiVE_fnc_hashSet;
+            [_session,"originalSide",_originalSide] call ALiVE_fnc_hashSet;
+            [_session,"originalWasLeader",!isNull _originalGroup && {(leader _originalGroup) isEqualTo _player}] call ALiVE_fnc_hashSet;
+            [_session,"originalState",[
+                getPosATL _player,
+                getDir _player,
+                [rank _player,name _player,face _player,speaker _player,pitch _player],
+                getUnitLoadout _player,
+                damage _player,
+                _originalVehicleRole select 0,
+                _originalVehicleRole select 1
+            ]] call ALiVE_fnc_hashSet;
+            [_session,"status","PREPARING"] call ALiVE_fnc_hashSet;
+            [_logic,_sessionKey,_session] call ALiVE_fnc_hashSet;
+
+            // AI commanders commonly lock their assigned vehicles. A scripted
+            // move-in can bypass the general lock, but the player would then be
+            // unable to dismount or re-enter. Unlock the vehicle and every seat
+            // while it is still local to the server-owned AI crew.
+            private _targetVehicle = _targetVehicleRole select 0;
+            if (!isNull _targetVehicle) then {
+                _targetVehicle setVehicleLock "UNLOCKED";
+                if (local _targetVehicle) then {
+                    _targetVehicle lockDriver false;
+                    _targetVehicle lockCargo false;
+                    {_targetVehicle lockTurret [_x,false]} forEach (allTurrets [_targetVehicle,true]);
+                };
+            };
+
+            _selected setVariable ["ALiVE_SCOMTakeoverUID",_playerID,true];
+            moveOut _selected;
+            unassignVehicle _selected;
+            _selected allowDamage false;
+            _selected enableSimulationGlobal false;
+            _selected hideObjectGlobal true;
+
+            [_player] joinSilent _targetGroup;
+            private _joinDeadline = diag_tickTime + 8;
+            waitUntil {
+                sleep 0.1;
+                (group _player isEqualTo _targetGroup) || {diag_tickTime >= _joinDeadline}
+            };
+
+            if !(group _player isEqualTo _targetGroup) exitWith {
+                _selected hideObjectGlobal false;
+                _selected enableSimulationGlobal true;
+                _selected allowDamage true;
+                _selected setVariable ["ALiVE_SCOMTakeoverUID",nil,true];
+                private _targetState = [_session,"targetState"] call ALiVE_fnc_hashGet;
+                _targetState params ["_position","_direction","_identity","_loadout","_damage","_vehicle","_vehicleRole"];
+                _selected setDir _direction;
+                _selected setPosATL _position;
+                if (!isNull _vehicle && {alive _vehicle} && {count _vehicleRole > 0}) then {
+                    switch (toLower (_vehicleRole param [0,"",[""]])) do {
+                        case "driver": {_selected assignAsDriver _vehicle; _selected moveInDriver _vehicle};
+                        case "gunner": {_selected assignAsGunner _vehicle; _selected moveInGunner _vehicle};
+                        case "commander": {_selected assignAsCommander _vehicle; _selected moveInCommander _vehicle};
+                        case "turret": {
+                            private _turretPath = _vehicleRole param [2,[],[[]]];
+                            _selected assignAsTurret [_vehicle,_turretPath];
+                            _selected moveInTurret [_vehicle,_turretPath];
+                        };
+                        case "cargo": {
+                            private _cargoIndex = _vehicleRole param [1,-1,[0]];
+                            if (_cargoIndex >= 0) then {
+                                _selected assignAsCargoIndex [_vehicle,_cargoIndex];
+                                _selected moveInCargo [_vehicle,_cargoIndex];
+                            } else {
+                                _selected assignAsCargo _vehicle;
+                                _selected moveInCargo _vehicle;
+                            };
+                        };
+                    };
+                };
+                if ([_session,"targetWasLeader",false] call ALiVE_fnc_hashGet) then {
+                    [_logic,"opsApplyGroupLeadership",[_targetGroup,_selected,true]] call MAINCLASS;
+                };
+                if (!isNull _originalGroup) then {[_player] joinSilent _originalGroup};
+                [_logic,_sessionKey,[]] call ALiVE_fnc_hashSet;
+                ["GROUP_JOIN_FAILED"] call _sendFailure;
+            };
+
+            ["OPS_JOIN_HANDOFF",[
+                _playerID,_player,_selected,_targetGroup,[_session,"targetState"] call ALiVE_fnc_hashGet
+            ]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+        };
+
+    };
+
+    case "opsJoinHandoffComplete": {
+
+        if (_args isEqualType [] && {count _args >= 3}) then {
+            _args params ["_playerID","_selected","_success",["_failureReason",""]];
+            private _sessionKey = format ["opsInstantJoinSession_%1",_playerID];
+            private _session = [_logic,_sessionKey,[]] call ALiVE_fnc_hashGet;
+            if !(_session isEqualTo []) then {
+                private _player = [_session,"player",objNull] call ALiVE_fnc_hashGet;
+                private _reserved = [_session,"selected",objNull] call ALiVE_fnc_hashGet;
+                private _targetGroup = [_session,"targetGroup",grpNull] call ALiVE_fnc_hashGet;
+                if (!isNull _player && {_reserved isEqualTo _selected}) then {
+                    private _applied = _success && {group _player isEqualTo _targetGroup};
+                    private _profile = [_session,"profile",[]] call ALiVE_fnc_hashGet;
+                    private _profileIndex = [_session,"profileIndex",-1] call ALiVE_fnc_hashGet;
+
+                    // Commit the replacement only after the client confirms that
+                    // its real player object has inherited the target state. The
+                    // selected AI is then genuinely removed; there is no hidden
+                    // formation member or parked proxy left behind.
+                    if (_applied && {!isNull _reserved}) then {
+                        private _profileUnits = if (_profile isEqualType []) then {[_profile,"units",[]] call ALiVE_fnc_hashGet} else {[]};
+                        if (_profileUnits isEqualType []) then {
+                            private _foundIndex = _profileUnits find _reserved;
+                            if (_foundIndex >= 0) then {_profileIndex = _foundIndex};
+                        };
+                        // Never commit the destructive half of the exchange unless
+                        // the selected object can be replaced in its exact profile
+                        // slot. That keeps a stale profile from losing a unit.
+                        _applied = _profileUnits isEqualType [] && {_profileIndex >= 0} && {_profileIndex < count _profileUnits} && {
+                            (_profileUnits select _profileIndex) isEqualTo _reserved
+                        };
+                        // Transfer leadership while the reserved AI still exists.
+                        // Deleting a local group leader first makes Arma promote a
+                        // temporary successor and can leave a dedicated server
+                        // unable to select the player as leader on the next pass.
+                        if (_applied && {[_session,"targetWasLeader",false] call ALiVE_fnc_hashGet}) then {
+                            private _leaderDeadline = diag_tickTime + 8;
+                            private _nextLeaderAttempt = 0;
+                            waitUntil {
+                                sleep 0.1;
+                                if (diag_tickTime >= _nextLeaderAttempt) then {
+                                    [_logic,"opsApplyGroupLeadership",[_targetGroup,_player,true]] call MAINCLASS;
+                                    _nextLeaderAttempt = diag_tickTime + 0.5;
+                                };
+                                (leader _targetGroup isEqualTo _player) || {diag_tickTime >= _leaderDeadline}
+                            };
+                            _applied = leader _targetGroup isEqualTo _player;
+                        };
+                        if (_applied) then {
+                            _reserved allowDamage false;
+                            _reserved hideObjectGlobal true;
+                            deleteVehicle _reserved;
+                            private _deleteDeadline = diag_tickTime + 3;
+                            waitUntil {
+                                sleep 0.05;
+                                isNull _reserved || {isNull (group _reserved)} || {diag_tickTime >= _deleteDeadline}
+                            };
+                            _applied = isNull _reserved || {isNull (group _reserved)};
+                        };
+
+                        if (_applied) then {
+                            _profileUnits set [_profileIndex,_player];
+                            [_profile,"units",_profileUnits] call ALiVE_fnc_hashSet;
+                            _player setVariable ["profileID",[_session,"profileID",""] call ALiVE_fnc_hashGet,true];
+                            _player setVariable ["profileIndex",_profileIndex,true];
+                            private _savedSnapshot = [_session,"targetSnapshot",[]] call ALiVE_fnc_hashGet;
+                            _player setVariable ["ALiVE_ignore_HC",_savedSnapshot param [10,false,[true]],true];
+                            [_session,"profileIndex",_profileIndex] call ALiVE_fnc_hashSet;
+                            [_session,"selected",objNull] call ALiVE_fnc_hashSet;
+                            [_session,"selectedDeleted",true] call ALiVE_fnc_hashSet;
+                        };
+                    };
+
+                    if (_applied && {[_session,"targetWasLeader",false] call ALiVE_fnc_hashGet}) then {
+                        private _leaderDeadline = diag_tickTime + 8;
+                        private _nextLeaderAttempt = 0;
+                        waitUntil {
+                            sleep 0.1;
+                            if (diag_tickTime >= _nextLeaderAttempt) then {
+                                [_logic,"opsApplyGroupLeadership",[_targetGroup,_player,true]] call MAINCLASS;
+                                _nextLeaderAttempt = diag_tickTime + 0.5;
+                            };
+                            (leader _targetGroup isEqualTo _player) || {diag_tickTime >= _leaderDeadline}
+                        };
+                        _applied = leader _targetGroup isEqualTo _player;
+                        if (_applied && {_profile isEqualType []}) then {
+                            [_profile,"leader",_player] call ALiVE_fnc_hashSet;
+                        };
+                    };
+
+                    if (_applied) then {
+                        private _profileID = [_session,"profileID",""] call ALiVE_fnc_hashGet;
+                        [_logic,"opsSuspendProfileWaypoints",[_playerID,_profileID,_profile,_targetGroup]] call MAINCLASS;
+                        _player hideObjectGlobal false;
+                        [_session,"status","ACTIVE"] call ALiVE_fnc_hashSet;
+                        [_logic,_sessionKey,_session] call ALiVE_fnc_hashSet;
+                    } else {
+                        [_session,"status","FAILED"] call ALiVE_fnc_hashSet;
+                        [_logic,_sessionKey,_session] call ALiVE_fnc_hashSet;
+                    };
+                    ["OPS_JOIN_HANDOFF_RESULT",[_applied,if (_applied) then {"ACTIVE"} else {if (_failureReason != "") then {_failureReason} else {"HANDOFF_FAILED"}}]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+                };
+            };
+        };
+
+    };
+
+    case "opsJoinPlayerKilled": {
+
+        if (_args isEqualType [] && {count _args >= 1}) then {
+            private _playerID = _args select 0;
+            private _sessionKey = format ["opsInstantJoinSession_%1",_playerID];
+            private _session = [_logic,_sessionKey,[]] call ALiVE_fnc_hashGet;
+            if !(_session isEqualTo []) then {
+                private _status = [_session,"status",""] call ALiVE_fnc_hashGet;
+                if !(_status in ["AWAITING_RESPAWN","CHOOSING_REPLACEMENT"]) then {
+                    private _player = [_session,"player",objNull] call ALiVE_fnc_hashGet;
+                    private _selected = [_session,"selected",objNull] call ALiVE_fnc_hashGet;
+                    private _targetGroup = [_session,"targetGroup",grpNull] call ALiVE_fnc_hashGet;
+
+                    private _profile = [_session,"profile",[]] call ALiVE_fnc_hashGet;
+                    private _selectedDeleted = [_session,"selectedDeleted",false] call ALiVE_fnc_hashGet;
+
+                    // Once committed, the player occupies the selected AI's
+                    // profile slot. A player death is therefore the one real role
+                    // casualty; no second, hidden AI corpse needs to be manufactured.
+                    if (_selectedDeleted && {!isNull _player} && {_profile isEqualType []}) then {
+                        private _profileUnits = [_profile,"units",[]] call ALiVE_fnc_hashGet;
+                        if (_profileUnits isEqualType [] && {_player in _profileUnits}) then {
+                            [_profile,"handleDeath",_player] call ALiVE_fnc_profileEntity;
+                        };
+                        _player setVariable ["profileID",nil,true];
+                        _player setVariable ["profileIndex",nil,true];
+                        _player setVariable ["ALiVE_ignore_HC",nil,true];
+                    } else {
+                        // A pre-commit handoff failure still owns a real selected
+                        // AI. Put it back into service rather than deleting it.
+                        if (!isNull _selected) then {
+                        _selected enableSimulationGlobal true;
+                        _selected hideObjectGlobal false;
+                        _selected allowDamage true;
+                        _selected setVariable ["ALiVE_SCOMTakeoverUID",nil,true];
+                        };
+                    };
+
+                    if (!isNull _targetGroup) then {
+                        // Only remove a reservation left by this exact session.
+                        // This also clears a stale value left by an interrupted
+                        // handoff before the successor was promoted.
+                        {
+                            if ((_x getVariable ["ALiVE_SCOMTakeoverUID",""]) == _playerID) then {
+                                _x setVariable ["ALiVE_SCOMTakeoverUID",nil,true];
+                            };
+                        } forEach units _targetGroup;
+
+                        private _nextLeaderIndex = (units _targetGroup) findIf {
+                            alive _x && {!isPlayer _x} && {simulationEnabled _x}
+                        };
+                        if (_nextLeaderIndex >= 0) then {
+                            private _nextLeader = (units _targetGroup) select _nextLeaderIndex;
+                            [_session,"replacementLeader",_nextLeader] call ALiVE_fnc_hashSet;
+                            [_logic,"opsApplyGroupLeadership",[_targetGroup,_nextLeader,true]] call MAINCLASS;
+                            if (_profile isEqualType []) then {[_profile,"leader",_nextLeader] call ALiVE_fnc_hashSet};
+                        };
+                    };
+
+                    [_session,"selected",objNull] call ALiVE_fnc_hashSet;
+                    [_session,"status","AWAITING_RESPAWN"] call ALiVE_fnc_hashSet;
+                    [_logic,_sessionKey,_session] call ALiVE_fnc_hashSet;
+                };
+            };
+        };
+
+    };
+
+    case "opsJoinPlayerRespawned": {
+
+        if (_args isEqualType [] && {count _args >= 1}) then {
+            private _playerID = _args select 0;
+            private _sessionKey = format ["opsInstantJoinSession_%1",_playerID];
+            private _session = [];
+            private _sessionDeadline = diag_tickTime + 10;
+
+            waitUntil {
+                sleep 0.05;
+                _session = [_logic,_sessionKey,[]] call ALiVE_fnc_hashGet;
+                !(_session isEqualTo []) || {diag_tickTime >= _sessionDeadline}
+            };
+
+            private _reportedPlayer = _args param [1,objNull,[objNull]];
+            private _player = objNull;
+            if (!isNull _reportedPlayer && {alive _reportedPlayer} && {getPlayerUID _reportedPlayer == _playerID}) then {
+                _player = _reportedPlayer;
             } else {
+                _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
+            };
+            if (isNull _player) exitWith {};
 
-                private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
-                ["OPS_RESET", [_playerID,[]]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient", _player];
+            private _sendReplacementChooser = {
+                params ["_session","_player"];
+                private _profileID = [_session,"profileID",""] call ALiVE_fnc_hashGet;
+                private _targetGroup = [_session,"targetGroup",grpNull] call ALiVE_fnc_hashGet;
+                private _availableUnits = [];
+                if (!isNull _targetGroup) then {
+                    _availableUnits = (units _targetGroup) select {
+                        alive _x && {!isPlayer _x} && {simulationEnabled _x} &&
+                        {(_x getVariable ["ALiVE_SCOMTakeoverUID",""]) == ""}
+                    };
+                };
+                _player hideObjectGlobal true;
+                ["OPS_JOIN_RESPAWN_READY",[_playerID,_profileID,_player,_availableUnits]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+            };
 
+            if (_session isEqualTo []) exitWith {
+                _player hideObjectGlobal false;
+                ["OPS_JOIN_RESPAWN_READY",[_playerID,"",_player,[]]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+            };
+
+            private _status = [_session,"status",""] call ALiVE_fnc_hashGet;
+            if (_status == "CHOOSING_REPLACEMENT") exitWith {
+                [_session,_player] call _sendReplacementChooser;
+            };
+            if (_status == "RESPAWN_PROCESSING") exitWith {};
+            if (_status != "AWAITING_RESPAWN") then {
+                private _previousPlayer = [_session,"player",objNull] call ALiVE_fnc_hashGet;
+                if (isNull _previousPlayer || {!alive _previousPlayer}) then {
+                    [_logic,"opsJoinPlayerKilled",[_playerID,_previousPlayer]] call MAINCLASS;
+                    _session = [_logic,_sessionKey,[]] call ALiVE_fnc_hashGet;
+                    _status = [_session,"status",""] call ALiVE_fnc_hashGet;
+                };
+            };
+
+            if (_status != "AWAITING_RESPAWN") exitWith {
+                _player hideObjectGlobal false;
+                ["OPS_JOIN_RESPAWN_READY",[_playerID,"",_player,[]]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+            };
+
+            // Serialize the client Respawn EH and the dedicated-server
+            // OnUserSelectedPlayer fallback. Whichever arrives first owns this
+            // transition; a later duplicate can safely reuse the chooser state.
+            [_session,"status","RESPAWN_PROCESSING"] call ALiVE_fnc_hashSet;
+            [_logic,_sessionKey,_session] call ALiVE_fnc_hashSet;
+
+            private _profile = [_session,"profile"] call ALiVE_fnc_hashGet;
+            private _profileID = [_session,"profileID",""] call ALiVE_fnc_hashGet;
+            private _targetGroup = [_session,"targetGroup",grpNull] call ALiVE_fnc_hashGet;
+            private _originalGroup = [_session,"originalGroup",grpNull] call ALiVE_fnc_hashGet;
+            private _originalSide = [_session,"originalSide",side _player] call ALiVE_fnc_hashGet;
+
+            // A mission respawn can inherit the takeover group. Detach the new
+            // body on the server before the chooser appears, while leaving the
+            // exact ALiVE profile pinned and physical.
+            if (isNull _originalGroup) then {
+                _originalGroup = createGroup _originalSide;
+            };
+            [_player] joinSilent _originalGroup;
+            private _joinDeadline = diag_tickTime + 8;
+            waitUntil {
+                sleep 0.1;
+                (group _player isEqualTo _originalGroup) || {diag_tickTime >= _joinDeadline}
+            };
+            if !(group _player isEqualTo _originalGroup) then {
+                _originalGroup = createGroup _originalSide;
+                [_player] joinSilent _originalGroup;
+                _joinDeadline = diag_tickTime + 8;
+                waitUntil {
+                    sleep 0.1;
+                    (group _player isEqualTo _originalGroup) || {diag_tickTime >= _joinDeadline}
+                };
+            };
+
+            if !(group _player isEqualTo _originalGroup) exitWith {
+                [_session,"status","AWAITING_RESPAWN"] call ALiVE_fnc_hashSet;
+                [_logic,_sessionKey,_session] call ALiVE_fnc_hashSet;
+                _player hideObjectGlobal false;
+                ["OPS_JOIN_RESPAWN_READY",[_playerID,"",_player,[]]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+            };
+
+            // The killed player may have owned the AI group when succession was
+            // first requested. Once the respawn body has been detached, repeat
+            // and verify the promotion before presenting the chooser. This makes
+            // the successor stable on a dedicated server and keeps the profile's
+            // leader reference in sync with the engine group.
+            if (!isNull _targetGroup) then {
+                {
+                    if ((_x getVariable ["ALiVE_SCOMTakeoverUID",""]) == _playerID) then {
+                        _x setVariable ["ALiVE_SCOMTakeoverUID",nil,true];
+                    };
+                } forEach units _targetGroup;
+
+                private _replacementLeader = [_session,"replacementLeader",objNull] call ALiVE_fnc_hashGet;
+                if (isNull _replacementLeader || {!alive _replacementLeader} || {!(_replacementLeader in units _targetGroup)} || {isPlayer _replacementLeader}) then {
+                    private _currentLeader = leader _targetGroup;
+                    if (!isNull _currentLeader && {alive _currentLeader} && {!isPlayer _currentLeader} && {_currentLeader in units _targetGroup}) then {
+                        _replacementLeader = _currentLeader;
+                    } else {
+                        private _replacementIndex = (units _targetGroup) findIf {
+                            alive _x && {!isPlayer _x} && {simulationEnabled _x}
+                        };
+                        _replacementLeader = if (_replacementIndex >= 0) then {(units _targetGroup) select _replacementIndex} else {objNull};
+                    };
+                };
+
+                if (!isNull _replacementLeader) then {
+                    private _leaderDeadline = diag_tickTime + 8;
+                    private _nextLeaderAttempt = 0;
+                    waitUntil {
+                        sleep 0.1;
+                        if (diag_tickTime >= _nextLeaderAttempt) then {
+                            [_logic,"opsApplyGroupLeadership",[_targetGroup,_replacementLeader,true]] call MAINCLASS;
+                            _nextLeaderAttempt = diag_tickTime + 0.5;
+                        };
+                        (leader _targetGroup isEqualTo _replacementLeader) || {diag_tickTime >= _leaderDeadline}
+                    };
+
+                    private _settledLeader = leader _targetGroup;
+                    if (!isNull _settledLeader && {alive _settledLeader} && {!isPlayer _settledLeader}) then {
+                        _replacementLeader = _settledLeader;
+                    };
+                    [_session,"replacementLeader",_replacementLeader] call ALiVE_fnc_hashSet;
+                    if (_profile isEqualType []) then {[_profile,"leader",_replacementLeader] call ALiVE_fnc_hashSet};
+                };
+            };
+
+            private _captureVehicleRole = {
+                params ["_unit"];
+                private _vehicle = vehicle _unit;
+                if (_vehicle isEqualTo _unit) exitWith {[objNull,[]]};
+                private _rowIndex = (fullCrew [_vehicle,"",false]) findIf {(_x select 0) isEqualTo _unit};
+                if (_rowIndex < 0) exitWith {[_vehicle,[]]};
+                private _row = (fullCrew [_vehicle,"",false]) select _rowIndex;
+                [_vehicle,[toLower (_row param [1,"",[""]]),_row param [2,-1,[0]],_row param [3,[],[[]]]]]
+            };
+            private _originalVehicleRole = [_player] call _captureVehicleRole;
+
+            _player hideObjectGlobal true;
+            [_session,"player",_player] call ALiVE_fnc_hashSet;
+            [_session,"selected",objNull] call ALiVE_fnc_hashSet;
+            [_session,"originalGroup",_originalGroup] call ALiVE_fnc_hashSet;
+            [_session,"originalSide",_originalSide] call ALiVE_fnc_hashSet;
+            [_session,"originalState",[
+                getPosATL _player,
+                getDir _player,
+                [rank _player,name _player,face _player,speaker _player,pitch _player],
+                getUnitLoadout _player,
+                damage _player,
+                _originalVehicleRole select 0,
+                _originalVehicleRole select 1
+            ]] call ALiVE_fnc_hashSet;
+            [_session,"status","CHOOSING_REPLACEMENT"] call ALiVE_fnc_hashSet;
+            [_logic,_sessionKey,_session] call ALiVE_fnc_hashSet;
+
+            [_session,_player] call _sendReplacementChooser;
+        };
+
+    };
+
+    case "opsCleanupJoin": {
+
+        if (_args isEqualType [] && {count _args >= 1}) then {
+            private _playerID = _args select 0;
+            private _disconnectUnit = _args param [1,objNull,[objNull]];
+            private _disconnectState = _args param [2,[],[[]]];
+            private _sessionKey = format ["opsInstantJoinSession_%1",_playerID];
+            private _prepKey = format ["opsInstantJoinPrep_%1",_playerID];
+            private _session = [_logic,_sessionKey,[]] call ALiVE_fnc_hashGet;
+            private _profileID = "";
+            private _cleanupComplete = true;
+
+            if !(_session isEqualTo []) then {
+                _profileID = [_session,"profileID",""] call ALiVE_fnc_hashGet;
+                private _selected = [_session,"selected",objNull] call ALiVE_fnc_hashGet;
+                private _source = [_session,"player",_disconnectUnit] call ALiVE_fnc_hashGet;
+                private _targetGroup = [_session,"targetGroup",grpNull] call ALiVE_fnc_hashGet;
+                private _profile = [_session,"profile",[]] call ALiVE_fnc_hashGet;
+                private _status = [_session,"status",""] call ALiVE_fnc_hashGet;
+                private _selectedDeleted = [_session,"selectedDeleted",false] call ALiVE_fnc_hashGet;
+                private _currentState = [_session,"currentTargetState",[]] call ALiVE_fnc_hashGet;
+                if (_status != "RESTORING" && {count _disconnectState >= 6}) then {
+                    _currentState = _disconnectState select [0,6];
+                };
+
+                if (_selectedDeleted && {_status in ["ACTIVE","FAILED","RESTORING","RECREATE_FAILED"]}) then {
+                    private _sourceAlive = if (count _disconnectState >= 7) then {_disconnectState select 6} else {!isNull _source && {alive _source}};
+                    if (!_sourceAlive) then {
+                        if (!isNull _source && {_profile isEqualType []}) then {
+                            private _profileUnits = [_profile,"units",[]] call ALiVE_fnc_hashGet;
+                            if (_profileUnits isEqualType [] && {_source in _profileUnits}) then {
+                                [_profile,"handleDeath",_source] call ALiVE_fnc_profileEntity;
+                            };
+                        };
+                    } else {
+                        private _snapshot = +([_session,"targetSnapshot",[]] call ALiVE_fnc_hashGet);
+                        if (count _snapshot >= 11 && {count _currentState >= 6}) then {
+                            _snapshot set [1,_currentState select 0];
+                            _snapshot set [2,_currentState select 1];
+                            _snapshot set [4,_currentState select 2];
+                            _snapshot set [5,_currentState select 3];
+                            _snapshot set [6,_currentState select 4];
+                            _snapshot set [7,_currentState select 5];
+                        };
+                        if (!isNull _source) then {moveOut _source; unassignVehicle _source};
+                        private _profileUnits = if (_profile isEqualType []) then {[_profile,"units",[]] call ALiVE_fnc_hashGet} else {[]};
+                        private _profileIndex = if (_profileUnits isEqualType []) then {_profileUnits find _source} else {-1};
+                        if (_profileIndex < 0) then {_profileIndex = [_session,"profileIndex",-1] call ALiVE_fnc_hashGet};
+                        private _recreate = [_logic,"opsRecreateTakeoverUnit",[
+                            _playerID,_targetGroup,_snapshot,_profileID,_profileIndex,[_session,"targetWasLeader",false] call ALiVE_fnc_hashGet
+                        ]] call MAINCLASS;
+                        _cleanupComplete = _recreate select 0;
+                        if (_cleanupComplete) then {
+                            private _replacement = _recreate select 2;
+                            if (_profileUnits isEqualType [] && {_profileIndex >= 0} && {_profileIndex < count _profileUnits}) then {
+                                _profileUnits set [_profileIndex,_replacement];
+                                [_profile,"units",_profileUnits] call ALiVE_fnc_hashSet;
+                            };
+                            if ([_session,"targetWasLeader",false] call ALiVE_fnc_hashGet && {_profile isEqualType []} && {!(_profile isEqualTo [])}) then {
+                                [_profile,"leader",_replacement] call ALiVE_fnc_hashSet
+                            };
+                        } else {
+                            [_session,"status","RECREATE_FAILED"] call ALiVE_fnc_hashSet;
+                            [_logic,_sessionKey,_session] call ALiVE_fnc_hashSet;
+                        };
+                    };
+                } else {
+                    // The handoff had not committed yet, so the original object
+                    // still exists and only needs to be made physical again.
+                    if (!isNull _selected) then {
+                        _selected enableSimulationGlobal true;
+                        _selected hideObjectGlobal false;
+                        _selected allowDamage true;
+                        _selected setVariable ["ALiVE_SCOMTakeoverUID",nil,true];
+                        if ([_session,"targetWasLeader",false] call ALiVE_fnc_hashGet) then {
+                            [_logic,"opsApplyGroupLeadership",[_targetGroup,_selected,true]] call MAINCLASS;
+                        };
+                    };
+                };
+
+                if (!isNull _source) then {
+                    _source setVariable ["profileID",nil,true];
+                    _source setVariable ["profileIndex",nil,true];
+                    _source setVariable ["ALiVE_ignore_HC",nil,true];
+                };
+                if (_cleanupComplete) then {
+                    [_logic,"opsResumeProfileWaypoints",[_playerID,_profileID,_profile,_targetGroup]] call MAINCLASS;
+                };
+            } else {
+                private _prep = [_logic,_prepKey,[]] call ALiVE_fnc_hashGet;
+                if (count _prep >= 2) then {_profileID = _prep select 1};
+            };
+
+            if (_cleanupComplete && {_profileID != ""}) then {
+                [_logic,"opsReleaseProfilePin",[_playerID,_profileID]] call MAINCLASS;
+            };
+            if (_cleanupComplete) then {
+                [_logic,format ["opsInstantJoinCancelled_%1",_playerID],true] call ALiVE_fnc_hashSet;
+                [_logic,_prepKey,[]] call ALiVE_fnc_hashSet;
+                [_logic,_sessionKey,[]] call ALiVE_fnc_hashSet;
+            };
+        };
+
+    };
+
+    case "opsCancelJoinActive": {
+
+        if (_args isEqualType [] && {count _args >= 1}) then {
+            private _playerID = _args select 0;
+            private _sessionKey = format ["opsInstantJoinSession_%1",_playerID];
+            private _prepKey = format ["opsInstantJoinPrep_%1",_playerID];
+            private _session = [_logic,_sessionKey,[]] call ALiVE_fnc_hashGet;
+            private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
+
+            if (_session isEqualTo []) exitWith {
+                private _position = if (isNull _player) then {[]} else {getPosATL _player};
+                [_logic,"opsCancelJoinPrep",[_playerID,_position]] call MAINCLASS;
+                if (!isNull _player) then {
+                    _player allowDamage true;
+                    ["OPS_JOIN_RESTORE_RESULT",[true,"NO_ACTIVE_SESSION"]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+                };
+            };
+
+            _player = [_session,"player",_player] call ALiVE_fnc_hashGet;
+            private _selected = [_session,"selected",objNull] call ALiVE_fnc_hashGet;
+
+            if (isNull _player || {!alive _player}) exitWith {
+                [_logic,"opsJoinPlayerKilled",[_playerID,_player]] call MAINCLASS;
+            };
+
+            private _status = [_session,"status",""] call ALiVE_fnc_hashGet;
+            if (_status == "RESTORING") exitWith {};
+            if (_status in ["AWAITING_RESPAWN","RESPAWN_PROCESSING","CHOOSING_REPLACEMENT"]) exitWith {
+                private _profileID = [_session,"profileID",""] call ALiVE_fnc_hashGet;
+                private _profile = [_session,"profile",[]] call ALiVE_fnc_hashGet;
+                private _targetGroup = [_session,"targetGroup",grpNull] call ALiVE_fnc_hashGet;
+                [_logic,"opsResumeProfileWaypoints",[_playerID,_profileID,_profile,_targetGroup]] call MAINCLASS;
+                if (_profileID != "") then {[_logic,"opsReleaseProfilePin",[_playerID,_profileID]] call MAINCLASS};
+                _player hideObjectGlobal false;
+                _player allowDamage true;
+                _player setVariable ["profileID",nil,true];
+                _player setVariable ["profileIndex",nil,true];
+                _player setVariable ["ALiVE_ignore_HC",nil,true];
+                [_logic,_prepKey,[]] call ALiVE_fnc_hashSet;
+                [_logic,_sessionKey,[]] call ALiVE_fnc_hashSet;
+                ["OPS_JOIN_RESTORE_RESULT",[true,"CANCELLED_REPLACEMENT_SELECTION"]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+            };
+
+            private _captureVehicleRole = {
+                params ["_unit"];
+                private _vehicle = vehicle _unit;
+                if (_vehicle isEqualTo _unit) exitWith {[objNull,[]]};
+                private _rowIndex = (fullCrew [_vehicle,"",false]) findIf {(_x select 0) isEqualTo _unit};
+                if (_rowIndex < 0) exitWith {[_vehicle,[]]};
+                private _row = (fullCrew [_vehicle,"",false]) select _rowIndex;
+                [_vehicle,[toLower (_row param [1,"",[""]]),_row param [2,-1,[0]],_row param [3,[],[[]]]]]
+            };
+            private _currentVehicleRole = [_player] call _captureVehicleRole;
+            [_session,"currentTargetState",[
+                getPosATL _player,getDir _player,getUnitLoadout _player,damage _player,
+                _currentVehicleRole select 0,_currentVehicleRole select 1
+            ]] call ALiVE_fnc_hashSet;
+
+            private _originalGroup = [_session,"originalGroup",grpNull] call ALiVE_fnc_hashGet;
+            if (isNull _originalGroup) then {
+                _originalGroup = createGroup ([_session,"originalSide",side _player] call ALiVE_fnc_hashGet);
+                [_session,"originalGroup",_originalGroup] call ALiVE_fnc_hashSet;
+            };
+
+            [_player] joinSilent _originalGroup;
+            private _joinDeadline = diag_tickTime + 8;
+            waitUntil {
+                sleep 0.1;
+                (group _player isEqualTo _originalGroup) || {diag_tickTime >= _joinDeadline}
+            };
+
+            if !(group _player isEqualTo _originalGroup) exitWith {
+                ["OPS_JOIN_RESTORE_RESULT",[false,"ORIGINAL_GROUP_JOIN_FAILED"]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+            };
+
+            [_session,"status","RESTORING"] call ALiVE_fnc_hashSet;
+            [_logic,_sessionKey,_session] call ALiVE_fnc_hashSet;
+            ["OPS_JOIN_RESTORE",[
+                _playerID,_player,_originalGroup,[_session,"originalState"] call ALiVE_fnc_hashGet
+            ]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+        };
+
+    };
+
+    case "opsJoinRestoreComplete": {
+
+        if (_args isEqualType [] && {count _args >= 2}) then {
+            _args params ["_playerID","_success"];
+            private _sessionKey = format ["opsInstantJoinSession_%1",_playerID];
+            private _prepKey = format ["opsInstantJoinPrep_%1",_playerID];
+            private _session = [_logic,_sessionKey,[]] call ALiVE_fnc_hashGet;
+            if !(_session isEqualTo []) then {
+                private _player = [_session,"player",objNull] call ALiVE_fnc_hashGet;
+                private _selected = [_session,"selected",objNull] call ALiVE_fnc_hashGet;
+                private _targetGroup = [_session,"targetGroup",grpNull] call ALiVE_fnc_hashGet;
+                private _currentState = [_session,"currentTargetState",[]] call ALiVE_fnc_hashGet;
+                private _profile = [_session,"profile",[]] call ALiVE_fnc_hashGet;
+                private _profileID = [_session,"profileID",""] call ALiVE_fnc_hashGet;
+                private _roleRestored = true;
+
+                if ([_session,"selectedDeleted",false] call ALiVE_fnc_hashGet) then {
+                    _roleRestored = count _currentState >= 6;
+                    private _snapshot = +([_session,"targetSnapshot",[]] call ALiVE_fnc_hashGet);
+                    if (_roleRestored && {count _snapshot >= 11}) then {
+                        _snapshot set [1,_currentState select 0];
+                        _snapshot set [2,_currentState select 1];
+                        _snapshot set [4,_currentState select 2];
+                        _snapshot set [5,_currentState select 3];
+                        _snapshot set [6,_currentState select 4];
+                        _snapshot set [7,_currentState select 5];
+
+                        private _profileUnits = if (_profile isEqualType []) then {[_profile,"units",[]] call ALiVE_fnc_hashGet} else {[]};
+                        private _profileIndex = if (_profileUnits isEqualType []) then {_profileUnits find _player} else {-1};
+                        if (_profileIndex < 0) then {_profileIndex = [_session,"profileIndex",-1] call ALiVE_fnc_hashGet};
+                        private _recreate = [_logic,"opsRecreateTakeoverUnit",[
+                            _playerID,_targetGroup,_snapshot,_profileID,_profileIndex,[_session,"targetWasLeader",false] call ALiVE_fnc_hashGet
+                        ]] call MAINCLASS;
+                        _roleRestored = _recreate select 0;
+                        if (_roleRestored) then {
+                            _selected = _recreate select 2;
+                            if (_profileUnits isEqualType [] && {_profileIndex >= 0} && {_profileIndex < count _profileUnits}) then {
+                                _profileUnits set [_profileIndex,_selected];
+                                [_profile,"units",_profileUnits] call ALiVE_fnc_hashSet;
+                            };
+                            if ([_session,"targetWasLeader",false] call ALiVE_fnc_hashGet && {_profile isEqualType []} && {!(_profile isEqualTo [])}) then {
+                                [_profile,"leader",_selected] call ALiVE_fnc_hashSet
+                            };
+                            [_session,"selected",_selected] call ALiVE_fnc_hashSet;
+                        };
+                    } else {
+                        _roleRestored = false;
+                    };
+                    _success = _success && _roleRestored;
+                };
+
+                if (!([_session,"selectedDeleted",false] call ALiVE_fnc_hashGet) && {!isNull _selected} && {count _currentState >= 6}) then {
+                    if (!isNull _targetGroup && {!(_selected in units _targetGroup)}) then {
+                        [_selected] joinSilent _targetGroup;
+                        private _joinDeadline = diag_tickTime + 8;
+                        waitUntil {
+                            sleep 0.1;
+                            (group _selected isEqualTo _targetGroup) || {diag_tickTime >= _joinDeadline}
+                        };
+                        _success = _success && {group _selected isEqualTo _targetGroup};
+                    };
+                    _currentState params ["_position","_direction","_loadout","_damage","_vehicle","_vehicleRole"];
+                    _selected enableSimulationGlobal true;
+                    moveOut _selected;
+                    unassignVehicle _selected;
+                    if (count _loadout > 0) then {_selected setUnitLoadout _loadout};
+                    _selected setDir _direction;
+                    _selected setPosATL _position;
+                    _selected setDamage (_damage min 0.95);
+
+                    if (!isNull _vehicle && {alive _vehicle} && {count _vehicleRole > 0}) then {
+                        private _roleKind = toLower (_vehicleRole param [0,"",[""]]);
+                        switch (_roleKind) do {
+                            case "driver": {_selected assignAsDriver _vehicle; _selected moveInDriver _vehicle};
+                            case "gunner": {_selected assignAsGunner _vehicle; _selected moveInGunner _vehicle};
+                            case "commander": {_selected assignAsCommander _vehicle; _selected moveInCommander _vehicle};
+                            case "turret": {
+                                private _turretPath = _vehicleRole param [2,[],[[]]];
+                                _selected assignAsTurret [_vehicle,_turretPath];
+                                _selected moveInTurret [_vehicle,_turretPath];
+                            };
+                            case "cargo": {
+                                private _cargoIndex = _vehicleRole param [1,-1,[0]];
+                                if (_cargoIndex >= 0) then {
+                                    _selected assignAsCargoIndex [_vehicle,_cargoIndex];
+                                    _selected moveInCargo [_vehicle,_cargoIndex];
+                                } else {
+                                    _selected assignAsCargo _vehicle;
+                                    _selected moveInCargo _vehicle;
+                                };
+                            };
+                        };
+                    };
+
+                    _selected allowDamage true;
+                    _selected hideObjectGlobal false;
+                    _selected setVariable ["ALiVE_SCOMTakeoverUID",nil,true];
+                    if (!isNull _targetGroup && {[_session,"targetWasLeader",false] call ALiVE_fnc_hashGet}) then {
+                        [_logic,"opsApplyGroupLeadership",[_targetGroup,_selected,true]] call MAINCLASS;
+                    };
+                };
+
+                private _originalGroup = [_session,"originalGroup",grpNull] call ALiVE_fnc_hashGet;
+                if (!isNull _player) then {
+                    _player hideObjectGlobal false;
+                    if (_roleRestored) then {
+                        _player setVariable ["profileID",nil,true];
+                        _player setVariable ["profileIndex",nil,true];
+                        _player setVariable ["ALiVE_ignore_HC",nil,true];
+                    };
+                    if (!isNull _originalGroup && {[_session,"originalWasLeader",false] call ALiVE_fnc_hashGet}) then {
+                        [_logic,"opsApplyGroupLeadership",[_originalGroup,_player,true]] call MAINCLASS;
+                    };
+                };
+
+                if (_roleRestored) then {
+                    [_logic,"opsResumeProfileWaypoints",[_playerID,_profileID,_profile,_targetGroup]] call MAINCLASS;
+                    if (_profileID != "") then {
+                        [_logic,"opsReleaseProfilePin",[_playerID,_profileID]] call MAINCLASS;
+                    };
+                    [_logic,_prepKey,[]] call ALiVE_fnc_hashSet;
+                    [_logic,_sessionKey,[]] call ALiVE_fnc_hashSet;
+                } else {
+                    [_session,"status","RECREATE_FAILED"] call ALiVE_fnc_hashSet;
+                    [_logic,_sessionKey,_session] call ALiVE_fnc_hashSet;
+                };
+
+                if (!isNull _player) then {
+                    ["OPS_JOIN_RESTORE_RESULT",[_success,if (_success) then {"RESTORED"} else {"RESTORE_FAILED"}]] remoteExecCall ["ALiVE_fnc_SCOMTabletEventToClient",_player];
+                };
+            };
+        };
+
+    };
+
+    case "opsCancelJoinPrep": {
+
+        if (_args isEqualType [] && {count _args >= 2}) then {
+            _args params ["_playerID","_initialPosition"];
+            [_logic,format ["opsInstantJoinCancelled_%1",_playerID],true] call ALiVE_fnc_hashSet;
+            private _player = [_playerID] call ALiVE_fnc_getPlayerByUID;
+
+            private _prepKey = format ["opsInstantJoinPrep_%1",_playerID];
+            private _prep = [_logic,_prepKey,[]] call ALiVE_fnc_hashGet;
+            if (count _prep >= 2) then {
+                [_logic,"opsReleaseProfilePin",[_playerID,_prep select 1]] call MAINCLASS;
+                [_logic,_prepKey,[]] call ALiVE_fnc_hashSet;
+            };
+
+            if (!isNull _player) then {
+                if (_initialPosition isEqualType [] && {count _initialPosition >= 2}) then {
+                    _player setPos _initialPosition;
+                };
+                _player hideObjectGlobal false;
             };
         };
 

--- a/addons/sup_group_manager/data/ui/common.hpp
+++ b/addons/sup_group_manager/data/ui/common.hpp
@@ -1,9 +1,9 @@
-#define GUI_GRID_X  (0)
-#define GUI_GRID_Y  (0)
-#define GUI_GRID_W  (0.025)
-#define GUI_GRID_H  (0.04)
-#define GUI_GRID_WAbs (1)
-#define GUI_GRID_HAbs (1)
+#define GUI_GRID_HAbs        (1.14 * safezoneH)
+#define GUI_GRID_WAbs        (1.2 * GUI_GRID_HAbs)
+#define GUI_GRID_W           (GUI_GRID_WAbs / 40)
+#define GUI_GRID_H           (GUI_GRID_HAbs / 25)
+#define GUI_GRID_X           (safezoneX + (safezoneW - GUI_GRID_WAbs) / 2)
+#define GUI_GRID_Y           (safezoneY + (safezoneH - GUI_GRID_HAbs) / 2)
 
 class RscPicture;
 
@@ -48,7 +48,7 @@ class GMTablet_RscText
     type = 13;
     style = 0x00;
     colorBackground[] = { 0, 0, 0, 0 };
-    size = "((safeZoneW / 75) + (safeZoneH / 225))";
+    size = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 6)";
     y = "safeZoneY + (safeZoneH / 6)";
     w = "safeZoneW / 5";
@@ -124,7 +124,7 @@ class GMTablet_RscRealButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};
@@ -188,7 +188,7 @@ class GMTablet_RscButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};
@@ -230,7 +230,7 @@ class GMTablet_RscListNBox {
     type = 102;
     shadow = 0;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -271,7 +271,7 @@ class GMTablet_RscListBox {
     type = 5;
     style = 0 + 0x10;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -314,7 +314,7 @@ class GMTablet_RscGUIListBox : GMTablet_RscListBox {
     colorSelectBackground[] = {0.333,0.333,0.333,1};
     colorSelectBackground2[] = {0.333,0.333,0.333,1};
     period = 0;
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     class ListScrollBar
     {
         color[] = {1, 1, 1, 0.6};
@@ -364,7 +364,7 @@ class GMTablet_RscComboBox
     colorActive[] = {0,0,0,1};
     colorDisabled[] = {0,0,0,0.3};
     font = "PuristaMedium";
-    sizeEx = "(safeZoneH / 100) + (safeZoneH / 100)";
+    sizeEx = 0.5 * GUI_GRID_H;
 };
 
 class GMTablet_RscMap

--- a/addons/sup_group_manager/data/ui/main.hpp
+++ b/addons/sup_group_manager/data/ui/main.hpp
@@ -13,10 +13,10 @@ class GMTablet
         class GMTablet_background : RscPicture
         {
             idc = 11002;
-            x = 0.142424 * safezoneW + safezoneX;
-            y = 0.0632 * safezoneH + safezoneY;
-            w = 0.73 * safezoneW;
-            h = 0.84 * safezoneH;
+            x = 0.142424 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.0632 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.73 * GUI_GRID_WAbs;
+            h = 0.84 * GUI_GRID_HAbs;
             text = "x\alive\addons\main\data\ui\ALiVE_toughbook.paa";
             moving = 0;
             colorBackground[] = {0,0,0,0};
@@ -30,10 +30,10 @@ class GMTablet
         {
             idc = 11007;
             text = "";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.1430 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1430 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -52,11 +52,11 @@ class GMTablet
             idc = 11006;
             text = "Back";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.7000 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.7000 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.376,0.196,0.204,1};
             colorText[] = {0.706,0.706,0.706,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
@@ -68,11 +68,11 @@ class GMTablet
             idc = 11010;
             text = "Close";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.7350 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.7350 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.376,0.196,0.204,1};
             colorText[] = {0.706,0.706,0.706,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
@@ -85,10 +85,10 @@ class GMTablet
         class GMTablet_TerrainButton : GMTablet_RscRealButton
         {
             idc = 11050;
-            x = 0.686 * safezoneW + safezoneX;
-            y = 0.098 * safezoneH + safezoneY;
-            w = 0.0597643 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.686 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.098 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0597643 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Terrain";
             periodFocus = 1e10;
             periodOver = 1e10;
@@ -97,25 +97,25 @@ class GMTablet
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.384,0.439,0.341,1};
             colorFocused[] = {0.706,0.706,0.706,1};
-            sizeEx = 0.9 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
         };
 
         class GMTablet_mainList : GMTablet_RscListNBox
         {
             idc = 11011;
             text = "";
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.5 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.5 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorSelectBackground[] = {0.3,0.3,0.3,1};
             colorSelectBackground2[] = {0.3,0.3,0.3,1};
             colorText[] = {0.6,0.6,0.6,1};
             color[] = {0.8,0.8,0.8,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
             columns[] = {0,0.07,0.6,0.8};
             drawSideArrows = false;
             idcLeft = -1;
@@ -126,18 +126,18 @@ class GMTablet
         {
             idc = 11012;
             text = "";
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.45 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.45 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorSelectBackground[] = {0.3,0.3,0.3,1};
             colorSelectBackground2[] = {0.3,0.3,0.3,1};
             colorText[] = {0.5,0.5,0.5,1};
             color[] = {0.5,0.5,0.5,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
             columns[] = {0,0.2,0.6,0.8};
             drawSideArrows = false;
             idcLeft = -1;
@@ -148,18 +148,18 @@ class GMTablet
         {
             idc = 11013;
             text = "";
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.45 * safezoneH;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.45 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorSelectBackground[] = {0.3,0.3,0.3,1};
             colorSelectBackground2[] = {0.3,0.3,0.3,1};
             colorText[] = {0.5,0.5,0.5,1};
             color[] = {0.5,0.5,0.5,1};
             colorActive[] = {0.3,0.3,0.3,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
             columns[] = {0,0.2,0.5,0.7};
             drawSideArrows = false;
             idcLeft = -1;
@@ -169,12 +169,12 @@ class GMTablet
         class GMTablet_1ButtonL : GMTablet_RscButton
         {
             idc = 11014;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6150 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6150 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button1";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -183,12 +183,12 @@ class GMTablet
         class GMTablet_2ButtonL : GMTablet_RscButton
         {
             idc = 11015;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6480 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6480 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button2";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -197,12 +197,12 @@ class GMTablet
         class GMTablet_3ButtonL : GMTablet_RscButton
         {
             idc = 11016;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6810 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6810 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button3";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -211,12 +211,12 @@ class GMTablet
         class GMTablet_1ButtonR : GMTablet_RscButton
         {
             idc = 11017;
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.6150 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6150 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button1";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -225,12 +225,12 @@ class GMTablet
         class GMTablet_2ButtonR : GMTablet_RscButton
         {
             idc = 11018;
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.6480 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6480 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button2";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -239,12 +239,12 @@ class GMTablet
         class GMTablet_3ButtonR : GMTablet_RscButton
         {
             idc = 11019;
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.6810 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6810 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button3";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -253,19 +253,19 @@ class GMTablet
         class GMTablet_left_map : GMTablet_RscMap
         {
             idc = 11020;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.45 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.45 * GUI_GRID_HAbs;
         };
 
         class GMTablet_right_map : GMTablet_RscMap
         {
             idc = 11021;
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.45 * safezoneH;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.45 * GUI_GRID_HAbs;
         };
 
     };

--- a/addons/sup_group_manager/fnc_GM.sqf
+++ b/addons/sup_group_manager/fnc_GM.sqf
@@ -404,13 +404,17 @@ switch(_operation) do {
                         case "Mapbag01": {
                             createDialog "GMTablet";
 
+                            private _uiW = (safezoneW / safezoneH) min 1.2;
+                            private _uiH = _uiW / 1.2;
+                            private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+                            private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                             private _ctrlBackground = ((findDisplay 11001) displayCtrl 11002);
                             _ctrlBackground ctrlsettext "x\alive\addons\main\data\ui\ALiVE_mapbag.paa";
                             _ctrlBackground ctrlSetPosition [
-                                0.15 * safezoneW + safezoneX,
-                                -0.242 * safezoneH + safezoneY,
-                                0.72 * safezoneW,
-                                1.372 * safezoneH
+                                0.15 * _uiW + _uiX,
+                                -0.242 * _uiH + _uiY,
+                                0.72 * _uiW,
+                                1.372 * _uiH
                             ];
                             _ctrlBackground ctrlCommit 0;
                         };

--- a/addons/sup_player_resupply/data/ui/common.hpp
+++ b/addons/sup_player_resupply/data/ui/common.hpp
@@ -1,9 +1,9 @@
-#define GUI_GRID_X  (0)
-#define GUI_GRID_Y  (0)
-#define GUI_GRID_W  (0.025)
-#define GUI_GRID_H  (0.04)
-#define GUI_GRID_WAbs (1)
-#define GUI_GRID_HAbs (1)
+#define GUI_GRID_HAbs        (1.14 * safezoneH)
+#define GUI_GRID_WAbs        (1.2 * GUI_GRID_HAbs)
+#define GUI_GRID_W           (GUI_GRID_WAbs / 40)
+#define GUI_GRID_H           (GUI_GRID_HAbs / 25)
+#define GUI_GRID_X           (safezoneX + (safezoneW - GUI_GRID_WAbs) / 2)
+#define GUI_GRID_Y           (safezoneY + (safezoneH - GUI_GRID_HAbs) / 2)
 
 class RscPicture;
 
@@ -47,7 +47,7 @@ class PRTablet_RscText
     type = 13;
     style = 0x00;
     colorBackground[] = { 0, 0, 0, 0 };
-    size = "((safeZoneW / 75) + (safeZoneH / 225))";
+    size = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 6)";
     y = "safeZoneY + (safeZoneH / 6)";
     w = "safeZoneW / 5";
@@ -86,7 +86,7 @@ class PRTablet_RscListBox {
     type = 5;
     style = 0 + 0x10;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -125,7 +125,7 @@ class PRTablet_RscListNBox {
     type = 102;
     shadow = 0;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -171,7 +171,7 @@ class PRTablet_RscGUIListBox : PRTablet_RscListBox {
     colorSelectBackground[] = {0.333,0.333,0.333,1};
     colorSelectBackground2[] = {0.333,0.333,0.333,1};
     period = 0;
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     class ListScrollBar
     {
         color[] = {1, 1, 1, 0.6};
@@ -221,7 +221,7 @@ class PRTablet_RscComboBox
     colorActive[] = {0,0,0,1};
     colorDisabled[] = {0,0,0,0.3};
     font = "PuristaMedium";
-    sizeEx = "(safeZoneH / 100) + (safeZoneH / 100)";
+    sizeEx = 0.5 * GUI_GRID_H;
 };
 
 // #698 real CT_BUTTON (type 1) base for the Terrain toggle. The tablet's other buttons are
@@ -265,7 +265,7 @@ class PRTablet_RscRealButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};
@@ -329,7 +329,7 @@ class PRTablet_RscButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};

--- a/addons/sup_player_resupply/data/ui/main.hpp
+++ b/addons/sup_player_resupply/data/ui/main.hpp
@@ -13,10 +13,10 @@ class PRTablet
         class GMTablet_background : RscPicture
         {
             idc = 60000;
-            x = 0.142424 * safezoneW + safezoneX;
-            y = 0.0632 * safezoneH + safezoneY;
-            w = 0.73 * safezoneW;
-            h = 0.84 * safezoneH;
+            x = 0.142424 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.0632 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.73 * GUI_GRID_WAbs;
+            h = 0.84 * GUI_GRID_HAbs;
             text = "x\alive\addons\main\data\ui\ALiVE_toughbook.paa";
             moving = 0;
             colorBackground[] = {0,0,0,0};
@@ -29,10 +29,10 @@ class PRTablet
         class PRTablet_map : PRTablet_RscMap
         {
             idc = 60002;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.1584 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.4 * safezoneH;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1584 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.4 * GUI_GRID_HAbs;
         };
 
         class PRTablet_status : PRTablet_RscButton
@@ -40,12 +40,12 @@ class PRTablet
             idc = 60025;
             text = "Show Status";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.7000 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.7000 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             colorBackground[] = {0.384,0.439,0.341,1};
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
         };
@@ -55,12 +55,12 @@ class PRTablet
             idc = 60003;
             text = "Send Request";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.6650 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6650 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             colorBackground[] = {0.384,0.439,0.341,1};
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
         };
@@ -70,11 +70,11 @@ class PRTablet
             idc = 60004;
             text = "Close";
             style = 0x02;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.7350 * safezoneH + safezoneY;
-            w = 0.216525 * safezoneW;
-            h = 0.028 * safezoneH;
-            sizeEx = 0.8 * GUI_GRID_H;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.7350 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.216525 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.376,0.196,0.204,1};
             colorText[] = {0.706,0.706,0.706,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
@@ -87,10 +87,10 @@ class PRTablet
         class PRTablet_TerrainButton : PRTablet_RscRealButton
         {
             idc = 60050;
-            x = 0.686 * safezoneW + safezoneX;
-            y = 0.098 * safezoneH + safezoneY;
-            w = 0.0597643 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.686 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.098 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0597643 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Terrain";
             periodFocus = 1e10; // never blink
             periodOver = 1e10;
@@ -99,17 +99,17 @@ class PRTablet
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.384,0.439,0.341,1};
             colorFocused[] = {0.706,0.706,0.706,1};
-            sizeEx = 0.9 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
         };
 
         class PRTablet_currentForcePool : PRTablet_RscText
         {
             text = "";
             idc = 60099;
-            x = 0.6462 * safezoneW + safezoneX;
-            y = 0.6450 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.6462 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6450 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -127,10 +127,10 @@ class PRTablet
         {
             text = "";
             idc = 60012;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.5700 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5700 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -148,10 +148,10 @@ class PRTablet
         {
             text = "";
             idc = 60023;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.5850 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5850 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -169,10 +169,10 @@ class PRTablet
         {
             text = "";
             idc = 60013;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.6000 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6000 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -190,10 +190,10 @@ class PRTablet
         {
             text = "";
             idc = 60014;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.6150 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6150 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -211,10 +211,10 @@ class PRTablet
         {
             text = "";
             idc = 60015;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.6300 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6300 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -232,10 +232,10 @@ class PRTablet
         {
             text = "";
             idc = 60016;
-            x = 0.519796 * safezoneW + safezoneX;
-            y = 0.6450 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.025 * safezoneH;
+            x = 0.519796 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6450 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.025 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -253,10 +253,10 @@ class PRTablet
         {
             idc = 60017;
             text = "Delivery Type  -  How your request will be transported";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.1430 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1430 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -273,24 +273,24 @@ class PRTablet
         class PRTablet_deliveryList : PRTablet_RscGUIListBox
         {
             idc = 60005;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.06 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.06 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class PRTablet_supplyTitle : PRTablet_RscText
         {
             idc = 60018;
             text = "Supply List  -  Vehicles and equipment to include in the payload";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.2230 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.2230 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -307,24 +307,24 @@ class PRTablet
         class PRTablet_supplyList : PRTablet_RscGUIListBox
         {
             idc = 60006;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.2400 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.13 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.2400 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.13 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class PRTablet_reinforceTitle : PRTablet_RscText
         {
             idc = 60019;
             text = "Reinforce  -  Personnel and groups to include in the payload";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.3730 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.3730 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -341,24 +341,24 @@ class PRTablet
         class PRTablet_reinforceList : PRTablet_RscGUIListBox
         {
             idc = 60007;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.3892 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.13 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.3892 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.13 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class PRTablet_selectedTitle : PRTablet_RscText
         {
             idc = 60020;
             text = "Payload  -  Your current request contents";
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.5230 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5230 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -375,24 +375,24 @@ class PRTablet
         class PRTablet_selectedList : PRTablet_RscGUIListBox
         {
             idc = 60008;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.5400 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.1 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.5400 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.1 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class PRTablet_selectedInfo : PRTablet_RscText
         {
             text = "";
             idc = 60009;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6730 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6730 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -409,12 +409,12 @@ class PRTablet
         class PRTablet_selectedDelete : PRTablet_RscButton
         {
             idc = 60010;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6400 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6400 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Delete";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -423,24 +423,24 @@ class PRTablet
         class PRTablet_selectedOptionList : PRTablet_RscGUIListBox
         {
             idc = 60011;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.6900 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.06 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6900 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.06 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
         };
 
         class PRTablet_requestedStatusTitle : PRTablet_RscText
         {
             text = "";
             idc = 60021;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.1430 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
-            h = 0.0308 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1430 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
+            h = 0.0308 * GUI_GRID_HAbs;
             colorBackground[] = {0,0,0,0};
             class Attributes
             {
@@ -458,10 +458,10 @@ class PRTablet
         {
             text = "";
             idc = 60022;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.2200 * safezoneH + safezoneY;
-            w = 0.241271 * safezoneW;
-            h = 0.2 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.2200 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.241271 * GUI_GRID_WAbs;
+            h = 0.2 * GUI_GRID_HAbs;
             style = 528;
             colorBackground[] = {0,0,0,0};
             class Attributes
@@ -480,18 +480,18 @@ class PRTablet
         {
             idc = 60024;
             text = "";
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.45 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.45 * GUI_GRID_HAbs;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorSelectBackground[] = {0.3,0.3,0.3,1};
             colorSelectBackground2[] = {0.3,0.3,0.3,1};
             colorText[] = {0.6,0.6,0.6,1};
             color[] = {0.8,0.8,0.8,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
             columns[] = {0,0.07,0.6,0.8};
             drawSideArrows = false;
             idcLeft = -1;
@@ -501,12 +501,12 @@ class PRTablet
         class PRTablet_1ButtonL : PRTablet_RscButton
         {
             idc = 60026;
-            x = 0.271203 * safezoneW + safezoneX;
-            y = 0.6150 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.271203 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6150 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button1";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -515,12 +515,12 @@ class PRTablet
         class PRTablet_1ButtonR : PRTablet_RscButton
         {
             idc = 60027;
-            x = 0.507 * safezoneW + safezoneX;
-            y = 0.6150 * safezoneH + safezoneY;
-            w = 0.2325 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.507 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6150 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2325 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Button1";
-            sizeEx = 0.8 * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
@@ -529,10 +529,10 @@ class PRTablet
         class PRTablet_status_map : PRTablet_RscMap
         {
             idc = 60028;
-            x = 0.271102 * safezoneW + safezoneX;
-            y = 0.1600 * safezoneH + safezoneY;
-            w = 0.465 * safezoneW;
-            h = 0.45 * safezoneH;
+            x = 0.271102 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.1600 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.465 * GUI_GRID_WAbs;
+            h = 0.45 * GUI_GRID_HAbs;
         };
 
     };

--- a/addons/sup_player_resupply/fnc_PR.sqf
+++ b/addons/sup_player_resupply/fnc_PR.sqf
@@ -1740,13 +1740,17 @@ switch(_operation) do {
                         case "Mapbag01": {
                             createDialog "PRTablet";
 
+                            private _uiW = (safezoneW / safezoneH) min 1.2;
+                            private _uiH = _uiW / 1.2;
+                            private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+                            private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                             private _ctrlBackground = ((findDisplay 60001) displayCtrl 60000);
                             _ctrlBackground ctrlsettext "x\alive\addons\main\data\ui\ALiVE_mapbag.paa";
                             _ctrlBackground ctrlSetPosition [
-                                0.15 * safezoneW + safezoneX,
-                                -0.242 * safezoneH + safezoneY,
-                                0.72 * safezoneW,
-                                1.372 * safezoneH
+                                0.15 * _uiW + _uiX,
+                                -0.242 * _uiH + _uiY,
+                                0.72 * _uiW,
+                                1.372 * _uiH
                             ];
                             _ctrlBackground ctrlCommit 0;
                         };

--- a/addons/sys_patrolrep/data/ui/common.hpp
+++ b/addons/sys_patrolrep/data/ui/common.hpp
@@ -1,9 +1,9 @@
-#define GUI_GRID_X  (0)
-#define GUI_GRID_Y  (0)
-#define GUI_GRID_W  (0.025)
-#define GUI_GRID_H  (0.04)
-#define GUI_GRID_WAbs (1)
-#define GUI_GRID_HAbs (1)
+#define GUI_GRID_HAbs        (1.14 * safezoneH)
+#define GUI_GRID_WAbs        (1.2 * GUI_GRID_HAbs)
+#define GUI_GRID_W           (GUI_GRID_WAbs / 40)
+#define GUI_GRID_H           (GUI_GRID_HAbs / 25)
+#define GUI_GRID_X           (safezoneX + (safezoneW - GUI_GRID_WAbs) / 2)
+#define GUI_GRID_Y           (safezoneY + (safezoneH - GUI_GRID_HAbs) / 2)
 
 class RscPicture;
 
@@ -106,7 +106,7 @@ class patrolrep_RscListBox {
     type = 5;
     style = 0 + 0x10;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -149,7 +149,7 @@ class patrolrep_RscGUIListBox : patrolrep_RscListBox {
     colorSelectBackground[] = {0.333,0.333,0.333,1};
     colorSelectBackground2[] = {0.333,0.333,0.333,1};
     period = 0;
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     class ListScrollBar
     {
         color[] = {1, 1, 1, 0.6};
@@ -167,7 +167,7 @@ class patrolrep_RscGUIListBox_multi
     style = 0x10 + 0x20;
     type = 5;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -238,7 +238,7 @@ class patrolrep_RscComboBox
     wholeHeight = 0.45;
     colorDisabled[] = {0,0,0,0};
     font = "PuristaMedium";
-    sizeEx = "(safeZoneH / 100) + (safeZoneH / 100)";
+    sizeEx = 0.5 * GUI_GRID_H;
 };
 
 // #698 real CT_BUTTON (type 1) base for the Terrain toggle. The report form's other buttons are
@@ -282,7 +282,7 @@ class patrolrep_RscRealButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};
@@ -346,7 +346,7 @@ class patrolrep_RscButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};

--- a/addons/sys_patrolrep/data/ui/main.hpp
+++ b/addons/sys_patrolrep/data/ui/main.hpp
@@ -12,10 +12,10 @@ class RscDisplayALiVEPATROLREP
          class patrolrep_Background : RscPicture
         {
             idc = 90003;
-            x = 0.142424 * safezoneW + safezoneX;
-            y = 0.0632 * safezoneH + safezoneY;
-            w = 0.73 * safezoneW;
-            h = 0.84 * safezoneH;
+            x = 0.142424 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.0632 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.73 * GUI_GRID_WAbs;
+            h = 0.84 * GUI_GRID_HAbs;
             text = "x\alive\addons\main\data\ui\ALiVE_toughbook.paa";
             moving = 1;
             colorBackground[] = {0,0,0,0};
@@ -27,18 +27,18 @@ class RscDisplayALiVEPATROLREP
         class patrolrep_Map: patrolrep_RscMap
         {
             idc = 1;
-            x = 0.586496 * safezoneW + safezoneX;
-            y = 0.158313 * safezoneH + safezoneY;
-            w = 0.159796 * safezoneW;
-            h = 0.308024 * safezoneH;
+            x = 0.586496 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.158313 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159796 * GUI_GRID_WAbs;
+            h = 0.308024 * GUI_GRID_HAbs;
         };
         class patrolrep_MainTitle: patrolrep_RscText
         {
             idc = 2;
             text = "PATROL REPORT (PATROLREP)"; //--- ToDo: Localize;
-            x = 0.263812 * safezoneW + safezoneX;
-            y = 0.162713 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
+            x = 0.263812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.162713 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
         };
         class patrolrep_Abort: patrolrep_RscButton
         {
@@ -46,29 +46,29 @@ class RscDisplayALiVEPATROLREP
             style = 2;
             action = "deleteMarkerLocal ALIVE_SYS_patrolrep_mapStartMarker; deleteMarkerLocal ALIVE_SYS_patrolrep_mapEndMarker; closeDialog 0";
             text = "CANCEL"; //--- ToDo: Localize;
-            x = 0.586496 * safezoneW + safezoneX;
-            y = 0.742019 * safezoneH + safezoneY;
-            w = 0.159796 * safezoneW;
-            h = 0.0220017 * safezoneH;
+            x = 0.586496 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.742019 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159796 * GUI_GRID_WAbs;
+            h = 0.0220017 * GUI_GRID_HAbs;
             colorBackground[] = {0.376,0.196,0.204,1};
             colorText[] = {0.706,0.706,0.706,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
-            sizeEx = 0.8 * GUI_GRID_H * GUI_GRID_H * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
         };
         class patrolrep_sendButton: patrolrep_RscButton
         {
             idc = 4;
             style = 2;
             text = "SEND PATROLREP"; //--- ToDo: Localize;
-            x = 0.586496 * safezoneW + safezoneX;
-            y = 0.714815 * safezoneH + safezoneY;
-            w = 0.159796 * safezoneW;
-            h = 0.0220017 * safezoneH;
+            x = 0.586496 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.714815 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159796 * GUI_GRID_WAbs;
+            h = 0.0220017 * GUI_GRID_HAbs;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
-            sizeEx = 0.8 * GUI_GRID_H * GUI_GRID_H * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             action = "call ALiVE_fnc_patrolrepButtonAction";
         };
         // #698 Terrain toggle - top-right of the header bezel (identical toughbook to the CS tablet,
@@ -76,10 +76,10 @@ class RscDisplayALiVEPATROLREP
         class patrolrep_TerrainButton: patrolrep_RscRealButton
         {
             idc = 90004;
-            x = 0.686 * safezoneW + safezoneX;
-            y = 0.098 * safezoneH + safezoneY;
-            w = 0.0597643 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.686 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.098 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0597643 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Terrain";
             periodFocus = 1e10; // never blink (0 can fall back to the default focus-pulse)
             periodOver = 1e10;
@@ -88,7 +88,7 @@ class RscDisplayALiVEPATROLREP
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.384,0.439,0.341,1}; // stay green on focus (matches the CS Terrain button)
             colorFocused[] = {0.706,0.706,0.706,1};
-            sizeEx = 0.9 * GUI_GRID_H; // 0.036 - readable label; the earlier cubed value (~0.00005) was invisible on a CT_BUTTON
+            sizeEx = 0.5 * GUI_GRID_H; // 0.036 - readable label; the earlier cubed value (~0.00005) was invisible on a CT_BUTTON
         };
         class patrolrep_DTGTEXT: patrolrep_RscText_Right
         {
@@ -96,18 +96,18 @@ class RscDisplayALiVEPATROLREP
             idc = 1004;
 
             text = "DTG:"; //--- ToDo: Localize;
-            x = 0.437834 * safezoneW + safezoneX;
-            y = 0.162713 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.437834 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.162713 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class patrolrep_DTGVALUE: RscText
         {
             idc = 5;
             sizeEx = "(            (            (            ((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 1)";
             style = 1;
-            x = 0.5 * safezoneW + safezoneX;
-            y = 0.162713 * safezoneH + safezoneY;
-            w = 0.070421 * safezoneW;
+            x = 0.5 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.162713 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.070421 * GUI_GRID_WAbs;
             class Attributes
             {
                 font = "PuristaMedium";
@@ -122,34 +122,34 @@ class RscDisplayALiVEPATROLREP
             idc = 6;
 
             text = "CALLSIGN:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.225979 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.225979 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class patrolrep_ValueCallsign: patrolrep_RscEdit
         {
             idc = 7;
 
-            x = 0.345668 * safezoneW + safezoneX;
-            y = 0.225979 * safezoneH + safezoneY;
-            w = 0.154641 * safezoneW;
+            x = 0.345668 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.225979 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.154641 * GUI_GRID_WAbs;
         };
         class patrolrep_SDATEText: patrolrep_RscText
         {
             idc = 8;
 
             text = "START TIME:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.258982 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.258982 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class patrolrep_SDATEVALUE: patrolrep_RscEdit
         {
             idc = 9;
 
-            x = 0.345668 * safezoneW + safezoneX;
-            y = 0.258982 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.345668 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.258982 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class patrolrep_SLOCTEXT: patrolrep_RscText_Right
         {
@@ -157,78 +157,78 @@ class RscDisplayALiVEPATROLREP
             style = 1;
 
             text = "START GRID:"; //--- ToDo: Localize;
-            x = 0.427834 * safezoneW + safezoneX;
-            y = 0.258982 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.427834 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.258982 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class patrolrep_SLOCVALUE: patrolrep_RscEdit
         {
             idc = 11;
 
-            x = 0.50 * safezoneW + safezoneX;
-            y = 0.258982 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.50 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.258982 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class patrolrep_EDATEText: patrolrep_RscText
         {
             idc = 40;
 
             text = "END TIME:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.291984 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.291984 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class patrolrep_EDATEVALUE: patrolrep_RscEdit
         {
             idc = 41;
 
-            x = 0.345668 * safezoneW + safezoneX;
-            y = 0.291984 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.345668 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.291984 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class patrolrep_ELOCTEXT: patrolrep_RscText_Right
         {
             idc = 12;
             text = "END GRID:"; //--- ToDo: Localize;
-            x = 0.427834 * safezoneW + safezoneX;
-            y = 0.291984 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.427834 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.291984 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class patrolrep_ELOCVALUE: patrolrep_RscEdit
         {
             idc = 13;
 
-            x = 0.50 * safezoneW + safezoneX;
-            y = 0.291984 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
-            h = 0.0176014 * safezoneH;
+            x = 0.50 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.291984 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
+            h = 0.0176014 * GUI_GRID_HAbs;
         };
         class PATCOMP_TEXT: patrolrep_RscText
         {
             idc = 14;
 
             text = "PATROL COMPOSITION:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.35799 * safezoneH + safezoneY;
-            w = 0.2 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.35799 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2 * GUI_GRID_WAbs;
         };
 
         class TASK_TEXT: patrolrep_RscText
         {
             idc = 18;
             text = "TASK SUMMARY:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.324987 * safezoneH + safezoneY;
-            w = 0.088 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.324987 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.088 * GUI_GRID_WAbs;
         };
         class SPOT_TEXT: patrolrep_RscText
         {
             idc = 20;
 
             text = "SPOTREPS:"; //--- ToDo: Localize;
-            x = 0.49 * safezoneW + safezoneX;
-            y = 0.467998 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.49 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.467998 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
 
         };
         class SIT_TEXT: patrolrep_RscText
@@ -236,9 +236,9 @@ class RscDisplayALiVEPATROLREP
             idc = 22;
 
             text = "SITREPS:"; //--- ToDo: Localize;
-            x = 0.49 * safezoneW + safezoneX;
-            y = 0.35799 * safezoneH + safezoneY;
-            w = 0.0780421 * safezoneW;
+            x = 0.49 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.35799 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0780421 * GUI_GRID_WAbs;
 
         };
         class ENBDA_TEXT: patrolrep_RscText
@@ -246,78 +246,78 @@ class RscDisplayALiVEPATROLREP
             idc = 24;
 
             text = "ENEMY/BDA:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.467998 * safezoneH + safezoneY;
-            w = 0.138318 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.467998 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.138318 * GUI_GRID_WAbs;
         };
         class SIT_VALUE: patrolrep_RscGUIListBox_multi
         {
             idc = 23;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
-            x = 0.49 * safezoneW + safezoneX;
-            y = 0.38 * safezoneH + safezoneY;
-            w = 0.0780421 * safezoneW;
-            h = 0.087829 * safezoneH;
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
+            x = 0.49 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.38 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0780421 * GUI_GRID_WAbs;
+            h = 0.087829 * GUI_GRID_HAbs;
         };
         class SPOT_VALUE: patrolrep_RscGUIListBox_multi
         {
             idc = 21;
             colorBackground[] = {0.173,0.173,0.173,1};
             colorActive[] = {0.384,0.439,0.341,1};
-            sizeEx = (safeZoneW / 75) + (safeZoneH / 275);
-            rowHeight = (safeZoneW / 75) + (safeZoneH / 275);
-            x = 0.49 * safezoneW + safezoneX;
-            y = 0.49 * safezoneH + safezoneY;
-            w = 0.0780421 * safezoneW;
-            h = 0.087829 * safezoneH;
+            sizeEx = 0.5 * GUI_GRID_H;
+            rowHeight = 0.55 * GUI_GRID_H;
+            x = 0.49 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.49 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0780421 * GUI_GRID_WAbs;
+            h = 0.087829 * GUI_GRID_HAbs;
         };
         class patrolrep_PATCOMPVALUE: patrolrep_RscEdit
         {
             idc = 15;
 
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.38 * safezoneH + safezoneY;
-            w = 0.2 * safezoneW;
-            h = 0.087829 * safezoneH;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.38 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2 * GUI_GRID_WAbs;
+            h = 0.087829 * GUI_GRID_HAbs;
         };
         class patrolrep_ENBDAVALUE: patrolrep_RscEdit
         {
             idc = 27;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.49 * safezoneH + safezoneY;
-            w = 0.2* safezoneW;
-            h = 0.087829 * safezoneH;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.49 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2* GUI_GRID_WAbs;
+            h = 0.087829 * GUI_GRID_HAbs;
         };
         class patrolrep_RESULTSTEXT: patrolrep_RscText
         {
             idc = 32;
             text = "RESULTS:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.578007 * safezoneH + safezoneY;
-            w = 0.270421 * safezoneW;
-            h = 0.0176014 * safezoneH;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.578007 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.270421 * GUI_GRID_WAbs;
+            h = 0.0176014 * GUI_GRID_HAbs;
         };
         class patrolrep_TASKVALUE: patrolrep_RscEdit
         {
             idc = 19;
 
-            x = 0.365668 * safezoneW + safezoneX;
-            y = 0.324987 * safezoneH + safezoneY;
-            w = 0.2 * safezoneW;
-            h = 0.0176014 * safezoneH;
+            x = 0.365668 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.324987 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.2 * GUI_GRID_WAbs;
+            h = 0.0176014 * GUI_GRID_HAbs;
         };
         class patrolrep_RESULTSVALUE: patrolrep_RscEdit
         {
             idc = 33;
 
             text = "DO NOT USE QUOTE MARKS IN TEXT BOXES"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.6 * safezoneH + safezoneY;
-            w = 0.28826 * safezoneW;
-            h = 0.127829 * safezoneH;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.28826 * GUI_GRID_WAbs;
+            h = 0.127829 * GUI_GRID_HAbs;
         };
         class patrolrep_AMMOTEXT: patrolrep_RscText_Right
         {
@@ -325,9 +325,9 @@ class RscDisplayALiVEPATROLREP
             style = 1;
 
             text = "AMMO:"; //--- ToDo: Localize;
-            x = 0.583011 * safezoneW + safezoneX;
-            y = 0.477998 * safezoneH + safezoneY;
-            w = 0.0637606 * safezoneW;
+            x = 0.583011 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.477998 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0637606 * GUI_GRID_WAbs;
 
         };
         class patrolrep_CASTEXT: patrolrep_RscText_Right
@@ -336,26 +336,26 @@ class RscDisplayALiVEPATROLREP
             style = 1;
 
             text = "CASUALTIES:"; //--- ToDo: Localize;
-            x = 0.583011 * safezoneW + safezoneX;
-            y = 0.511001 * safezoneH + safezoneY;
-            w = 0.0637606 * safezoneW;
+            x = 0.583011 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.511001 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0637606 * GUI_GRID_WAbs;
 
         };
         class patrolrep_AMMOLIST: patrolrep_RscComboBox
         {
             idc = 31;
-            x = 0.644022 * safezoneW + safezoneX;
-            y = 0.477998 * safezoneH + safezoneY;
-            w = 0.10002 * safezoneW;
-            h = 0.0203195 * safezoneH;
+            x = 0.644022 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.477998 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.10002 * GUI_GRID_WAbs;
+            h = 0.0203195 * GUI_GRID_HAbs;
         };
         class patrolrep_CASLIST: patrolrep_RscComboBox
         {
             idc = 29;
-            x = 0.644022 * safezoneW + safezoneX;
-            y = 0.511001 * safezoneH + safezoneY;
-            w = 0.10002 * safezoneW;
-            h = 0.0203195 * safezoneH;
+            x = 0.644022 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.511001 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.10002 * GUI_GRID_WAbs;
+            h = 0.0203195 * GUI_GRID_HAbs;
         };
         class patrolrep_VEHTEXT: patrolrep_RscText_Right
         {
@@ -363,18 +363,18 @@ class RscDisplayALiVEPATROLREP
             style = 1;
 
             text = "VEHICLES:"; //--- ToDo: Localize;
-            x = 0.563011 * safezoneW + safezoneX;
-            y = 0.544004 * safezoneH + safezoneY;
-            w = 0.0837606 * safezoneW;
+            x = 0.563011 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.544004 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0837606 * GUI_GRID_WAbs;
 
         };
         class patrolrep_VEHLIST: patrolrep_RscComboBox
         {
             idc = 37;
-            x = 0.644022 * safezoneW + safezoneX;
-            y = 0.544004 * safezoneH + safezoneY;
-            w = 0.10002 * safezoneW;
-            h = 0.0203195 * safezoneH;
+            x = 0.644022 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.544004 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.10002 * GUI_GRID_WAbs;
+            h = 0.0203195 * GUI_GRID_HAbs;
         };
         class patrolrep_CSTEXT: patrolrep_RscText_Right
         {
@@ -382,36 +382,36 @@ class RscDisplayALiVEPATROLREP
             style = 1;
 
             text = "COMBAT SPT:"; //--- ToDo: Localize;
-            x = 0.563011 * safezoneW + safezoneX;
-            y = 0.577007 * safezoneH + safezoneY;
-            w = 0.0837606 * safezoneW;
+            x = 0.563011 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.577007 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0837606 * GUI_GRID_WAbs;
 
         };
         class patrolrep_CSLIST: patrolrep_RscComboBox
         {
             idc = 39;
-            x = 0.644022 * safezoneW + safezoneX;
-            y = 0.577007 * safezoneH + safezoneY;
-            w = 0.10002 * safezoneW;
-            h = 0.0203195 * safezoneH;
+            x = 0.644022 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.577007 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.10002 * GUI_GRID_WAbs;
+            h = 0.0203195 * GUI_GRID_HAbs;
         };
         class ALIVE_EYESTEXT: patrolrep_RscText_Right
         {
             idc = 34;
             text = "EYES ONLY:"; //--- ToDo: Localize;
             style = 1;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.742019 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
-            h = 0.0176014 * safezoneH;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.742019 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
+            h = 0.0176014 * GUI_GRID_HAbs;
         };
         class ALIVE_EYESVALUE: patrolrep_RscComboBox
         {
             idc = 35;
-            x = 0.353812 * safezoneW + safezoneX;
-            y = 0.742019 * safezoneH + safezoneY;
-            w = 0.184641 * safezoneW;
-            h = 0.0203195 * safezoneH;
+            x = 0.353812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.742019 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.184641 * GUI_GRID_WAbs;
+            h = 0.0203195 * GUI_GRID_HAbs;
         };
     };
 };

--- a/addons/sys_profile/fnc_profileEntity.sqf
+++ b/addons/sys_profile/fnc_profileEntity.sqf
@@ -847,9 +847,26 @@ switch(_operation) do {
     };
 
     case "mergePositions": {
+        private _type = _logic select 2 select 5;
+
+        // A vehicle profile occasionally reached this group operation through
+        // an OPCOM vehicle bucket. Slot 18 is `canFire` on vehicles, which was
+        // the source of "Type Bool, expected Array". Route it to the matching
+        // vehicle operation instead of treating the boolean as unit positions.
+        if (_type == "vehicle") exitWith {
+            [_logic,"mergePositions"] call ALiVE_fnc_profileVehicle;
+        };
+
         private _position = _logic select 2 select 2; //[_logic,"position"] call ALIVE_fnc_hashGet;
         private _unitCount = [_logic,"unitCount"] call MAINCLASS;
         private _positions = _logic select 2 select 18; //[_logic,"positions"] call ALIVE_fnc_hashGet;
+
+        // Repair a malformed entity profile defensively. This keeps one bad
+        // saved profile from producing the same error every simulator tick.
+        if !(_positions isEqualType []) then {
+            _positions = [];
+            [_logic,"positions",_positions] call ALiVE_fnc_hashSet;
+        };
 
         //["ENTITY %1 mergePosition: %2",_logic select 2 select 4,_position] call ALIVE_fnc_dump;
 

--- a/addons/sys_sitrep/data/ui/common.hpp
+++ b/addons/sys_sitrep/data/ui/common.hpp
@@ -1,9 +1,9 @@
-#define GUI_GRID_X  (0)
-#define GUI_GRID_Y  (0)
-#define GUI_GRID_W  (0.025)
-#define GUI_GRID_H  (0.04)
-#define GUI_GRID_WAbs (1)
-#define GUI_GRID_HAbs (1)
+#define GUI_GRID_HAbs        (1.14 * safezoneH)
+#define GUI_GRID_WAbs        (1.2 * GUI_GRID_HAbs)
+#define GUI_GRID_W           (GUI_GRID_WAbs / 40)
+#define GUI_GRID_H           (GUI_GRID_HAbs / 25)
+#define GUI_GRID_X           (safezoneX + (safezoneW - GUI_GRID_WAbs) / 2)
+#define GUI_GRID_Y           (safezoneY + (safezoneH - GUI_GRID_HAbs) / 2)
 
 class RscPicture;
 
@@ -106,7 +106,7 @@ class SITREP_RscListBox {
     type = 5;
     style = 0 + 0x10;
     font = "PuristaMedium";
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     x = "safeZoneX + (safeZoneW / 5)";
     y = "safeZoneY + (safeZoneH / 2.25)";
     w = "(safeZoneW / 10)";
@@ -149,7 +149,7 @@ class SITREP_RscGUIListBox : SITREP_RscListBox {
     colorSelectBackground[] = {0.333,0.333,0.333,1};
     colorSelectBackground2[] = {0.333,0.333,0.333,1};
     period = 0;
-    sizeEx = (safeZoneH / 100) + (safeZoneH / 100);
+    sizeEx = 0.5 * GUI_GRID_H;
     class ListScrollBar
     {
         color[] = {1, 1, 1, 0.6};
@@ -199,7 +199,7 @@ class SITREP_RscComboBox
     wholeHeight = 0.45;
     colorDisabled[] = {0,0,0,0};
     font = "PuristaMedium";
-    sizeEx = "(safeZoneH / 100) + (safeZoneH / 100)";
+    sizeEx = 0.5 * GUI_GRID_H;
 };
 
 // #698 real CT_BUTTON (type 1) base for the Terrain toggle. The report form's other buttons are
@@ -243,7 +243,7 @@ class SITREP_RscRealButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};
@@ -307,7 +307,7 @@ class SITREP_RscButton
     animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
     period = 0.4;
     font = "PuristaMedium";
-    size = "(safeZoneW / 125) + (safeZoneH / 125)";
+    size = 0.5 * GUI_GRID_H;
     text = "";
     soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
     soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};

--- a/addons/sys_sitrep/data/ui/main.hpp
+++ b/addons/sys_sitrep/data/ui/main.hpp
@@ -11,10 +11,10 @@ class RscDisplayALiVESITREP
          class SITREP_Background : RscPicture
         {
                 idc = 90002;
-                x = 0.142424 * safezoneW + safezoneX;
-                y = 0.0632 * safezoneH + safezoneY;
-                w = 0.73 * safezoneW;
-                h = 0.84 * safezoneH;
+                x = 0.142424 * GUI_GRID_WAbs + GUI_GRID_X;
+                y = 0.0632 * GUI_GRID_HAbs + GUI_GRID_Y;
+                w = 0.73 * GUI_GRID_WAbs;
+                h = 0.84 * GUI_GRID_HAbs;
                 text = "x\alive\addons\main\data\ui\ALiVE_toughbook.paa";
                 moving = 1;
                 colorBackground[] = {0,0,0,0};
@@ -25,18 +25,18 @@ class RscDisplayALiVESITREP
         class SITREP_Map: SITREP_RscMap
         {
             idc = 1;
-            x = 0.586496 * safezoneW + safezoneX;
-            y = 0.158313 * safezoneH + safezoneY;
-            w = 0.159796 * safezoneW;
-            h = 0.308024 * safezoneH;
+            x = 0.586496 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.158313 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159796 * GUI_GRID_WAbs;
+            h = 0.308024 * GUI_GRID_HAbs;
         };
         class SITREP_MainTitle: SITREP_RscText
         {
             idc = 2;
             text = "SITUATION REPORT (SITREP)"; //--- ToDo: Localize;
-            x = 0.263812 * safezoneW + safezoneX;
-            y = 0.162713 * safezoneH + safezoneY;
-            w = 0.159596 * safezoneW;
+            x = 0.263812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.162713 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159596 * GUI_GRID_WAbs;
         };
         class SITREP_Abort: SITREP_RscButton
         {
@@ -44,29 +44,29 @@ class RscDisplayALiVESITREP
             style = 2;
             action = "if !(isNil 'ALIVE_SYS_sitrep_mapStartMarker') then {deleteMarkerLocal ALIVE_SYS_sitrep_mapStartMarker;}; closeDialog 0";
             text = "CANCEL"; //--- ToDo: Localize;
-            x = 0.586496 * safezoneW + safezoneX;
-            y = 0.742019 * safezoneH + safezoneY;
-            w = 0.159796 * safezoneW;
-            h = 0.0220017 * safezoneH;
+            x = 0.586496 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.742019 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159796 * GUI_GRID_WAbs;
+            h = 0.0220017 * GUI_GRID_HAbs;
             colorBackground[] = {0.376,0.196,0.204,1};
             colorText[] = {0.706,0.706,0.706,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
-            sizeEx = 0.8 * GUI_GRID_H * GUI_GRID_H * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
         };
         class SITREP_sendButton: SITREP_RscButton
         {
             idc = 4;
             style = 2;
             text = "SEND SITREP"; //--- ToDo: Localize;
-            x = 0.586496 * safezoneW + safezoneX;
-            y = 0.714815 * safezoneH + safezoneY;
-            w = 0.159796 * safezoneW;
-            h = 0.0220017 * safezoneH;
+            x = 0.586496 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.714815 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.159796 * GUI_GRID_WAbs;
+            h = 0.0220017 * GUI_GRID_HAbs;
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.706,0.706,0.706,1};
             colorFocused[] = {0.706,0.706,0.706,1};
-            sizeEx = 0.8 * GUI_GRID_H * GUI_GRID_H * GUI_GRID_H;
+            sizeEx = 0.5 * GUI_GRID_H;
             action = "call ALiVE_fnc_sitrepButtonAction";
         };
         // #698 Terrain toggle - top-right of the header bezel (identical toughbook to the CS tablet,
@@ -74,10 +74,10 @@ class RscDisplayALiVESITREP
         class SITREP_TerrainButton: SITREP_RscRealButton
         {
             idc = 40;
-            x = 0.686 * safezoneW + safezoneX;
-            y = 0.098 * safezoneH + safezoneY;
-            w = 0.0597643 * safezoneW;
-            h = 0.028 * safezoneH;
+            x = 0.686 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.098 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0597643 * GUI_GRID_WAbs;
+            h = 0.028 * GUI_GRID_HAbs;
             text = "Terrain";
             periodFocus = 1e10; // never blink (0 can fall back to the default focus-pulse)
             periodOver = 1e10;
@@ -86,7 +86,7 @@ class RscDisplayALiVESITREP
             colorBackground[] = {0.384,0.439,0.341,1};
             colorBackgroundFocused[] = {0.384,0.439,0.341,1}; // stay green on focus (matches the CS Terrain button)
             colorFocused[] = {0.706,0.706,0.706,1};
-            sizeEx = 0.9 * GUI_GRID_H; // 0.036 - readable label; the earlier cubed value (~0.00005) was invisible on a CT_BUTTON
+            sizeEx = 0.5 * GUI_GRID_H; // 0.036 - readable label; the earlier cubed value (~0.00005) was invisible on a CT_BUTTON
         };
         class SITREP_DTGTEXT: SITREP_RscText_Right
         {
@@ -94,18 +94,18 @@ class RscDisplayALiVESITREP
             idc = 1004;
 
             text = "DTG:"; //--- ToDo: Localize;
-            x = 0.437834 * safezoneW + safezoneX;
-            y = 0.162713 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.437834 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.162713 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class SITREP_DTGVALUE: RscText
         {
             idc = 5;
             sizeEx = "(            (            (            ((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 1)";
             style = 1;
-            x = 0.51 * safezoneW + safezoneX;
-            y = 0.162713 * safezoneH + safezoneY;
-            w = 0.060421 * safezoneW;
+            x = 0.51 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.162713 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.060421 * GUI_GRID_WAbs;
             class Attributes
             {
                 font = "PuristaMedium";
@@ -120,34 +120,34 @@ class RscDisplayALiVESITREP
             idc = 6;
 
             text = "CALLSIGN:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.225979 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.225979 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class SITREP_ValueCallsign: SITREP_RscEdit
         {
             idc = 7;
 
-            x = 0.345668 * safezoneW + safezoneX;
-            y = 0.225979 * safezoneH + safezoneY;
-            w = 0.154641 * safezoneW;
+            x = 0.345668 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.225979 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.154641 * GUI_GRID_WAbs;
         };
         class SITREP_TextText: SITREP_RscText
         {
             idc = 8;
 
             text = "DATE/TIME:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.258982 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.258982 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class SITREP_ValueText: SITREP_RscEdit
         {
             idc = 9;
 
-            x = 0.345668 * safezoneW + safezoneX;
-            y = 0.258982 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.345668 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.258982 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class SITREP_LOCTEXT: SITREP_RscText_Right
         {
@@ -155,60 +155,60 @@ class RscDisplayALiVESITREP
             style = 1;
 
             text = "GRID:"; //--- ToDo: Localize;
-            x = 0.427834 * safezoneW + safezoneX;
-            y = 0.258982 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.427834 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.258982 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class SITREP_LOCVALUE: SITREP_RscEdit
         {
             idc = 11;
 
-            x = 0.50 * safezoneW + safezoneX;
-            y = 0.258982 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.50 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.258982 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class SITREP_EKIATEXT: SITREP_RscText
         {
             idc = 12;
             text = "ENEMY KIA:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.291984 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.291984 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class SITREP_EKIAVALUE: SITREP_RscEdit
         {
             idc = 13;
 
-            x = 0.345668 * safezoneW + safezoneX;
-            y = 0.291984 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.345668 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.291984 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class EN_TEXT: SITREP_RscText
         {
             idc = 14;
 
             text = "ENEMY STATE:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.35799 * safezoneH + safezoneY;
-            w = 0.127817 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.35799 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.127817 * GUI_GRID_WAbs;
         };
 
         class CIV_TEXT: SITREP_RscText
         {
             idc = 18;
             text = "CIVILIAN KIA:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.324987 * safezoneH + safezoneY;
-            w = 0.068 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.324987 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.068 * GUI_GRID_WAbs;
         };
         class FKIA_TEXT: SITREP_RscText_Right
         {
             idc = 20;
 
             text = "FRIENDLY KIA:"; //--- ToDo: Localize;
-            x = 0.427834 * safezoneW + safezoneX;
-            y = 0.291984 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.427834 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.291984 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
 
         };
         class FWIA_TEXT: SITREP_RscText_Right
@@ -216,9 +216,9 @@ class RscDisplayALiVESITREP
             idc = 22;
 
             text = "FRIENDLY WIA:"; //--- ToDo: Localize;
-            x = 0.417834 * safezoneW + safezoneX;
-            y = 0.324987 * safezoneH + safezoneY;
-            w = 0.0780421 * safezoneW;
+            x = 0.417834 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.324987 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0780421 * GUI_GRID_WAbs;
 
         };
         class FF_TEXT: SITREP_RscText
@@ -226,71 +226,71 @@ class RscDisplayALiVESITREP
             idc = 24;
 
             text = "FRIENDLY STATE:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.467998 * safezoneH + safezoneY;
-            w = 0.138318 * safezoneW;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.467998 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.138318 * GUI_GRID_WAbs;
         };
         class FWIA_VALUE: SITREP_RscEdit
         {
             idc = 23;
 
-            x = 0.50 * safezoneW + safezoneX;
-            y = 0.324987 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
+            x = 0.50 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.324987 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
         };
         class FKIA_VALUE: SITREP_RscEdit
         {
             idc = 21;
 
-            x = 0.50 * safezoneW + safezoneX;
-            y = 0.291984 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
-            h = 0.0176014 * safezoneH;
+            x = 0.50 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.291984 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
+            h = 0.0176014 * GUI_GRID_HAbs;
         };
         class SITREP_ENVALUE: SITREP_RscEdit
         {
             idc = 15;
 
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.38 * safezoneH + safezoneY;
-            w = 0.28826 * safezoneW;
-            h = 0.087829 * safezoneH;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.38 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.28826 * GUI_GRID_WAbs;
+            h = 0.087829 * GUI_GRID_HAbs;
         };
         class SITREP_FFVALUE: SITREP_RscEdit
         {
             idc = 27;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.49 * safezoneH + safezoneY;
-            w = 0.28826 * safezoneW;
-            h = 0.087829 * safezoneH;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.49 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.28826 * GUI_GRID_WAbs;
+            h = 0.087829 * GUI_GRID_HAbs;
         };
         class SITREP_REMARKSTEXT: SITREP_RscText
         {
             idc = 32;
             text = "REMARKS / INTEL / OTHER:"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.578007 * safezoneH + safezoneY;
-            w = 0.270421 * safezoneW;
-            h = 0.0176014 * safezoneH;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.578007 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.270421 * GUI_GRID_WAbs;
+            h = 0.0176014 * GUI_GRID_HAbs;
         };
         class SITREP_CIVVALUE: SITREP_RscEdit
         {
             idc = 19;
 
-            x = 0.345668 * safezoneW + safezoneX;
-            y = 0.324987 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
-            h = 0.0176014 * safezoneH;
+            x = 0.345668 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.324987 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
+            h = 0.0176014 * GUI_GRID_HAbs;
         };
         class SITREP_REMARKSVALUE: SITREP_RscEdit
         {
             idc = 33;
 
             text = "DO NOT USE QUOTE MARKS IN TEXT BOXES"; //--- ToDo: Localize;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.6 * safezoneH + safezoneY;
-            w = 0.28826 * safezoneW;
-            h = 0.127829 * safezoneH;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.6 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.28826 * GUI_GRID_WAbs;
+            h = 0.127829 * GUI_GRID_HAbs;
         };
         class SITREP_AMMOTEXT: SITREP_RscText_Right
         {
@@ -298,9 +298,9 @@ class RscDisplayALiVESITREP
             style = 1;
 
             text = "AMMO:"; //--- ToDo: Localize;
-            x = 0.583011 * safezoneW + safezoneX;
-            y = 0.477998 * safezoneH + safezoneY;
-            w = 0.0637606 * safezoneW;
+            x = 0.583011 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.477998 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0637606 * GUI_GRID_WAbs;
 
         };
         class SITREP_CASTEXT: SITREP_RscText_Right
@@ -309,26 +309,26 @@ class RscDisplayALiVESITREP
             style = 1;
 
             text = "CASUALTIES:"; //--- ToDo: Localize;
-            x = 0.583011 * safezoneW + safezoneX;
-            y = 0.511001 * safezoneH + safezoneY;
-            w = 0.0637606 * safezoneW;
+            x = 0.583011 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.511001 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0637606 * GUI_GRID_WAbs;
 
         };
         class SITREP_AMMOLIST: SITREP_RscComboBox
         {
             idc = 31;
-            x = 0.644022 * safezoneW + safezoneX;
-            y = 0.477998 * safezoneH + safezoneY;
-            w = 0.10002 * safezoneW;
-            h = 0.0203195 * safezoneH;
+            x = 0.644022 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.477998 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.10002 * GUI_GRID_WAbs;
+            h = 0.0203195 * GUI_GRID_HAbs;
         };
         class SITREP_CASLIST: SITREP_RscComboBox
         {
             idc = 29;
-            x = 0.644022 * safezoneW + safezoneX;
-            y = 0.511001 * safezoneH + safezoneY;
-            w = 0.10002 * safezoneW;
-            h = 0.0203195 * safezoneH;
+            x = 0.644022 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.511001 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.10002 * GUI_GRID_WAbs;
+            h = 0.0203195 * GUI_GRID_HAbs;
         };
         class SITREP_VEHTEXT: SITREP_RscText_Right
         {
@@ -336,18 +336,18 @@ class RscDisplayALiVESITREP
             style = 1;
 
             text = "VEHICLES:"; //--- ToDo: Localize;
-            x = 0.563011 * safezoneW + safezoneX;
-            y = 0.544004 * safezoneH + safezoneY;
-            w = 0.0837606 * safezoneW;
+            x = 0.563011 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.544004 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0837606 * GUI_GRID_WAbs;
 
         };
         class SITREP_VEHLIST: SITREP_RscComboBox
         {
             idc = 37;
-            x = 0.644022 * safezoneW + safezoneX;
-            y = 0.544004 * safezoneH + safezoneY;
-            w = 0.10002 * safezoneW;
-            h = 0.0203195 * safezoneH;
+            x = 0.644022 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.544004 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.10002 * GUI_GRID_WAbs;
+            h = 0.0203195 * GUI_GRID_HAbs;
         };
         class SITREP_CSTEXT: SITREP_RscText_Right
         {
@@ -355,36 +355,36 @@ class RscDisplayALiVESITREP
             style = 1;
 
             text = "COMBAT SPT:"; //--- ToDo: Localize;
-            x = 0.563011 * safezoneW + safezoneX;
-            y = 0.577007 * safezoneH + safezoneY;
-            w = 0.0837606 * safezoneW;
+            x = 0.563011 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.577007 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0837606 * GUI_GRID_WAbs;
 
         };
         class SITREP_CSLIST: SITREP_RscComboBox
         {
             idc = 39;
-            x = 0.644022 * safezoneW + safezoneX;
-            y = 0.577007 * safezoneH + safezoneY;
-            w = 0.10002 * safezoneW;
-            h = 0.0203195 * safezoneH;
+            x = 0.644022 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.577007 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.10002 * GUI_GRID_WAbs;
+            h = 0.0203195 * GUI_GRID_HAbs;
         };
         class ALIVE_EYESTEXT: SITREP_RscText_Right
         {
             idc = 34;
             text = "EYES ONLY:"; //--- ToDo: Localize;
             style = 1;
-            x = 0.283812 * safezoneW + safezoneX;
-            y = 0.742019 * safezoneH + safezoneY;
-            w = 0.0680421 * safezoneW;
-            h = 0.0176014 * safezoneH;
+            x = 0.283812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.742019 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.0680421 * GUI_GRID_WAbs;
+            h = 0.0176014 * GUI_GRID_HAbs;
         };
         class ALIVE_EYESVALUE: SITREP_RscComboBox
         {
             idc = 35;
-            x = 0.353812 * safezoneW + safezoneX;
-            y = 0.742019 * safezoneH + safezoneY;
-            w = 0.184641 * safezoneW;
-            h = 0.0203195 * safezoneH;
+            x = 0.353812 * GUI_GRID_WAbs + GUI_GRID_X;
+            y = 0.742019 * GUI_GRID_HAbs + GUI_GRID_Y;
+            w = 0.184641 * GUI_GRID_WAbs;
+            h = 0.0203195 * GUI_GRID_HAbs;
         };
     };
 };

--- a/utils/tools/ALIVE_make_dev_build.ps1
+++ b/utils/tools/ALIVE_make_dev_build.ps1
@@ -10,10 +10,15 @@
 #		for linking with the unpacked addons.	#
 #-----------------------------------------------#
 
+[CmdletBinding()]
+param(
+	[switch]$NoPause
+)
+
 # Settings -------------------------------------#
 
 $bi_game = "arma 3";
-$make_pbo_exe = "mikero\MakePbo.exe";
+$make_pbo_exe = Join-Path $PSScriptRoot "mikero\MakePbo.exe";
 $dev_mod_folder = "@ALiVE_dev";
 $dev_repo_path = "\x\alive\addons";
 $include_pbo_prefix = $false;
@@ -54,7 +59,9 @@ function EchoSpaced([string]$text) {
 function EndScript {
 	echo " ";
 	echo " ";
-	Read-Host "Press ENTER to continue";
+	if (!$NoPause) {
+		Read-Host "Press ENTER to continue";
+	};
 };
 
 # Script ---------------------------------------#
@@ -99,9 +106,11 @@ if ($game_dir -ne $null) { # Check game path
 			# Copy stringtable.xml file if available
 			CopyItem ($addon.fullname + "\stringtable.xml") ($addon_path + "\stringtable.xml");
 			
-			# Add config.cpp hook to dev path
+			# Add config.cpp hook to dev path. Local loose-source builds opt in
+			# automatically so SQF function bodies are refreshed on mission start.
+			# Packed public builds do not define this and avoid the menu-start cost.
 			if (Test-Path ($addon.fullname + "\config.cpp")) {
-				"#include <$dev_repo_path\$addon\config.cpp>" > ($addon_path + "\config.cpp");
+				"#define ALIVE_DEV_RECOMPILE_FUNCTIONS`r`n#include <$dev_repo_path\$addon\config.cpp>" > ($addon_path + "\config.cpp");
 			};
 			
 			# Compile addon to PBO


### PR DESCRIPTION
## Summary

This PR improves the usability of ALiVE’s tablet interfaces, with a particular focus on Commander Operations, ultrawide display support, multiplayer Instant Join, and main-menu responsiveness.

It retains ALiVE’s existing tablet and remote-control approach.

## Tablet scaling

- Uses a centered, fixed-aspect-ratio tablet canvas based on screen height.
- Prevents the tablet from stretching laterally on ultrawide displays.
- Provides a larger, more usable interface while keeping text and controls inside their panels.
- Applies consistent scaling to:
  - Main ALiVE tablet
  - Commander Operations
  - C2ISTAR
  - Combat Support
  - Group Manager
  - Player Resupply
  - Patrol Reports
  - SITREP
  - Essentially everything that uses the tablet
- Updates Combat Support controls and panels to fit the new tablet dimensions.
- Restores functional terrain-map switching.

## Commander Operations

- Allows groups to be selected by double-clicking them on the map.
- Adds a **Back to Groups** button while issuing orders.
- Discards uncommitted order changes when returning to the group list.
- Returns to the group list after applying orders.
- Keeps the map focused on the group that was just ordered.
- Allows an individual selected order to be deleted without clearing the complete order chain.
- Highlights the currently selected order and path.
- Rearranges and resizes the order controls to prevent overlap.
- Separates commander-locked groups into a player battle-group section for easier tracking.
- Places the player battle group at the top of the group list for easier tracking.

## Instant Join

- Adds a tablet screen for selecting the specific unit to take over.
- Displays each unit’s class or role.
- Identifies the group leader.
- Displays vehicle positions such as driver, commander, gunner, turret, and passenger.
- Supports taking over either the leader or a regular group member.
- Replaces the previous Instant Join control method with an adapted version of my `WS_PlayerTakeover.sqf` script.
- Integrates the takeover script with ALiVE profiles, group leadership, vehicles, cancellation, and respawning.
- Provides full multiplayer compatibility.
- Ends takeover through **Cancel Instant Join** in Commander Operations.
- Maintains functional squad membership, leadership, movement commands, and vehicle seating.
- Restores the AI unit and its group state when the takeover ends.
- Handles player death and respawn during an active takeover.
- Returns the player to the same group’s unit-selection screen after respawn.

## Multiplayer and dedicated servers

- Uses server-authoritative takeover session tracking.
- Performs locality-sensitive player and vehicle operations on the player’s owning client.
- Keeps the selected group available while the player chooses another unit.
- Supports repeated takeover after cancellation or death.
- Handles exact vehicle roles using `fullCrew` verification.
- Waits for dedicated-server replication before confirming vehicle-seat placement.
- Includes fallback handling for missions where the normal client respawn event is unavailable.

## Profile handling

- Corrects invalid profile-position data encountered while issuing tablet orders.
- Routes vehicle position merging through the appropriate vehicle profile handler.
- Prevents the recurring `Type Bool, expected Array,HashMap` error associated with Commander Operations orders.

## Function recompilation and menu responsiveness

- Prevents the complete ALiVE CfgFunctions library from being recompiled whenever Arma starts a mission.
- Removes the multi-second interface delay caused by recompilation when:
  - The main menu initially loads
  - Returning to the main menu from Eden
  - Returning to the main menu after playing a scenario
  - Starting or restarting missions
- Changes the shared `RECOMPILE` macro to use `recompile = 0` by default.
- Adds the `ALIVE_DEV_RECOMPILE_FUNCTIONS` preprocessor definition for loose-source development builds.
- Keeps automatic SQF recompilation enabled for contributors using the existing `@ALiVE_dev` workflow.
- Ensures normal packed development and release builds use `recompile = 0` automatically.
- Requires no manual setting or release-build toggle.
- Prevents Eden fallback initialization from overwriting functions that CfgFunctions has already registered.
- Updates the faction vehicle-class fallback to avoid overwriting registered hash functions.

## Development build tooling

- Updates `ALIVE_make_dev_build.ps1` to define `ALIVE_DEV_RECOMPILE_FUNCTIONS` in generated dummy configs.
- Resolves `MakePbo.exe` relative to the helper script instead of the caller’s working directory.
- Adds a `-NoPause` option for noninteractive development-build generation.
- Preserves the existing loose-source workflow:
  1. Edit an SQF file.
  2. Save the file.
  3. Restart the Eden preview.
  4. Use the updated function without rebuilding its PBO.

Existing contributors with an already-generated `