### PR TITLE
[UI/SUP_COMMAND] Fix Mapbag scaling not aligning with tablet scaling rework.

### DIFF
--- a/addons/mil_c2istar/fnc_C2ISTAR.sqf
+++ b/addons/mil_c2istar/fnc_C2ISTAR.sqf
@@ -1977,8 +1977,8 @@ switch(_operation) do {
                         case "Mapbag01": {
                             createDialog "C2Tablet";
 
-                            private _uiW = (safezoneW / safezoneH) min 1.2;
-                            private _uiH = _uiW / 1.2;
+                            private _uiH = 1.14 * safezoneH;
+                            private _uiW = 1.2 * _uiH;
                             private _uiX = safezoneX + (safezoneW - _uiW) / 2;
                             private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                             private _ctrlBackground = ((findDisplay 70001) displayCtrl 70002);

--- a/addons/mil_c2istar/fnc_C2MenuDef.sqf
+++ b/addons/mil_c2istar/fnc_C2MenuDef.sqf
@@ -232,8 +232,8 @@ if (_menuName == "C2ISTAR") then {
                             case "Mapbag01": {
                                 createDialog "RscDisplayALIVESITREP";
 
-                                private _uiW = (safezoneW / safezoneH) min 1.2;
-                                private _uiH = _uiW / 1.2;
+                                private _uiH = 1.14 * safezoneH;
+                                private _uiW = 1.2 * _uiH;
                                 private _uiX = safezoneX + (safezoneW - _uiW) / 2;
                                 private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                                 private _ctrlBackground = ((findDisplay 90001) displayCtrl 90002);
@@ -269,8 +269,8 @@ if (_menuName == "C2ISTAR") then {
                             case "Mapbag01": {
                                 createDialog "RscDisplayALIVEPATROLREP";
 
-                                private _uiW = (safezoneW / safezoneH) min 1.2;
-                                private _uiH = _uiW / 1.2;
+                                private _uiH = 1.14 * safezoneH;
+                                private _uiW = 1.2 * _uiH;
                                 private _uiX = safezoneX + (safezoneW - _uiW) / 2;
                                 private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                                 private _ctrlBackground = ((findDisplay 90002) displayCtrl 90003);

--- a/addons/sup_command/fnc_SCOM.sqf
+++ b/addons/sup_command/fnc_SCOM.sqf
@@ -907,8 +907,8 @@ switch (_operation) do {
 
                         case "Mapbag01": {
                             createDialog "SCOMTablet";
-                            private _uiW = (safezoneW / safezoneH) min 1.2;
-                            private _uiH = _uiW / 1.2;
+                            private _uiH = 1.14 * safezoneH;
+                            private _uiW = 1.2 * _uiH;
                             private _uiX = safezoneX + (safezoneW - _uiW) / 2;
                             private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                             private _ctrlBackground = ((findDisplay 12001) displayCtrl 12002);
@@ -946,8 +946,8 @@ switch (_operation) do {
 
                         case "Mapbag01": {
                             createDialog "SCOMTablet";
-                            private _uiW = (safezoneW / safezoneH) min 1.2;
-                            private _uiH = _uiW / 1.2;
+                            private _uiH = 1.14 * safezoneH;
+                            private _uiW = 1.2 * _uiH;
                             private _uiX = safezoneX + (safezoneW - _uiW) / 2;
                             private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                             private _ctrlBackground = ((findDisplay 12001) displayCtrl 12002);

--- a/addons/sup_group_manager/fnc_GM.sqf
+++ b/addons/sup_group_manager/fnc_GM.sqf
@@ -404,8 +404,8 @@ switch(_operation) do {
                         case "Mapbag01": {
                             createDialog "GMTablet";
 
-                            private _uiW = (safezoneW / safezoneH) min 1.2;
-                            private _uiH = _uiW / 1.2;
+                            private _uiH = 1.14 * safezoneH;
+                            private _uiW = 1.2 * _uiH;
                             private _uiX = safezoneX + (safezoneW - _uiW) / 2;
                             private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                             private _ctrlBackground = ((findDisplay 11001) displayCtrl 11002);

--- a/addons/sup_player_resupply/fnc_PR.sqf
+++ b/addons/sup_player_resupply/fnc_PR.sqf
@@ -1740,8 +1740,8 @@ switch(_operation) do {
                         case "Mapbag01": {
                             createDialog "PRTablet";
 
-                            private _uiW = (safezoneW / safezoneH) min 1.2;
-                            private _uiH = _uiW / 1.2;
+                            private _uiH = 1.14 * safezoneH;
+                            private _uiW = 1.2 * _uiH;
                             private _uiX = safezoneX + (safezoneW - _uiW) / 2;
                             private _uiY = safezoneY + (safezoneH - _uiH) / 2;
                             private _ctrlBackground = ((findDisplay 60001) displayCtrl 60000);

--- a/addons/sys_acemenu/fnc_aceMenu_repDialog.sqf
+++ b/addons/sys_acemenu/fnc_aceMenu_repDialog.sqf
@@ -61,13 +61,17 @@ switch (MOD(TABLET_MODEL)) do {
     case "Mapbag01": {
         createDialog _dialog;
 
+        private _uiH = 1.14 * safezoneH;
+        private _uiW = 1.2 * _uiH;
+        private _uiX = safezoneX + (safezoneW - _uiW) / 2;
+        private _uiY = safezoneY + (safezoneH - _uiH) / 2;
         private _ctrlBackground = call _ctrl;
         _ctrlBackground ctrlsettext "x\alive\addons\main\data\ui\ALiVE_mapbag.paa";
         _ctrlBackground ctrlSetPosition [
-            0.15 * safezoneW + safezoneX,
-            -0.242 * safezoneH + safezoneY,
-            0.72 * safezoneW,
-            1.372 * safezoneH
+            0.15 * _uiW + _uiX,
+            -0.242 * _uiH + _uiY,
+            0.72 * _uiW,
+            1.372 * _uiH
         ];
         _ctrlBackground ctrlCommit 0;
     };


### PR DESCRIPTION
Fix for https://github.com/ALiVEOS/ALiVE.OS/issues/986

Fixed the Mapbag scaling mismatch across ALiVE.
Eight outdated Mapbag launch paths now use the same centered 1.2:1 box as the standard tablet controls:

1. C2ISTAR
2. SITREP and PATROLREP
3. Commander Intel and Operations
4. Group Manager
5. Player Resupply
6. ACE report dialogs

Combat Support already used the correct geometry and was left unchanged. Mapbag’s artwork-specific offsets remain intact; only its sizing basis changed.