### PR TITLE
[MIL_PLACEMENT] Two intermediate garrison amounts for placement modules

### DIFF
--- a/addons/civ_placement/CfgVehicles.hpp
+++ b/addons/civ_placement/CfgVehicles.hpp
@@ -240,7 +240,9 @@ class CfgVehicles {
                                 {
                                     class NONE { name = "$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_NONE"; value = "0"; };
                                     class LOW { name = "$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_LOW"; value = "0.2"; default = 1; };
+                                    class MEDIUMLOW { name = "$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_MEDIUMLOW"; value = "0.4"; };
                                     class MEDIUM { name = "$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_MEDIUM"; value = "0.6"; };
+                                    class MEDIUMHIGH { name = "$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_MEDIUMHIGH"; value = "0.8"; };
                                     class HIGH { name = "$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_HIGH"; value = "1"; };
                                 };
                         };

--- a/addons/civ_placement/stringtable.xml
+++ b/addons/civ_placement/stringtable.xml
@@ -745,7 +745,7 @@
     <Russian>Группы пехоты гарнизона:</Russian>
 </Key>
 <Key ID="STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_COMMENT">
-    <English>Additional infantry groups spawned at each objective to garrison and patrol buildings. Low/Medium/High resolve to roughly 1-2, 3-4 or 5-6 groups per objective when enough infantry groups exist. These are not a Force Size cap and can multiply the final unit count across many objectives.</English>
+    <English>Additional infantry groups spawned at each objective to garrison and patrol buildings. Levels resolve to roughly 1-2 (Low) up to 5-6 (High) groups per objective when enough infantry groups exist. These are not a Force Size cap and can multiply the final unit count across many objectives.</English>
     <Chinese>分配到每個目標內駐防和巡邏建築物的步兵組數量。如果沒有生成步兵組，則沒有效果。</Chinese>
     <Chinesesimp>分配到每个目标内驻防和巡逻建筑物的步兵组数量。如果没有生成步兵组，则没有效果。</Chinesesimp>
     <Spanish>Número de grupos de infantería asignados a guarnecer y patrullar edificios dentro de cada objetivo. No tiene efecto si no se generan grupos de infantería.</Spanish>
@@ -771,6 +771,16 @@
     <Portuguese>Baixo (1-2 grupos)</Portuguese>
     <Russian>Низко (1-2 группы)</Russian>
 </Key>
+<!-- AI-translated; native-speaker review welcome -->
+<Key ID="STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_MEDIUMLOW">
+    <English>Medium-Low (2-3 Groups)</English>
+    <Chinese>中低（2-3 組）</Chinese>
+    <Chinesesimp>中低（2-3 组）</Chinesesimp>
+    <Spanish>Medio-bajo (2-3 grupos)</Spanish>
+    <French>Moyen-faible (2-3 groupes)</French>
+    <Portuguese>Médio-baixo (2-3 grupos)</Portuguese>
+    <Russian>Средне-низко (2-3 группы)</Russian>
+</Key>
 <Key ID="STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_MEDIUM">
     <English>Medium (3-4 Groups)</English>
     <Chinese>中（3-4 組）</Chinese>
@@ -779,6 +789,16 @@
     <French>Moyen (3-4 groupes)</French>
     <Portuguese>Médio (3-4 grupos)</Portuguese>
     <Russian>Средне (3-4 группы)</Russian>
+</Key>
+<!-- AI-translated; native-speaker review welcome -->
+<Key ID="STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_MEDIUMHIGH">
+    <English>Medium-High (4-5 Groups)</English>
+    <Chinese>中高（4-5 組）</Chinese>
+    <Chinesesimp>中高（4-5 组）</Chinesesimp>
+    <Spanish>Medio-alto (4-5 grupos)</Spanish>
+    <French>Moyen-élevé (4-5 groupes)</French>
+    <Portuguese>Médio-alto (4-5 grupos)</Portuguese>
+    <Russian>Средне-высоко (4-5 групп)</Russian>
 </Key>
 <Key ID="STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_HIGH">
     <English>High (5-6 Groups)</English>

--- a/addons/civ_placement_custom/CfgVehicles.hpp
+++ b/addons/civ_placement_custom/CfgVehicles.hpp
@@ -181,7 +181,7 @@ class CfgVehicles {
             class guardProbability : Combo
             {
                     property = "ALiVE_civ_placement_custom_guardProbability"; displayName = "$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT"; tooltip = "$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_COMMENT"; defaultValue = """0.2""";
-                    class Values { class NONE{name="$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_NONE";value="0";}; class LOW{name="$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_LOW";value="0.2";default=1;}; class MEDIUM{name="$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_MEDIUM";value="0.6";}; class HIGH{name="$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_HIGH";value="1";}; };
+                    class Values { class NONE{name="$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_NONE";value="0";}; class LOW{name="$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_LOW";value="0.2";default=1;}; class MEDIUMLOW{name="$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_MEDIUMLOW";value="0.4";}; class MEDIUM{name="$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_MEDIUM";value="0.6";}; class MEDIUMHIGH{name="$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_MEDIUMHIGH";value="0.8";}; class HIGH{name="$STR_ALIVE_CP_CUSTOM_GUARD_AMOUNT_HIGH";value="1";}; };
             };
             class guardRadius : Edit { property = "ALiVE_civ_placement_custom_guardRadius"; displayName = "$STR_ALIVE_CP_CUSTOM_GUARD_RADIUS"; tooltip = "$STR_ALIVE_CP_CUSTOM_GUARD_RADIUS_COMMENT"; defaultValue = """200"""; };
             class guardPatrolPercentage : Combo

--- a/addons/mil_placement/CfgVehicles.hpp
+++ b/addons/mil_placement/CfgVehicles.hpp
@@ -159,7 +159,7 @@ class CfgVehicles {
                         class guardProbability : Combo
                         {
                                 property = "ALiVE_mil_placement_guardProbability"; displayName = "$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT"; tooltip = "$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_COMMENT"; defaultValue = """0.2""";
-                                class Values { class NONE{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_NONE";value="0";}; class LOW{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_LOW";value="0.2";default=1;}; class MEDIUM{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_MEDIUM";value="0.6";}; class HIGH{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_HIGH";value="1";}; };
+                                class Values { class NONE{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_NONE";value="0";}; class LOW{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_LOW";value="0.2";default=1;}; class MEDIUMLOW{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_MEDIUMLOW";value="0.4";}; class MEDIUM{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_MEDIUM";value="0.6";}; class MEDIUMHIGH{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_MEDIUMHIGH";value="0.8";}; class HIGH{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_HIGH";value="1";}; };
                         };
                         class guardRadius : Edit { property = "ALiVE_mil_placement_guardRadius"; displayName = "$STR_ALIVE_MP_AMBIENT_GUARD_RADIUS"; tooltip = "$STR_ALIVE_MP_AMBIENT_GUARD_RADIUS_COMMENT"; defaultValue = """200"""; };
                         class guardPatrolPercentage : Combo

--- a/addons/mil_placement/stringtable.xml
+++ b/addons/mil_placement/stringtable.xml
@@ -1002,7 +1002,7 @@
     <Russian>Группы пехоты гарнизона:</Russian>
 </Key>
 <Key ID="STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_COMMENT">
-    <English>Additional infantry groups spawned at each objective to garrison and patrol buildings. Low/Medium/High resolve to roughly 1-2, 3-4 or 5-6 groups per objective when enough infantry groups exist. These are not a Force Size cap and can multiply the final unit count across many objectives.</English>
+    <English>Additional infantry groups spawned at each objective to garrison and patrol buildings. Levels resolve to roughly 1-2 (Low) up to 5-6 (High) groups per objective when enough infantry groups exist. These are not a Force Size cap and can multiply the final unit count across many objectives.</English>
     <Chinese>分配到每個目標內駐防和巡邏建築物的步兵組數量。如果沒有生成步兵組，則沒有效果。</Chinese>
     <Chinesesimp>分配到每个目标内驻防和巡逻建筑物的步兵组数量。如果没有生成步兵组，则没有效果。</Chinesesimp>
     <Spanish>Número de grupos de infantería asignados a guarnecer y patrullar edificios dentro de cada objetivo. No tiene efecto si no se generan grupos de infantería.</Spanish>
@@ -1028,6 +1028,16 @@
     <Portuguese>Baixo (1-2 grupos)</Portuguese>
     <Russian>Низко (1-2 группы)</Russian>
 </Key>
+<!-- AI-translated; native-speaker review welcome -->
+<Key ID="STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_MEDIUMLOW">
+    <English>Medium-Low (2-3 Groups)</English>
+    <Chinese>中低（2-3 組）</Chinese>
+    <Chinesesimp>中低(2-3组)</Chinesesimp>
+    <Spanish>Medio-bajo (2-3 grupos)</Spanish>
+    <French>Moyen-faible (2-3 groupes)</French>
+    <Portuguese>Médio-baixo (2-3 grupos)</Portuguese>
+    <Russian>Средне-низко (2-3 группы)</Russian>
+</Key>
 <Key ID="STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_MEDIUM">
     <English>Medium (3-4 Groups)</English>
     <Chinese>中等（3-4 組）</Chinese>
@@ -1036,6 +1046,16 @@
     <French>Moyen (3-4 groupes)</French>
     <Portuguese>Médio (3-4 grupos)</Portuguese>
     <Russian>Средне (3-4 группы)</Russian>
+</Key>
+<!-- AI-translated; native-speaker review welcome -->
+<Key ID="STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_MEDIUMHIGH">
+    <English>Medium-High (4-5 Groups)</English>
+    <Chinese>中高（4-5 組）</Chinese>
+    <Chinesesimp>中高(4-5组)</Chinesesimp>
+    <Spanish>Medio-alto (4-5 grupos)</Spanish>
+    <French>Moyen-élevé (4-5 groupes)</French>
+    <Portuguese>Médio-alto (4-5 grupos)</Portuguese>
+    <Russian>Средне-высоко (4-5 групп)</Russian>
 </Key>
 <Key ID="STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_HIGH">
     <English>High (5-6 Groups)</English>

--- a/addons/mil_placement_custom/CfgVehicles.hpp
+++ b/addons/mil_placement_custom/CfgVehicles.hpp
@@ -172,7 +172,7 @@ class CfgVehicles {
                         class guardProbability : Combo
                         {
                                 property = "ALiVE_mil_placement_custom_guardProbability"; displayName = "$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT"; tooltip = "$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_COMMENT"; defaultValue = """0.2""";
-                                class Values { class NONE{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_NONE";value="0";}; class LOW{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_LOW";value="0.2";default=1;}; class MEDIUM{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_MEDIUM";value="0.6";}; class HIGH{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_HIGH";value="1";}; };
+                                class Values { class NONE{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_NONE";value="0";}; class LOW{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_LOW";value="0.2";default=1;}; class MEDIUMLOW{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_MEDIUMLOW";value="0.4";}; class MEDIUM{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_MEDIUM";value="0.6";}; class MEDIUMHIGH{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_MEDIUMHIGH";value="0.8";}; class HIGH{name="$STR_ALIVE_MP_AMBIENT_GUARD_AMOUNT_HIGH";value="1";}; };
                         };
                         class guardRadius : Edit { property = "ALiVE_mil_placement_custom_guardRadius"; displayName = "$STR_ALIVE_MP_AMBIENT_GUARD_RADIUS"; tooltip = "$STR_ALIVE_MP_AMBIENT_GUARD_RADIUS_COMMENT"; defaultValue = """200"""; };
                         class guardPatrolPercentage : Combo

--- a/addons/x_lib/functions/behaviour/fnc_infantryGuardProbabilityCount.sqf
+++ b/addons/x_lib/functions/behaviour/fnc_infantryGuardProbabilityCount.sqf
@@ -36,7 +36,13 @@ if (ALiVE_SYS_PROFILE_DEBUG_ON) then {
             		      if (_countInfantry == 2) then { _guardProbabilityCount = 1; };
 							     	  if (_countInfantry > 2) then { _guardProbabilityCount = [1,2] call BIS_fnc_randomInt;};
             	};
-            	case "0.6": { 
+            	case "0.4": {
+            		      if (_countInfantry == 1) then { _guardProbabilityCount = 0; };
+            		      if (_countInfantry == 2) then { _guardProbabilityCount = 1; };
+            		      if (_countInfantry == 3) then { _guardProbabilityCount = 2; };
+								     	  if (_countInfantry > 3) then { _guardProbabilityCount = [2,3] call BIS_fnc_randomInt;};
+            	};
+            	case "0.6": {
             		      if (_countInfantry == 1) then { _guardProbabilityCount = 0; };
             		      if (_countInfantry == 2) then { _guardProbabilityCount = 1; };
             		      if (_countInfantry == 3) then { _guardProbabilityCount = 2; };
@@ -44,7 +50,15 @@ if (ALiVE_SYS_PROFILE_DEBUG_ON) then {
 							     	  if (_countInfantry > 4) then { _guardProbabilityCount = [3,4] call BIS_fnc_randomInt;};
 							     	
             	};
-            	case "1": { 
+            	case "0.8": {
+            		      if (_countInfantry == 1) then { _guardProbabilityCount = 0; };
+            		      if (_countInfantry == 2) then { _guardProbabilityCount = 1; };
+            		      if (_countInfantry == 3) then { _guardProbabilityCount = 2; };
+            		      if (_countInfantry == 4) then { _guardProbabilityCount = 3; };
+            		      if (_countInfantry == 5) then { _guardProbabilityCount = 4; };
+								     	  if (_countInfantry > 5) then { _guardProbabilityCount = [4,5] call BIS_fnc_randomInt;};
+            	};
+            	case "1": {
              		      if (_countInfantry == 1) then { _guardProbabilityCount = 0; };
             		      if (_countInfantry == 2) then { _guardProbabilityCount = 1; };
             		      if (_countInfantry == 3) then { _guardProbabilityCount = 2; };


### PR DESCRIPTION
The guard probability combo jumps from Medium (3-4 groups) straight to High (5-6), which is the coarse stepping the issue asks about. This adds Medium-Low (2-3 groups, 0.4) and Medium-High (4-5 groups, 0.8) to the guardProbability combo in mil_placement, mil_placement_custom, civ_placement and civ_placement_custom, with the matching branches in fnc_infantryGuardProbabilityCount following the existing pattern. Existing values, labels and the 0.2 default are untouched, so current missions read the same.

mil_placement_spe has no guardProbability attribute so it is deliberately left alone. Config plus a switch extension mirroring existing branches; not run in-game yet.

Fixes #978