### PR TITLE
[MIL_C2ISTAR] Task manager survives a vanished task; diagnostics for #1002

### DIFF
--- a/addons/mil_c2istar/fnc_C2ISTAR.sqf
+++ b/addons/mil_c2istar/fnc_C2ISTAR.sqf
@@ -1081,6 +1081,15 @@ switch(_operation) do {
         // the server-side COP loop honours it too.
         ALiVE_mil_c2istar_debug = _debug;
 
+        // Same for the task diagnostics flag. Nothing in a mission sets
+        // ALiVE_c2istar_taskDiag -- it was console-only -- and the traces it gates sit
+        // in the task manager loop, which runs on the server, so asking a reporter for
+        // a log meant asking them to set a global server side first. Turning the
+        // module's Debug attribute on now raises it here too, on every machine init
+        // touches. Only ever raised, never cleared, so setting the flag by hand on a
+        // mission with Debug off still works.
+        if (_debug) then { ALiVE_c2istar_taskDiag = true; };
+
         // Distribute the consolidated auto-task faction picker into the six
         // per-slot vars the auto-task generator reads (autoGenerateBluforFaction
         // / ...EnemyFaction / OPF / IND). The Eden SAVE handler can't persist

--- a/addons/mil_c2istar/fnc_taskHandler.sqf
+++ b/addons/mil_c2istar/fnc_taskHandler.sqf
@@ -1979,11 +1979,12 @@ switch (_operation) do {
                                 // task params, and dispatches the removal to clients.
                                 // The requesting player comes off _mainTask, which the guard
                                 // at the top of this iteration has already proved is an array.
-                                // Reading it off the lookup above instead was the one place in
-                                // this branch still doing so unguarded: when that lookup came
-                                // back with nothing, select threw, the waitUntil ended, and the
-                                // manager stopped re-checking every task it held -- each one
-                                // left open at its current stage for the rest of the mission.
+                                // Reading it off the lookup above instead: when that lookup
+                                // came back with nothing, select threw, the waitUntil ended,
+                                // and the manager stopped re-checking every task it held --
+                                // each one left open at its current stage for the rest of the
+                                // mission. Same source is used for the Constant regeneration
+                                // below, which had the identical problem.
                                 [_logic, "TASK_DELETE", [_rootTaskID, (_mainTask select 1), _taskSide]] call MAINCLASS;
 
                                 // DIAG-STRIP #942: prove the teardown really removed the root task --
@@ -1994,13 +1995,25 @@ switch (_operation) do {
                                     ["[C2ISTAR #942 DIAG] teardown %1: stillActive=%2 activeLeft=%3", _rootTaskID, _rootTaskID in (_diagActiveTasks select 1), count (_diagActiveTasks select 1)] call ALIVE_fnc_dump;
                                 };
 
-                                private _autoGenerateSides = [_logic,"autoGenerateSides"] call ALIVE_fnc_hashGet;
-                                private _sideAutoGeneration = [_autoGenerateSides,_taskSide] call ALIVE_fnc_hashGet;
+                                // Both reads now carry a default, the way the pair in the else
+                                // branch below does. A side with no auto-generate entry -- the
+                                // init only writes EAST, WEST, GUER and CIV -- read back as
+                                // nothing, and the select on the next line took the manager down
+                                // before it ever reached the Constant branch. "None" is what the
+                                // init writes for a side that does not auto-generate.
+                                private _autoGenerateSides = [_logic,"autoGenerateSides",["", [], [], ""]] call ALIVE_fnc_hashGet;
+                                private _sideAutoGeneration = [_autoGenerateSides,_taskSide,["None",""]] call ALIVE_fnc_hashGet;
 
                                 if (_sideAutoGeneration select 0 == "Constant") then {
                                     uiSleep (10 + (random 50));
 
-                                    _task params ["", "_requestPlayerID", "", "", "_taskFaction"];
+                                    // Requesting player and faction come off _mainTask for the same
+                                    // reason the teardown above does: the root lookup they used to
+                                    // come off can return nothing now a running task is cancellable,
+                                    // and params against nothing ends the manager thread. Both
+                                    // records carry the same two values -- a child task is built
+                                    // from its parent's requester and faction.
+                                    _mainTask params ["", "_requestPlayerID", "", "", "_taskFaction"];
 
                                     private _taskEnemyFaction = [_taskParams, "enemyFaction"] call ALIVE_fnc_hashGet;
                                     private _generate = [format ["%1_%2", _taskSide, time], _requestPlayerID, _taskSide, _taskFaction, _taskEnemyFaction, _sideAutoGeneration select 0];

--- a/addons/mil_c2istar/fnc_taskHandler.sqf
+++ b/addons/mil_c2istar/fnc_taskHandler.sqf
@@ -1891,6 +1891,14 @@ switch (_operation) do {
                     [_managedTasks, _x] call ALIVE_fnc_hashRem;
                 } forEach _managedTasksToRemove;
 
+                // DIAG-STRIP #1002: heartbeat. An error thrown anywhere below ends this
+                // waitUntil for good, and every managed task then sits at its current
+                // stage for the rest of the mission looking exactly like a completion
+                // check that never fires. If these lines stop, the thread died.
+                if (!isNil "ALiVE_c2istar_taskDiag" && {ALiVE_c2istar_taskDiag}) then {
+                    ["[C2ISTAR #1002 DIAG] manager cycle: %1 managed task(s)", count (_managedTasks select 1)] call ALIVE_fnc_dump;
+                };
+
                 if (count (_managedTasks select 1) > 0) then {
                     // for each of the tasks
                     {
@@ -1969,7 +1977,14 @@ switch (_operation) do {
                                 // them from the client task menu (#934). TASK_DELETE
                                 // unregisters the root + all children, releases the managed
                                 // task params, and dispatches the removal to clients.
-                                [_logic, "TASK_DELETE", [_rootTaskID, (_task select 1), _taskSide]] call MAINCLASS;
+                                // The requesting player comes off _mainTask, which the guard
+                                // at the top of this iteration has already proved is an array.
+                                // Reading it off the lookup above instead was the one place in
+                                // this branch still doing so unguarded: when that lookup came
+                                // back with nothing, select threw, the waitUntil ended, and the
+                                // manager stopped re-checking every task it held -- each one
+                                // left open at its current stage for the rest of the mission.
+                                [_logic, "TASK_DELETE", [_rootTaskID, (_mainTask select 1), _taskSide]] call MAINCLASS;
 
                                 // DIAG-STRIP #942: prove the teardown really removed the root task --
                                 // stillActive must read false here. true means stale activeTasks keys

--- a/addons/mil_c2istar/utils/fnc_taskGetStateOfObjects.sqf
+++ b/addons/mil_c2istar/utils/fnc_taskGetStateOfObjects.sqf
@@ -37,6 +37,24 @@ private _output = [];
     _output pushback _target;
 
     if (alive _target) then {[_state,"allDestroyed",false] call ALIVE_fnc_hashSet};
+
+    // DIAG-STRIP #1002: a sabotage/destroy task that stays open after the target has
+    // visibly come down cannot be told apart from a task nothing is re-checking at all.
+    // This says, once per management cycle, what this machine sees of the target. A
+    // handle that reads alive with damage 0 at its original position, while the building
+    // is gone on the client that blew it up, means the destruction never reached here --
+    // which is a different problem from the check itself. No line at all around the
+    // moment of destruction means the manager thread is no longer running.
+    if (!isNil "ALiVE_c2istar_taskDiag" && {ALiVE_c2istar_taskDiag}) then {
+        ["[C2ISTAR #1002 DIAG] target %1 (%2): isNull=%3 alive=%4 damage=%5 pos=%6",
+            _target,
+            typeOf _target,
+            isNull _target,
+            alive _target,
+            damage _target,
+            getPosATL _target
+        ] call ALIVE_fnc_dump;
+    };
 } forEach _targets;
 
 [_state,"targets",_output] call ALIVE_fnc_hashSet;


### PR DESCRIPTION
Went digging for #1002 and couldn't fault the completion check itself - the Sabotage Destroy stage runs the same taskGetStateOfObjects helper as DestroyBuilding and InsurgencyDestroyAssets, and it only holds a task open while a target reads alive. Whatever the reporter is hitting isn't separable from a log that covers the moment the building comes down, so this PR ships the instrumentation to settle it: behind the existing ALiVE_c2istar_taskDiag flag, the helper now dumps isNull/alive/damage/type/position per target each cycle, and the manager loop emits a heartbeat line. Silent and byte-identical with the flag unset.

The real find was in the teardown path next door: the TASK_DELETE payload was built by select on a getTask result that can come back empty now that running tasks are cancellable since the #992 work. When that happens the select throws, the manager's waitUntil dies for the session, and every task it held stays open forever - which incidentally reproduces the reported symptom exactly. It now reads the requesting player off the main task record the loop has already validated. Same value, always defined.

I'll ask the reporter for a flag-enabled log on the issue; between the heartbeat and the per-target dump, one log pins down which of the remaining explanations it is.

Ref #1002