### PR TITLE
[SYS_PLAYER] Save players when they actually disconnect; never persist a dead state

### DIFF
--- a/addons/sys_player/fnc_player.sqf
+++ b/addons/sys_player/fnc_player.sqf
@@ -337,6 +337,48 @@ switch(_operation) do {
 
                 [ALiVE_fnc_autoStorePlayer, DEFAULT_INTERVAL, [DEFAULT_INTERVAL]] call CBA_fnc_addPerFrameHandler;
 
+                // Inferno #885: capture player state the moment they drop. This
+                // is the only save path in sys_player driven by an actual engine
+                // disconnect. ALIVE_fnc_player_onPlayerDisconnected is not wired
+                // to one despite the name - main's PlayerDisconnected EH
+                // (main\XEH_postServerInit.sqf) runs ALiVE_fnc_onPlayerDisconnected,
+                // which only decrements the player count. The sys_player function
+                // is called by the Abort button (main\fnc_buttonAbort.sqf) and by
+                // the sys_data_pns autosave, both with the unit still in play.
+                // So an alt-F4 or a timeout saved nothing at all: those players
+                // rejoined on the last autoStorePlayer pass, up to
+                // DEFAULT_INTERVAL stale. HandleDisconnect fires on the real
+                // drop and still receives the live unit object, which closes that
+                // window without a separate uid->unit map.
+                if (isNil QGVAR(disconnectEH)) then {
+                    GVAR(disconnectEH) = addMissionEventHandler ["HandleDisconnect", {
+                        params ["_unit","_id","_uid","_name"];
+
+                        private _save = _uid != ""
+                            && {!isNull _unit}
+                            && {MOD(sys_player) getVariable ["enablePlayerPersistence", false]}
+                            && {!(_unit getVariable [QGVAR(kicked), false])};
+
+                        // #885 comment (UnRealxInferno): never persist a dead,
+                        // downed or unconscious state - see PLAYER_STATE_UNSAVEABLE.
+                        // Bailing here keeps the disconnect-specific log; the
+                        // "setPlayer" case below repeats the check so the periodic
+                        // autoStorePlayer pass cannot store it either.
+                        if (_save && {PLAYER_STATE_UNSAVEABLE(_unit)}) then {
+                            _save = false;
+                            ["SYS_PLAYER - DISCONNECT SAVE SKIPPED, %1 IS NOT ALIVE", _name] call ALiVE_fnc_dump;
+                        };
+
+                        if (_save) then {
+                            [MOD(sys_player), "setPlayer", [_unit, _uid]] call ALIVE_fnc_player;
+                            ["SYS_PLAYER - SAVED STATE ON DISCONNECT FOR %1", _name] call ALiVE_fnc_dump;
+                        };
+
+                        // Never claim the body - let the engine handle it as before
+                        false
+                    }];
+                };
+
             };
 
             // Eventhandlers for other stuff here
@@ -486,12 +528,36 @@ switch(_operation) do {
         };
         case "setPlayer": {
                         // Set player data to player store
-                        private ["_playerHash","_unit"];
+                        private ["_playerHash","_unit","_puid"];
                         _unit  = _args select 0;
-                        _playerHash = [_logic, _args] call ALIVE_fnc_setPlayer;
-                        [GVAR(player_data), getplayerUID _unit] call ALIVE_fnc_hashRem;
-                        [GVAR(player_data), getplayerUID _unit, _playerHash] call ALIVE_fnc_hashSet;
-                        _result = _playerHash;
+                        // The HandleDisconnect save passes the UID explicitly:
+                        // getPlayerUID is already empty on a dropping unit, and an
+                        // empty key would file the record under "" and lose it on
+                        // rejoin. Every other caller omits it and keeps the old
+                        // getPlayerUID behaviour.
+                        _puid = _args param [1, getPlayerUID _unit, [""]];
+                        if (_puid == "") then {
+                            TRACE_1("SYS_PLAYER NO UID FOR PLAYER SAVE",_unit);
+                            _result = false;
+                        } else {
+                            // Inferno #885: this is the single choke point for the
+                            // server player store - autoStorePlayer, the Abort
+                            // button path, the sys_playeroptions manual save and
+                            // the HandleDisconnect save all land
+                            // here. Guarding it (rather than any one caller) is
+                            // what makes "leave the last good save standing" hold:
+                            // the periodic autostore would otherwise write a dead
+                            // player's state mid-window and restore it on rejoin.
+                            if (PLAYER_STATE_UNSAVEABLE(_unit)) then {
+                                TRACE_2("SYS_PLAYER SAVE SKIPPED, UNIT NOT IN A SAVEABLE STATE",_unit,lifeState _unit);
+                                _result = false;
+                            } else {
+                                _playerHash = [_logic, [_unit, _puid]] call ALIVE_fnc_setPlayer;
+                                [GVAR(player_data), _puid] call ALIVE_fnc_hashRem;
+                                [GVAR(player_data), _puid, _playerHash] call ALIVE_fnc_hashSet;
+                                _result = _playerHash;
+                            };
+                        };
         };
         case "checkPlayer": {
                    // Check to see if the player joining has the same class as the one stored in memory

--- a/addons/sys_player/fnc_player.sqf
+++ b/addons/sys_player/fnc_player.sqf
@@ -354,10 +354,22 @@ switch(_operation) do {
                     GVAR(disconnectEH) = addMissionEventHandler ["HandleDisconnect", {
                         params ["_unit","_id","_uid","_name"];
 
+                        // "checkPlayer" sets the kicked flag on the unit so the
+                        // wrong-class kick does not overwrite a good save, but the
+                        // only place that ever cleared it again was the Abort path
+                        // in ALIVE_fnc_player_onPlayerDisconnected. A kicked slot
+                        // therefore stayed flagged, and every later player in it
+                        // silently lost their disconnect save. Honour it once here,
+                        // then clear it so the flag does not outlive the kick.
+                        private _kicked = !isNull _unit && {_unit getVariable [QGVAR(kicked), false]};
+                        if (_kicked) then {
+                            _unit setVariable [QGVAR(kicked), false, true];
+                        };
+
                         private _save = _uid != ""
                             && {!isNull _unit}
                             && {MOD(sys_player) getVariable ["enablePlayerPersistence", false]}
-                            && {!(_unit getVariable [QGVAR(kicked), false])};
+                            && {!_kicked};
 
                         // #885 comment (UnRealxInferno): never persist a dead,
                         // downed or unconscious state - see PLAYER_STATE_UNSAVEABLE.
@@ -549,7 +561,15 @@ switch(_operation) do {
                             // the periodic autostore would otherwise write a dead
                             // player's state mid-window and restore it on rejoin.
                             if (PLAYER_STATE_UNSAVEABLE(_unit)) then {
-                                TRACE_2("SYS_PLAYER SAVE SKIPPED, UNIT NOT IN A SAVEABLE STATE",_unit,lifeState _unit);
+                                // Plain log, not TRACE - a release build compiles the
+                                // trace out, so there was no way to tell the guard
+                                // fired. autoStorePlayer walks the playable units
+                                // every DEFAULT_INTERVAL, so this repeats once per
+                                // interval while someone is down: keep it
+                                // informational and name the player, the state and
+                                // the fact the earlier save still stands, so a
+                                // repeat reads as the same player still down.
+                                ["SYS_PLAYER - SAVE SKIPPED FOR %1 (%2), UNIT IS %3 - LAST GOOD SAVE KEPT", name _unit, _puid, toUpper (lifeState _unit)] call ALiVE_fnc_dump;
                                 _result = false;
                             } else {
                                 _playerHash = [_logic, [_unit, _puid]] call ALIVE_fnc_setPlayer;

--- a/addons/sys_player/fnc_player_onPlayerDisconnected.sqf
+++ b/addons/sys_player/fnc_player_onPlayerDisconnected.sqf
@@ -3,7 +3,13 @@
  * fnc_player_onPlayerDisconnected.sqf
  *
  * Description:
- * handled onPlayerDisconnected event for sys_player, saving player data when they disconnect
+ * Saves player data on request. Despite the name this is NOT bound to an
+ * engine disconnect event - main's PlayerDisconnected EH runs
+ * ALiVE_fnc_onPlayerDisconnected (a player count decrement) and never reaches
+ * here. The real callers are the Abort button (main\fnc_buttonAbort.sqf, both
+ * the player and __SERVER__ paths) and the sys_data_pns autosave
+ * (sys_data_pns\fnc_autosave.sqf), all with the unit still in play. Saves on
+ * an actual drop are handled by the HandleDisconnect EH in ALiVE_fnc_player.
  *
  * Created by Tupolov
  * Creation date: 06/08/2013

--- a/addons/sys_player/fnc_setPlayer.sqf
+++ b/addons/sys_player/fnc_setPlayer.sqf
@@ -29,7 +29,7 @@ Peer reviewed:
 nil
 ---------------------------------------------------------------------------- */
 
-private ["_logic","_args","_player","_find","_saveLoadout","_saveHealth","_savePosition","_saveScores","_data","_playerHash","_result","_data"];
+private ["_logic","_args","_player","_puid","_find","_saveLoadout","_saveHealth","_savePosition","_saveScores","_data","_playerHash","_result","_data"];
 
 _logic = _this param [0, objNull, [objNull,[]]];
 _args = _this param [1, objNull, [objNull,[],"",0,true,false]];
@@ -37,6 +37,13 @@ _args = _this param [1, objNull, [objNull,[],"",0,true,false]];
 _data =  [];
 
 _player = _args select 0;
+
+// Optional explicit UID. Only the HandleDisconnect save in ALiVE_fnc_player
+// supplies it, because getPlayerUID returns "" once the engine has detached
+// the dropping player (Inferno #885). Every other caller - the Abort button
+// and the sys_data_pns autosave, both of which run with the unit still in
+// play - omits it and gets the old getPlayerUID behaviour.
+_puid = _args param [1, getPlayerUID _player, [""]];
 
 _playerHash = [] call CBA_fnc_hashCreate;
 
@@ -91,9 +98,17 @@ TRACE_5("SYS_PLAYER SET",_saveLoadout,_saveHealth,_savePosition,_saveScores, cou
     [_playerHash, _key, _value] call CBA_fnc_hashSet;
 } foreach _data;
 
+// UNIT_DATA reads puid off the unit, which is already blank on a
+// HandleDisconnect save - stamp the UID we were given so the stored record
+// stays identifiable. Only when we actually got one, so callers that rely
+// on the unit-derived puid are unaffected.
+if (_puid != "") then {
+    [_playerHash, "puid", _puid] call CBA_fnc_hashSet;
+};
+
 // Add gear data to player's hash
 private ["_gearHash","_addGear"];
-_gearHash = [GVAR(gear_data), getPlayerUID _player, "NONE"] call ALIVE_fnc_hashGet;
+_gearHash = [GVAR(gear_data), _puid, "NONE"] call ALIVE_fnc_hashGet;
 
 _addGear = {
     [_playerHash, _key, _value] call ALIVE_fnc_hashSet;

--- a/addons/sys_player/fnc_setPlayer.sqf
+++ b/addons/sys_player/fnc_setPlayer.sqf
@@ -29,7 +29,7 @@ Peer reviewed:
 nil
 ---------------------------------------------------------------------------- */
 
-private ["_logic","_args","_player","_puid","_find","_saveLoadout","_saveHealth","_savePosition","_saveScores","_data","_playerHash","_result","_data"];
+private ["_logic","_args","_player","_puid","_find","_saveLoadout","_saveHealth","_savePosition","_saveScores","_saveAmmo","_data","_playerHash","_result"];
 
 _logic = _this param [0, objNull, [objNull,[]]];
 _args = _this param [1, objNull, [objNull,[],"",0,true,false]];

--- a/addons/sys_player/script_component.hpp
+++ b/addons/sys_player/script_component.hpp
@@ -10,3 +10,10 @@
 #endif
 
 #include "\x\cba\addons\main\script_macros.hpp"
+
+// Inferno #885: states that must never be written to the player store.
+// HEALTH_DATA round trips damage and lifestate, and playerData.hpp's
+// lifestate setter calls setUnconscious true on restore, so persisting any
+// of these puts the player straight back into a dead or downed state on
+// rejoin. Leave the last good save standing instead.
+#define PLAYER_STATE_UNSAVEABLE(var1) (!alive (var1) || {toUpper (lifeState (var1)) in ["DEAD","DEAD-SWITCHING","DEAD-RESPAWN","INCAPACITATED","UNCONSCIOUS","AGONY","AGONY-UNCONSCIOUS"]})


### PR DESCRIPTION
Digging into this one turned up something unexpected: nothing in sys_player was ever bound to an engine disconnect event. The function named onPlayerDisconnected is real, but its callers are the Abort button and the PnS periodic autosave - the only PlayerDisconnected handler in the mod just decrements a player counter. So on an unintentional drop nothing saved at all, which is a cleaner explanation for players logging back in at their first spawn than any of the theories in the thread.

This adds a HandleDisconnect mission event handler that saves the departing player server-side while the engine still holds the unit object, passing the UID explicitly since getPlayerUID goes blank at that point. On top of that, the store's single choke point now refuses to persist a dead or downed state (dead, incapacitated, unconscious, agony variants), so the last good save stands and the rejoin-into-a-corpse respawn loop can't happen. Because the guard sits at the store rather than on one caller, the Abort button and autosave inherit the same rule - under master, aborting while dead saved the dead state, and that no longer happens. That's deliberate (a caller-level guard would leave the 300-second autosave free to write a dead state mid-window anyway), but it is a behaviour change on the Abort path, so flagging it clearly in case you want it narrower.

Honest limits: our dedicated box is retired, so HandleDisconnect timing on dedicated - specifically the unit still being non-null in the handler - is verified against the sup_command precedent in this codebase (its own HandleDisconnect comment relies on the same timing) rather than a live run. And lifeState on a remote unit reporting the downed states across the network is the other assumption a dedicated test should confirm.

Fixes #885