### PR TITLE
[X_LIB] ProfileNameSpaceLoad returns false when the id is missing

### DIFF
--- a/addons/x_lib/functions/data/fnc_ProfileNameSpaceLoad.sqf
+++ b/addons/x_lib/functions/data/fnc_ProfileNameSpaceLoad.sqf
@@ -36,6 +36,6 @@ private _mission = format["ALiVE_%1_%2",missionName,worldName];
 
 _data = profileNamespace getVariable _mission;
 
-_result = if (isnil "_data") then {false} else {[_data,_id] call ALiVE_fnc_HashGet};
+_result = if (isnil "_data") then {false} else {[_data,_id,false] call ALiVE_fnc_HashGet};
 
 _result


### PR DESCRIPTION
ALiVE_fnc_ProfileNameSpaceLoad handles the no-data case (nothing saved for the mission) by returning false, but when the mission hash exists and the requested id doesn't, HashGet is called without a default and returns nil. That nil propagates as the undefined _result error in the report.

Passing false as the HashGet default makes the missing-id case behave like the documented no-data case. The only in-repo caller (fnc_profilesLoadDataPNS) already guards with an ARRAY check, so false and nil take the same path there; direct callers just stop erroring.

Fixes #791