### PR TITLE
[SYS_PROFILE] Entity profiles keep their objectType across saves

### DIFF
--- a/addons/sys_profile/fnc_profileHandler.sqf
+++ b/addons/sys_profile/fnc_profileHandler.sqf
@@ -1132,7 +1132,6 @@ switch(_operation) do {
                         "damages",
                         "positions",
                         "isPlayer",
-                        "objectType",
                         "unitCount",
                         "ranks",
                         "side",


### PR DESCRIPTION
objectType sits in the entity export's exclusion list, so it is never written on save. On load the import passes the missing key (nil) into the profileEntity setter, whose string type guard silently no-ops, and the entity falls back to the init default - which is why saved entity profiles come back with the wrong objectType while vehicle profiles, which do save it, are fine.

Removing objectType from the entity exclusion list makes the save/load round-trip symmetric with vehicles. Verified against the profile init path: the key always exists on export (default "inf"), so nothing else changes shape. Traced in code only so far - an SP save/load cycle on the attached repro mission is the quick confirmation.

Fixes #820