### PR TITLE
[SYS_DATA] UID allowlist for the Save Server button

### DIFF
--- a/addons/main/fnc_buttonAbort.sqf
+++ b/addons/main/fnc_buttonAbort.sqf
@@ -471,13 +471,25 @@ if (_mode == "SAVESERVERYO" && isServer && ALiVE_sys_data_DISABLED) then {
 
 // Function run on server
 if (_mode == "SAVESERVERYO" && isServer) exitWith {
+
+    // Only accept save requests from admins or UIDs on the sys_data save allowlist (#873)
+    private _requester = [_adminUID] call ALIVE_fnc_getPlayerByUID;
+    private _authorised = !isMultiplayer
+        || {hasInterface && {call ALiVE_fnc_isServerAdmin}}
+        || {_adminUID in (missionNamespace getVariable ["ALiVE_sys_data_saveAllowlist",[]])}
+        || {!isNull _requester && {(admin owner _requester) > 0}};
+
+    if !(_authorised) exitWith {
+        ["Exit - Server save request from unauthorised UID %1 - ignoring",_adminUID] call ALiVE_fnc_dump;
+    };
+
     // Save server data
     [_saveServer,_exitServer,_adminUID] spawn {
         private ["_saveServer","_exitServer"];
         _saveServer = _this select 0;
         _exitServer = _this select 1;
         _adminUID = _this select 2;
-        WaitUntil {sleep 1; (count ([] call BIS_fnc_ListPlayers)) == 1};
+        WaitUntil {sleep 1; (count ([] call BIS_fnc_ListPlayers)) <= 1};
         [_adminUID] call _saveServer;
         [_adminUID] call _exitServer;
         "serversaved" call BIS_fnc_endMission;
@@ -518,6 +530,9 @@ if ((_mode == "SAVE" || _mode == "REMSAVE") && hasInterface) then {
 };
 
 
+// Server save may also be triggered by a UID on the sys_data save allowlist (#873)
+private _saveAllowed = (call ALiVE_fnc_isServerAdmin) || {hasInterface && {(getPlayerUID player) in (missionNamespace getVariable ["ALiVE_sys_data_saveAllowlist",[]])}};
+
 // Check client for admin
 if (call ALiVE_fnc_isServerAdmin) then {
 
@@ -537,14 +552,19 @@ if (call ALiVE_fnc_isServerAdmin) then {
 
     };
 
+};
+
+// Check client for admin or save allowlist
+if (_saveAllowed) then {
+
     if (_mode == "SERVERSAVE") then {
 
         ["Exit - Abort / Save by Admin"] call ALiVE_fnc_dump;
 
         ["Exit - Broadcasting abort call to all players"] call ALiVE_fnc_dump;
 
-        // Save all players
-        [["REMSAVE"],"ALiVE_fnc_buttonAbort",true,false] call BIS_fnc_MP;
+        // Save all players (pass the initiator's UID so they stay behind for the server save)
+        [["REMSAVE",getPlayerUID player],"ALiVE_fnc_buttonAbort",true,false] call BIS_fnc_MP;
 
         ["Exit - Trigger Server abort call"] call ALiVE_fnc_dump;
 
@@ -566,13 +586,22 @@ switch (_mode) do {
         "abort" call BIS_fnc_endMission;
     };
     case "REMSAVE" : {
-        if !(call ALiVE_fnc_isServerAdmin) then {
+        // Exactly one player stays behind for the server's player-count
+        // wait: the initiator when the save request carries a UID, else
+        // the admin (legacy REMSAVE). Keeping both would strand the
+        // count above 1 and stall the save.
+        private _staysBehind = if (_adminUID != "") then {
+            (getPlayerUID player) == _adminUID
+        } else {
+            call ALiVE_fnc_isServerAdmin
+        };
+        if !(_staysBehind) then {
             ["Exit - [%1] !(Admin) Ending mission",_mode] call ALiVE_fnc_dump;
             "saved" call BIS_fnc_endMission;
         };
     };
     case "SERVERSAVE": {
-        if (call ALiVE_fnc_isServerAdmin) then {
+        if (_saveAllowed) then {
             ["Exit - [%1] (Admin) Ending mission",_mode] call ALiVE_fnc_dump;
             //"serversaved" call BIS_fnc_endMission;
         };

--- a/addons/main/fnc_buttonAbort.sqf
+++ b/addons/main/fnc_buttonAbort.sqf
@@ -473,9 +473,16 @@ if (_mode == "SAVESERVERYO" && isServer && ALiVE_sys_data_DISABLED) then {
 if (_mode == "SAVESERVERYO" && isServer) exitWith {
 
     // Only accept save requests from admins or UIDs on the sys_data save allowlist (#873)
+    //
+    // Every test here has to ask about the machine that ASKED for the save, not
+    // about this one. We are already inside the server branch, so asking whether
+    // this machine is an admin is asking about the server, and on a host that is
+    // always true - which would wave through every request and leave the check
+    // doing nothing at all. The second test therefore asks whether the requester
+    // is the host themselves, which is the case it was meant to cover.
     private _requester = [_adminUID] call ALIVE_fnc_getPlayerByUID;
     private _authorised = !isMultiplayer
-        || {hasInterface && {call ALiVE_fnc_isServerAdmin}}
+        || {hasInterface && {!isNull _requester && {_requester isEqualTo player}}}
         || {_adminUID in (missionNamespace getVariable ["ALiVE_sys_data_saveAllowlist",[]])}
         || {!isNull _requester && {(admin owner _requester) > 0}};
 
@@ -489,7 +496,12 @@ if (_mode == "SAVESERVERYO" && isServer) exitWith {
         _saveServer = _this select 0;
         _exitServer = _this select 1;
         _adminUID = _this select 2;
-        WaitUntil {sleep 1; (count ([] call BIS_fnc_ListPlayers)) <= 1};
+        // Wait for everyone to leave before writing. One person is expected to
+        // remain, the one who asked for the save, so they can watch it finish.
+        // On a server someone is hosting from, the host is a player too and is
+        // also still here, so two remaining is the normal case there and waiting
+        // for one would wait for ever.
+        WaitUntil {sleep 1; (count ([] call BIS_fnc_ListPlayers)) <= ([1,2] select (isServer && hasInterface))};
         [_adminUID] call _saveServer;
         [_adminUID] call _exitServer;
         "serversaved" call BIS_fnc_endMission;
@@ -590,10 +602,21 @@ switch (_mode) do {
         // wait: the initiator when the save request carries a UID, else
         // the admin (legacy REMSAVE). Keeping both would strand the
         // count above 1 and stall the save.
-        private _staysBehind = if (_adminUID != "") then {
-            (getPlayerUID player) == _adminUID
-        } else {
-            call ALiVE_fnc_isServerAdmin
+        //
+        // The server has to be excluded from that decision outright. This
+        // runs on every machine, the server included, and a server that
+        // ends its own mission here kills the save it is about to write.
+        // On a dedicated server there is nobody playing, so asking whether
+        // the local player is the one who asked always comes back no, and
+        // the branch below would end the mission every time. The check that
+        // used to sit here happened to return true on the server, which is
+        // the only reason saving has worked until now.
+        private _staysBehind = isServer || {
+            if (_adminUID != "") then {
+                hasInterface && {(getPlayerUID player) isEqualTo _adminUID}
+            } else {
+                call ALiVE_fnc_isServerAdmin
+            }
         };
         if !(_staysBehind) then {
             ["Exit - [%1] !(Admin) Ending mission",_mode] call ALiVE_fnc_dump;

--- a/addons/sys_data/CfgVehicles.hpp
+++ b/addons/sys_data/CfgVehicles.hpp
@@ -64,6 +64,13 @@ class CfgVehicles {
                                 tooltip = "$STR_ALIVE_data_customPerfMonCode_COMMENT";
                                 defaultValue = """[['entities',150],['vehicles',300],['agents',450],['allDead',600],['objects',750],['triggers',900],['activeScripts',1050]]""";
                         };
+                        class saveAllowlist : Edit
+                        {
+                                property = "ALiVE_sys_data_saveAllowlist";
+                                displayName = "$STR_ALIVE_data_saveAllowlist";
+                                tooltip = "$STR_ALIVE_data_saveAllowlist_COMMENT";
+                                defaultValue = """""";
+                        };
                         class ModuleDescription : ModuleDescription {};
                 };
         };

--- a/addons/sys_data/fnc_DataInit.sqf
+++ b/addons/sys_data/fnc_DataInit.sqf
@@ -58,6 +58,12 @@ if (isnil "_logic") then {
 // Check data source
 GVAR(SOURCE) = _logic getVariable ["source","CouchDB"];
 
+// Parse the Save Server UID allowlist (comma separated Steam UIDs) and broadcast it (#873)
+if (isServer) then {
+    GVAR(saveAllowlist) = (_logic getVariable ["saveAllowlist",""]) splitString ", ";
+    publicVariable QGVAR(saveAllowlist);
+};
+
 TRACE_2("SYS_DATA",isDedicated, _logic);
 
 _moduleID = [_logic, true] call ALIVE_fnc_dumpModuleInit;

--- a/addons/sys_data/stringtable.xml
+++ b/addons/sys_data/stringtable.xml
@@ -119,6 +119,16 @@
                 <Chinesesimp>自定义对象计数和间隔。确保间隔值按升序排列。'triggers'将计算所有的missionobjects "EmptyDetector", 'entities'将计算实体"All", 'objects'将计算所有的missionobjects "All", 'activeScripts'将计算所有的活动脚本。其他的将被计算为YOURPARAM,也就是计算allDead。</Chinesesimp>
             </Key>
             <!-- AI-translated; native-speaker review welcome -->
+            <Key ID="STR_ALIVE_Data_saveAllowlist">
+                <English>Save Server Allowlist:</English>
+                <Chinesesimp>服务器保存白名单:</Chinesesimp>
+            </Key>
+            <!-- AI-translated; native-speaker review welcome -->
+            <Key ID="STR_ALIVE_Data_saveAllowlist_COMMENT">
+                <English>Comma separated list of Steam UIDs allowed to use the Save Server button without being logged in as admin. Leave empty to restrict saving to admins.</English>
+                <Chinesesimp>允许在未以管理员身份登录的情况下使用"保存服务器"按钮的Steam UID列表(逗号分隔)。留空则仅限管理员保存。</Chinesesimp>
+            </Key>
+            <!-- AI-translated; native-speaker review welcome -->
             <Key ID="STR_ALIVE_DATA_MENU">
                 <English>Persistent Data</English>
                 <Chinese>持久化資料</Chinese>

--- a/addons/ui/fnc_RscDisplayMPInterruptALIVE.sqf
+++ b/addons/ui/fnc_RscDisplayMPInterruptALIVE.sqf
@@ -9,7 +9,7 @@ _display = _this select 0;
 
 // ALIVE ADMIN BUTTONS
 _serverSave = _display displayctrl 195;
-_serverSave ctrladdeventhandler ["buttonclick","with uinamespace do {if (serverCommandAvailable '#kick') then {(ctrlParent (_this select 0)) closeDisplay 1; ['SERVERSAVE'] call alive_fnc_buttonAbort};};"];
+_serverSave ctrladdeventhandler ["buttonclick","with uinamespace do {if (serverCommandAvailable '#kick' || {(getPlayerUID player) in (missionNamespace getVariable ['ALiVE_sys_data_saveAllowlist',[]])}) then {(ctrlParent (_this select 0)) closeDisplay 1; ['SERVERSAVE'] call alive_fnc_buttonAbort};};"];
 
 _serverExit = _display displayctrl 196;
 _serverExit ctrladdeventhandler ["buttonclick","with uinamespace do {if (serverCommandAvailable '#kick') then {(ctrlParent (_this select 0)) closeDisplay 1; ['SERVERABORT'] call alive_fnc_buttonAbort};};"];


### PR DESCRIPTION
Server owners currently have to hand out the admin password just to let a trusted player press Save Server, since the button is gated on serverCommandAvailable '#kick'. This adds a Save Allowlist attribute (comma-separated Steam UIDs) to the data module. Players on the list see the button and their save request passes a new server-side check on the SAVESERVERYO handler, which previously accepted any remote call. Legacy behavior is unchanged when the list is empty.

The stay-behind logic also needed touching: with a non-admin initiator plus a logged-in admin online, both used to stay behind and the server's wait for exactly one remaining player never fired. Now exactly one player stays (the initiator when the request carries a UID, the admin on legacy calls) and the wait accepts the player count dropping past one, so a disconnect mid-save no longer strands it.

Two honest caveats. The server gate authenticates by the UID carried in the call, and UIDs of connected players are readable by other clients, so this is a mission-maker convenience gate rather than hard anti-spoof security - though it is stricter than the previous state, which had no server-side check at all. And our dedicated box is retired, so the dedicated-server path is verified in code but not live; the hosted path behaves as before.

Fixes #873