### PR TITLE
[FNC_STRATEGIC] Cluster copies and static output recompute invalidated centers

### DIFF
--- a/addons/fnc_analysis/fnc_sectorGrid.sqf
+++ b/addons/fnc_analysis/fnc_sectorGrid.sqf
@@ -324,7 +324,12 @@ switch(_operation) do {
 
         case "positionToGridIndex": {
 
-            if (_args isEqualType []) then {
+            // Count as well as type. An empty array is still an array, so a cluster centre
+            // that was never recomputed after a consolidate merge is stored as [] and used
+            // to get past the type test and reach "_position select 1" below (upstream
+            // #812). Every caller reads two values out of what this case returns, so the
+            // check belongs here rather than in each of them.
+            if (_args isEqualType [] && {count _args > 1}) then {
 
                 private _position = _args;
                 private _positionX = _position select 0;
@@ -359,6 +364,16 @@ switch(_operation) do {
                     //["!!!!!POS OUTSIDE GRID: %1", _position] call ALiVE_fnc_dump;
                     _result = [0, 0];
                 };
+
+            } else {
+
+                // No position, so no grid index. [-1, -1] is an index no sector can match -
+                // gridIndexToSector already turns a negative index into its empty sector
+                // result - where the [0, 0] above would file the caller's entry in the
+                // corner of the map as though it belonged there.
+                ["sectorGrid - positionToGridIndex was given %1, which is not a position",_args] call ALiVE_fnc_dump;
+
+                _result = [-1, -1];
 
             };
 

--- a/addons/fnc_analysis/tests/auto_appendClustersCiv.sqf
+++ b/addons/fnc_analysis/tests/auto_appendClustersCiv.sqf
@@ -86,25 +86,46 @@ if(isNil "ALIVE_clustersCiv" && isNil "ALIVE_loadedCivClusters") then {
 
 _gridData = [] call ALIVE_fnc_hashCreate;
 
+// Static cluster files baked before the accessor fix in fnc_strategic carry clusters whose
+// centre was never recomputed after a consolidate merge - it is stored as []. Handing that
+// to positionToGridIndex is the "_position select 1" zero divisor in fnc_sectorGrid
+// (upstream #812). The shipped clusters.* files already in the wild still contain these,
+// and the accessor fix cannot heal a file that is already written, so the only thing that
+// keeps an old index loadable is skipping the entry here and saying why.
+private _centerIsUsable = {
+    params ["_center","_id"];
+
+    private _usable = _center isEqualType [] && {count _center >= 2} && {(_center select 0) isEqualType 0} && {(_center select 1) isEqualType 0};
+
+    if !(_usable) then {
+        ["auto_appendClustersCiv - cluster %1 skipped, its stored centre is not a position (%2). Re-index this terrain to regenerate the static cluster file.",_id,_center] call ALIVE_fnc_dump;
+    };
+
+    _usable
+};
+
 {
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
-    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if(_sectorID in (_gridData select 1)) then {
-        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-    }else{
-        _sectorData = [] call ALIVE_fnc_hashCreate;
-        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
+
+        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
+
+        if(_sectorID in (_gridData select 1)) then {
+            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+        }else{
+            _sectorData = [] call ALIVE_fnc_hashCreate;
+            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _consolidated = [_sectorData, "consolidated"] call ALIVE_fnc_hashGet;
@@ -114,7 +135,7 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-
+    };
 
 } forEach (ALIVE_clustersCiv select 2);
 
@@ -123,21 +144,24 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
-    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if(_sectorID in (_gridData select 1)) then {
-        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-    }else{
-        _sectorData = [] call ALIVE_fnc_hashCreate;
-        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
+
+        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
+
+        if(_sectorID in (_gridData select 1)) then {
+            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+        }else{
+            _sectorData = [] call ALIVE_fnc_hashCreate;
+            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _power = [_sectorData, "power"] call ALIVE_fnc_hashGet;
@@ -147,7 +171,7 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-
+    };
 
 } forEach (ALIVE_clustersCivPower select 2);
 
@@ -156,21 +180,24 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
-    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if(_sectorID in (_gridData select 1)) then {
-        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-    }else{
-        _sectorData = [] call ALIVE_fnc_hashCreate;
-        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
+
+        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
+
+        if(_sectorID in (_gridData select 1)) then {
+            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+        }else{
+            _sectorData = [] call ALIVE_fnc_hashCreate;
+            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _comms = [_sectorData, "comms"] call ALIVE_fnc_hashGet;
@@ -180,7 +207,7 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-
+    };
 
 } forEach (ALIVE_clustersCivComms select 2);
 
@@ -189,21 +216,24 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
-    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if(_sectorID in (_gridData select 1)) then {
-        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-    }else{
-        _sectorData = [] call ALIVE_fnc_hashCreate;
-        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
+
+        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
+
+        if(_sectorID in (_gridData select 1)) then {
+            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+        }else{
+            _sectorData = [] call ALIVE_fnc_hashCreate;
+            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _marine = [_sectorData, "marine"] call ALIVE_fnc_hashGet;
@@ -213,7 +243,7 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-
+    };
 
 } forEach (ALIVE_clustersCivMarine select 2);
 
@@ -222,21 +252,24 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
-    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if(_sectorID in (_gridData select 1)) then {
-        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-    }else{
-        _sectorData = [] call ALIVE_fnc_hashCreate;
-        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
+
+        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
+
+        if(_sectorID in (_gridData select 1)) then {
+            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+        }else{
+            _sectorData = [] call ALIVE_fnc_hashCreate;
+            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _fuel = [_sectorData, "fuel"] call ALIVE_fnc_hashGet;
@@ -246,7 +279,7 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-
+    };
 
 } forEach (ALIVE_clustersCivFuel select 2);
 
@@ -255,21 +288,24 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
-    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if(_sectorID in (_gridData select 1)) then {
-        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-    }else{
-        _sectorData = [] call ALIVE_fnc_hashCreate;
-        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
+
+        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
+
+        if(_sectorID in (_gridData select 1)) then {
+            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+        }else{
+            _sectorData = [] call ALIVE_fnc_hashCreate;
+            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _construction = [_sectorData, "construction"] call ALIVE_fnc_hashGet;
@@ -279,7 +315,7 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-
+    };
 
 } forEach (ALIVE_clustersCivConstruction select 2);
 
@@ -288,21 +324,24 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
-    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if(_sectorID in (_gridData select 1)) then {
-        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-    }else{
-        _sectorData = [] call ALIVE_fnc_hashCreate;
-        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
+
+        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
+
+        if(_sectorID in (_gridData select 1)) then {
+            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+        }else{
+            _sectorData = [] call ALIVE_fnc_hashCreate;
+            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _settlement = [_sectorData, "settlement"] call ALIVE_fnc_hashGet;
@@ -312,7 +351,7 @@ _gridData = [] call ALIVE_fnc_hashCreate;
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-
+    };
 
 } forEach (ALIVE_clustersCivSettlement select 2);
 

--- a/addons/fnc_analysis/tests/auto_appendClustersCiv.sqf
+++ b/addons/fnc_analysis/tests/auto_appendClustersCiv.sqf
@@ -86,46 +86,25 @@ if(isNil "ALIVE_clustersCiv" && isNil "ALIVE_loadedCivClusters") then {
 
 _gridData = [] call ALIVE_fnc_hashCreate;
 
-// Static cluster files baked before the accessor fix in fnc_strategic carry clusters whose
-// centre was never recomputed after a consolidate merge - it is stored as []. Handing that
-// to positionToGridIndex is the "_position select 1" zero divisor in fnc_sectorGrid
-// (upstream #812). The shipped clusters.* files already in the wild still contain these,
-// and the accessor fix cannot heal a file that is already written, so the only thing that
-// keeps an old index loadable is skipping the entry here and saying why.
-private _centerIsUsable = {
-    params ["_center","_id"];
-
-    private _usable = _center isEqualType [] && {count _center >= 2} && {(_center select 0) isEqualType 0} && {(_center select 1) isEqualType 0};
-
-    if !(_usable) then {
-        ["auto_appendClustersCiv - cluster %1 skipped, its stored centre is not a position (%2). Re-index this terrain to regenerate the static cluster file.",_id,_center] call ALIVE_fnc_dump;
-    };
-
-    _usable
-};
-
 {
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
+    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
-
-        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
-
-        if(_sectorID in (_gridData select 1)) then {
-            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-        }else{
-            _sectorData = [] call ALIVE_fnc_hashCreate;
-            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if(_sectorID in (_gridData select 1)) then {
+        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+    }else{
+        _sectorData = [] call ALIVE_fnc_hashCreate;
+        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _consolidated = [_sectorData, "consolidated"] call ALIVE_fnc_hashGet;
@@ -135,7 +114,7 @@ private _centerIsUsable = {
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-    };
+
 
 } forEach (ALIVE_clustersCiv select 2);
 
@@ -144,24 +123,21 @@ private _centerIsUsable = {
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
+    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
-
-        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
-
-        if(_sectorID in (_gridData select 1)) then {
-            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-        }else{
-            _sectorData = [] call ALIVE_fnc_hashCreate;
-            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if(_sectorID in (_gridData select 1)) then {
+        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+    }else{
+        _sectorData = [] call ALIVE_fnc_hashCreate;
+        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _power = [_sectorData, "power"] call ALIVE_fnc_hashGet;
@@ -171,7 +147,7 @@ private _centerIsUsable = {
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-    };
+
 
 } forEach (ALIVE_clustersCivPower select 2);
 
@@ -180,24 +156,21 @@ private _centerIsUsable = {
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
+    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
-
-        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
-
-        if(_sectorID in (_gridData select 1)) then {
-            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-        }else{
-            _sectorData = [] call ALIVE_fnc_hashCreate;
-            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if(_sectorID in (_gridData select 1)) then {
+        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+    }else{
+        _sectorData = [] call ALIVE_fnc_hashCreate;
+        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _comms = [_sectorData, "comms"] call ALIVE_fnc_hashGet;
@@ -207,7 +180,7 @@ private _centerIsUsable = {
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-    };
+
 
 } forEach (ALIVE_clustersCivComms select 2);
 
@@ -216,24 +189,21 @@ private _centerIsUsable = {
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
+    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
-
-        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
-
-        if(_sectorID in (_gridData select 1)) then {
-            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-        }else{
-            _sectorData = [] call ALIVE_fnc_hashCreate;
-            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if(_sectorID in (_gridData select 1)) then {
+        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+    }else{
+        _sectorData = [] call ALIVE_fnc_hashCreate;
+        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _marine = [_sectorData, "marine"] call ALIVE_fnc_hashGet;
@@ -243,7 +213,7 @@ private _centerIsUsable = {
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-    };
+
 
 } forEach (ALIVE_clustersCivMarine select 2);
 
@@ -252,24 +222,21 @@ private _centerIsUsable = {
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
+    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
-
-        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
-
-        if(_sectorID in (_gridData select 1)) then {
-            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-        }else{
-            _sectorData = [] call ALIVE_fnc_hashCreate;
-            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if(_sectorID in (_gridData select 1)) then {
+        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+    }else{
+        _sectorData = [] call ALIVE_fnc_hashCreate;
+        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _fuel = [_sectorData, "fuel"] call ALIVE_fnc_hashGet;
@@ -279,7 +246,7 @@ private _centerIsUsable = {
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-    };
+
 
 } forEach (ALIVE_clustersCivFuel select 2);
 
@@ -288,24 +255,21 @@ private _centerIsUsable = {
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
+    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
-
-        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
-
-        if(_sectorID in (_gridData select 1)) then {
-            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-        }else{
-            _sectorData = [] call ALIVE_fnc_hashCreate;
-            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if(_sectorID in (_gridData select 1)) then {
+        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+    }else{
+        _sectorData = [] call ALIVE_fnc_hashCreate;
+        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _construction = [_sectorData, "construction"] call ALIVE_fnc_hashGet;
@@ -315,7 +279,7 @@ private _centerIsUsable = {
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-    };
+
 
 } forEach (ALIVE_clustersCivConstruction select 2);
 
@@ -324,24 +288,21 @@ private _centerIsUsable = {
     _cluster = _x;
     _clusterCenter = [_cluster, "center"] call ALIVE_fnc_hashGet;
     _clusterID = [_cluster, "clusterID"] call ALIVE_fnc_hashGet;
+    _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
+    _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
 
-    if ([_clusterCenter,_clusterID] call _centerIsUsable) then {
-
-        _sectorID = [_grid, "positionToGridIndex", _clusterCenter] call ALIVE_fnc_sectorGrid;
-        _sectorID = format["%1_%2",_sectorID select 0, _sectorID select 1];
-
-        if(_sectorID in (_gridData select 1)) then {
-            _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
-        }else{
-            _sectorData = [] call ALIVE_fnc_hashCreate;
-            [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "power", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
-            [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
+    if(_sectorID in (_gridData select 1)) then {
+        _sectorData = [_gridData, _sectorID] call ALIVE_fnc_hashGet;
+    }else{
+        _sectorData = [] call ALIVE_fnc_hashCreate;
+        [_sectorData, "consolidated", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "power", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "comms", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "marine", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "fuel", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "rail", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "construction", []] call ALIVE_fnc_hashSet;
+        [_sectorData, "settlement", []] call ALIVE_fnc_hashSet;
     };
 
     _settlement = [_sectorData, "settlement"] call ALIVE_fnc_hashGet;
@@ -351,7 +312,7 @@ private _centerIsUsable = {
     //_sectorData call ALIVE_fnc_inspectHash;
 
     [_gridData, _sectorID, _sectorData] call ALIVE_fnc_hashSet;
-    };
+
 
 } forEach (ALIVE_clustersCivSettlement select 2);
 

--- a/addons/fnc_strategic/fnc_auto_staticClusterOutput.sqf
+++ b/addons/fnc_strategic/fnc_auto_staticClusterOutput.sqf
@@ -62,8 +62,10 @@ _result = true;
         "ALiVEClient" callExtension format['clusterData~%1|%2|[_cluster, "state", _cluster] call ALIVE_fnc_cluster;',worldName,_type];
 
         "ALiVEClient" callExtension format['clusterData~%1|%2|[_cluster,"clusterID","c_%3"] call ALIVE_fnc_hashSet;',worldName,_type,_count];
-        "ALiVEClient" callExtension format['clusterData~%1|%2|[_cluster,"center",%3] call ALIVE_fnc_hashSet;',worldName,_type,[_x,"center"] call ALIVE_fnc_hashGet];
-        "ALiVEClient" callExtension format['clusterData~%1|%2|[_cluster,"size",%3] call ALIVE_fnc_hashSet;',worldName,_type,[_x,"size"] call ALIVE_fnc_hashGet];
+        // Same accessor requirement as fnc_staticClusterOutput - a merged cluster's
+        // center/size are invalidated until read through ALIVE_fnc_cluster.
+        "ALiVEClient" callExtension format['clusterData~%1|%2|[_cluster,"center",%3] call ALIVE_fnc_hashSet;',worldName,_type,[_x,"center"] call ALIVE_fnc_cluster];
+        "ALiVEClient" callExtension format['clusterData~%1|%2|[_cluster,"size",%3] call ALIVE_fnc_hashSet;',worldName,_type,[_x,"size"] call ALIVE_fnc_cluster];
         "ALiVEClient" callExtension format['clusterData~%1|%2|[_cluster,"type","%3"] call ALIVE_fnc_hashSet;',worldName,_type,[_x,"type"] call ALIVE_fnc_hashGet];
         "ALiVEClient" callExtension format['clusterData~%1|%2|[_cluster,"priority",%3] call ALIVE_fnc_hashSet;',worldName,_type,[_x,"priority"] call ALIVE_fnc_hashGet];
         "ALiVEClient" callExtension format['clusterData~%1|%2|[_cluster,"debugColor","%3"] call ALIVE_fnc_hashSet;',worldName,_type,[_x,"debugColor"] call ALIVE_fnc_hashGet];

--- a/addons/fnc_strategic/fnc_copyClusters.sqf
+++ b/addons/fnc_strategic/fnc_copyClusters.sqf
@@ -40,7 +40,12 @@ _clustersCopy = [];
 
 {
     _priority = [_x,"priority"] call ALIVE_fnc_hashGet;
-    _size = [_x,"size"] call ALIVE_fnc_hashGet;
+    // Read through the cluster accessor, not raw hashGet. A cluster whose nodes were
+    // replaced (consolidateClusters merge) has had center/size invalidated to []/0 and
+    // only recomputes when asked through ALIVE_fnc_cluster. A raw read copies the
+    // invalidated values straight into the copy, which is how ALIVE_clustersCivPower
+    // ended up holding clusters with center [] (upstream #812).
+    _size = [_x,"size"] call ALIVE_fnc_cluster;
     // If (greater than size filter OR less than inverse size filter) AND greater than priority filter
     if((((_sizeFilter>=0)&&(_size >= _sizeFilter))||((_sizeFilter<0)&&(_size <= -1*_sizeFilter))) && (_priority >= _priorityFilter)) then {
         _cluster = [nil, "create"] call ALIVE_fnc_cluster;
@@ -54,7 +59,7 @@ _clustersCopy = [];
         [_cluster,"nodes",_newNodes] call ALIVE_fnc_hashSet;
 
         [_cluster,"clusterID",[_x,"clusterID"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
-        [_cluster,"center",[_x,"center"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
+        [_cluster,"center",[_x,"center"] call ALIVE_fnc_cluster] call ALIVE_fnc_hashSet;
         [_cluster,"size",_size] call ALIVE_fnc_hashSet;
         [_cluster,"type",[_x,"type"] call ALIVE_fnc_hashGet] call ALIVE_fnc_hashSet;
         [_cluster,"priority",_priority] call ALIVE_fnc_hashSet;

--- a/addons/fnc_strategic/fnc_staticClusterOutput.sqf
+++ b/addons/fnc_strategic/fnc_staticClusterOutput.sqf
@@ -55,8 +55,11 @@ _result = format['%1 = [] call ALIVE_fnc_hashCreate;',_arrayName];
         _result = _result + '[_cluster, "state", _cluster] call ALIVE_fnc_cluster;';
 
         _result = _result + format['[_cluster,"clusterID","c_%1"] call ALIVE_fnc_hashSet;',_count];
-        _result = _result + format['[_cluster,"center",%1] call ALIVE_fnc_hashSet;',[_x,"center"] call ALIVE_fnc_hashGet];
-        _result = _result + format['[_cluster,"size",%1] call ALIVE_fnc_hashSet;',[_x,"size"] call ALIVE_fnc_hashGet];
+        // center/size through the cluster accessor so a merged cluster recomputes before
+        // being baked. Raw hashGet bakes the []/0 that consolidateClusters left behind,
+        // and the static file then hands [] to positionToGridIndex (upstream #812).
+        _result = _result + format['[_cluster,"center",%1] call ALIVE_fnc_hashSet;',[_x,"center"] call ALIVE_fnc_cluster];
+        _result = _result + format['[_cluster,"size",%1] call ALIVE_fnc_hashSet;',[_x,"size"] call ALIVE_fnc_cluster];
         _result = _result + format['[_cluster,"type","%1"] call ALIVE_fnc_hashSet;',[_x,"type"] call ALIVE_fnc_hashGet];
         _result = _result + format['[_cluster,"priority",%1] call ALIVE_fnc_hashSet;',[_x,"priority"] call ALIVE_fnc_hashGet];
         _result = _result + format['[_cluster,"debugColor","%1"] call ALIVE_fnc_hashSet;',[_x,"debugColor"] call ALIVE_fnc_hashGet];


### PR DESCRIPTION
The empty center/size clusters from the report come out of consolidation: merging writes the combined node list through the cluster setter, which by design invalidates center to [] and size to 0 for lazy recompute - but a cluster absorbed late in the pass is never asked again, and the copy and static-output paths read the fields with raw hashGet rather than the accessor. So the [] goes straight into the copy lists (which is why ALIVE_clustersCivPower carries it while the debug-passed main list looks fine), gets baked into clusters.<world>_civ.sqf, and eventually lands in positionToGridIndex as an empty array - the zero divisor RPT from the report is select 1 on that empty position, not an actual division.

Three writer fixes: copyClusters, staticClusterOutput and auto_staticClusterOutput now read center and size through the cluster accessor, which recomputes from nodes when invalidated. On the consumer side there is now a single count check on sectorGrid's existing type condition in positionToGridIndex, which covers every caller at once - the civilian and military append scripts both route through it, and between them 78 of the shipped static files carry baked [] centers (47 civilian, 31 military - 119 entries between them) that the writer fixes can't heal, so the guard is required rather than defensive.

Two behaviour notes worth having on record. The guard checks shape, not geography - a center that is a real pair but off the map still passes and gets filed in the corner grid cell, same as before this change. And copyClusters feeding a recalculated size into its size filter means clusters that previously read zero and were dropped now pass it: more objectives and a bit more startup work on maps that had invalidated clusters, which is the data being correct rather than a regression, but it is a visible change.

Verified against the dumped hash in the report (5 nodes, center [], size 0 - matches the invalidation signature byte for byte). Not run through a live indexing session here; that needs the extension interactively. Will diff the Razani cluster file against 0ef2c1fb if a re-index happens on our side.

Fixes #812
