### PR TITLE
[SYS_INDEXER] Composition environment dropdown on the indexer module

### DIFF
--- a/addons/sys_indexer/CfgVehicles.hpp
+++ b/addons/sys_indexer/CfgVehicles.hpp
@@ -68,6 +68,27 @@ class CfgVehicles {
                                     class Win10 { name = "Windows 10"; value = 1; };
                                 };
                         };
+                        class environment : Combo
+                        {
+                                property = "ALiVE_sys_indexer_environment";
+                                displayName = "$STR_ALIVE_INDEXER_ENVIRONMENT";
+                                tooltip = "$STR_ALIVE_INDEXER_ENVIRONMENT_COMMENT";
+                                // Values match the composition sets shipped with the
+                                // composition PBOs (see fnc_getCompositions). Urban is
+                                // the base set and what the search falls back to, so it
+                                // stays the default.
+                                typeName = "STRING";
+                                defaultValue = """Urban""";
+                                class Values
+                                {
+                                    class Urban { name = "Urban"; value = "Urban"; };
+                                    class Woodland { name = "Woodland"; value = "Woodland"; };
+                                    class Desert { name = "Desert"; value = "Desert"; };
+                                    class Jungle { name = "Jungle"; value = "Jungle"; };
+                                    class Pacific { name = "Pacific"; value = "Pacific"; };
+                                    class Bocage { name = "Bocage"; value = "Bocage"; };
+                                };
+                        };
                         class ModuleDescription : ModuleDescription {};
                 };
         };

--- a/addons/sys_indexer/fnc_auto_staticObjects.sqf
+++ b/addons/sys_indexer/fnc_auto_staticObjects.sqf
@@ -317,6 +317,11 @@ if (_mapBounds != 0) then {
     _result = "ALiVEClient" callExtension format['staticData~%1|[ALIVE_mapBounds, worldName, %2] call ALIVE_fnc_hashSet;',worldName,_mapBounds];
 };
 
+// Set the composition environment selected on the indexer module
+if (!isNil "ALiVE_mapCompositionType") then {
+    _result = "ALiVEClient" callExtension format['staticData~%1|ALiVE_mapCompositionType = "%2";',worldName,ALiVE_mapCompositionType];
+};
+
 {
     private ["_array","_arrayActual","_result"];
     _array = _x select 0;

--- a/addons/sys_indexer/fnc_indexer.sqf
+++ b/addons/sys_indexer/fnc_indexer.sqf
@@ -173,6 +173,10 @@ switch(_operation) do {
             _result = [_logic,_operation,_args,false] call ALIVE_fnc_OOsimpleOperation;
         };
 
+        case "environment": {
+            _result = [_logic,_operation,_args,"Urban"] call ALIVE_fnc_OOsimpleOperation;
+        };
+
         case "start": {
             private ["_mapPath","_customStatic","_customMapBound"];
 
@@ -182,6 +186,13 @@ switch(_operation) do {
                 _customStatic = [_logic, "customStatic"] call MAINCLASS;
                 _customMapBound = [_logic, "customMapBound"] call MAINCLASS;
                 private _launch = [_logic, "OS"] call MAINCLASS;
+                private _environment = [_logic, "environment"] call MAINCLASS;
+
+                // Make the selected composition environment available to the
+                // static data export (and composition searches) without having
+                // to hand-edit staticData afterwards
+                ALiVE_mapCompositionType = _environment;
+
                 ALIVE_mapBounds = [] call ALIVE_fnc_hashCreate;
 
                 if (_customMapBound != 0) then {

--- a/addons/sys_indexer/stringtable.xml
+++ b/addons/sys_indexer/stringtable.xml
@@ -46,5 +46,13 @@
     <English>If map indexer crashes, try changing the operating system selection here.</English>
     <Chinesesimp>如果映射索引器崩溃，请尝试在这里更改操作系统选择。</Chinesesimp>
 </Key>
+<Key ID="STR_ALIVE_INDEXER_ENVIRONMENT">
+    <English>Composition Environment:</English>
+    <Chinesesimp>阵地布局环境:</Chinesesimp>
+</Key>
+<Key ID="STR_ALIVE_INDEXER_ENVIRONMENT_COMMENT">
+    <English>Environment used to select ALiVE compositions on this map. Written to the exported static data, so it no longer needs to be added by hand after indexing.</English>
+    <Chinesesimp>用于在此地图上选择ALiVE阵地布局的环境。会写入导出的静态数据，索引后无需再手动添加。</Chinesesimp>
+</Key>
 
 </Container></Package></Project>


### PR DESCRIPTION
Map indexers currently get a composition environment only if someone hand-edits ALiVE_mapCompositionType into the exported static data afterwards. This adds an Environment combo (Urban/Woodland/Desert/Jungle/Pacific/Bocage - the set actually used across the shipped staticData files) to the indexer module, sets the global before the indexing run, and writes the line into the exported static data block in the same format the hand-edited files use.

Default Urban behaves identically to the previous unset state in fnc_getCompositions, so nothing changes for existing setups. Statically verified against the export path and the OS combo precedent in the same file; I have not run a full indexing session against it since that needs the ALiVEClient extension interactively.

Fixes #333