### PR TITLE
[SUP_MULTISPAWN] Establishing shot no longer errors on an empty target

### DIFF
--- a/addons/sup_multispawn/fnc_establishingShotCustom.sqf
+++ b/addons/sup_multispawn/fnc_establishingShotCustom.sqf
@@ -78,7 +78,7 @@ _mul = [];
 switch (typeName _tgt) do {
     case ("OBJECT") : {_pos = position _tgt};
     case ("ARRAY") : {
-        if (count _tgt == 0) exitwith {_pos = [0,0,0]};
+        if (count _tgt == 0) exitwith {_pos = [0,0,0]; _tgt = _pos};
 
         if (typeName (_tgt select 0) == "SCALAR") then {
             _pos = _tgt;


### PR DESCRIPTION
The custom establishing shot's empty-target branch sets _pos to [0,0,0] but leaves _tgt as an empty array, so camPrepareTarget _tgt later throws the "0 elements provided, 3 expected" error from the report. The path triggers whenever the target array comes up empty, e.g. the disablePlayer flow building its targets from AI-only groups when there are none.

The empty branch now also assigns the fallback position to _tgt, so the camera gets a valid 3-element target and the shot degrades gracefully instead of erroring.

Fixes #747