### PR TITLE
[MAIN] Composition spawn search runs unscheduled in tick-budgeted chunks

### DIFF
--- a/addons/main/fnc_findCompositionSpawnPosition.sqf
+++ b/addons/main/fnc_findCompositionSpawnPosition.sqf
@@ -14,7 +14,8 @@ Description:
       1. CENTRE - if the supplied position is already clear (envelope-aware
          footprint, exclusion zones for the requested mode), use it as-is.
          Most callers pre-pick a cluster centre so this often wins.
-      2. SAMPLE - random toss within radius (up to 200 attempts), each
+      2. SAMPLE - random toss within radius (200-1200 attempts, scaled
+         by radius - see _maxAttempts), each
          candidate validated against envelope clearance + exclusion zones.
       3. ROAD ALIGN (mode=="roadblock" only) - additionally require a road
          within envelope-half + 5 m and snap orientation to road heading.
@@ -707,16 +708,37 @@ if (_mode == "roadblock") exitWith {
 // matters most when _radius is large (search-cap-expanded scenarios)
 // where the outer annulus is where unobstructed terrain typically lives.
 // ------------------------------------------------------------------------
+// The candidate checks are engine geometry queries with no suspension
+// points, but in a scheduled context the 3ms scheduler slice still
+// preempts the loop every few candidates and resumes it next frame. On
+// a dedicated server mid-init that stretches one 667-attempt search to
+// 30s+ of wall time (issue #1008); on a hosted client the loading
+// screen pauses the sim and the same search takes a second. Running
+// the attempts in unscheduled tick-budgeted chunks lets each chunk
+// finish inside one frame: the 3ms budget is only checked between
+// candidates, so a chunk costs the budget plus whichever candidate was
+// still in flight when it expired - about 2ms on the observed numbers,
+// per-candidate cost varying ~10x with envelope and map object density.
+// The chunking keeps the scheduler in control between chunks.
+// directCall is the same unscheduled-execution idiom sys_profile uses
+// (fnc_profileSystem.sqf:164, fnc_profileEntity.sqf:547).
 private _result = [];
-for "_i" from 1 to _maxAttempts do {
-    private _angle = random 360;
-    private _dist  = sqrt (random 1) * _radius;
-    private _candidate = _centerPos getPos [_dist, _angle];
-    if ([_candidate, _envelope] call _candidateClear) exitWith {
-        private _dir = if (_preferredDir >= 0) then { _preferredDir } else { random 360 };
-        _result = [_candidate, _dir];
-        if (_debug) then { ["[ALiVE CompSpawn] placed (mode %1) at %2", _mode, _candidate] call ALiVE_fnc_dump };
-    };
+private _i = 0;
+while {_i < _maxAttempts && {count _result == 0}} do {
+    [{
+        private _chunkEnd = diag_tickTime + 0.003;
+        while {_i < _maxAttempts && {count _result == 0} && {diag_tickTime < _chunkEnd}} do {
+            _i = _i + 1;
+            private _angle = random 360;
+            private _dist  = sqrt (random 1) * _radius;
+            private _candidate = _centerPos getPos [_dist, _angle];
+            if ([_candidate, _envelope] call _candidateClear) then {
+                private _dir = if (_preferredDir >= 0) then { _preferredDir } else { random 360 };
+                _result = [_candidate, _dir];
+                if (_debug) then { ["[ALiVE CompSpawn] placed (mode %1) at %2", _mode, _candidate] call ALiVE_fnc_dump };
+            };
+        };
+    }] call CBA_fnc_directCall;
 };
 
 if (count _result == 0 && _debug) then {


### PR DESCRIPTION
Went through the three RPTs on #1008 and the gap has a clean mechanism. The composition spawn search is a tight loop of engine geometry queries with no suspension points, but it runs in a scheduled context, so the 3ms scheduler slice preempts it every few candidates and parks it until the next frame. The logs show the same 667-attempt failed search taking 1-2 seconds on LAN but 28-35 seconds on dedicated - because on a hosted game the loading screen pauses the sim and init scripts run with the unthrottled loading budget, while a dedicated server goes live at around 80 seconds uptime with only two modules initialised and everything heavy crawls at in-mission scheduler rates from there. Same work, twenty times the wall clock: mil_placement completes init in 30 seconds on the LAN log and 618 on the dedicated one, and the fifteen CompSpawn failures alone account for several minutes of the difference.

The fix runs the candidate attempts unscheduled via CBA_fnc_directCall (the sys_profile idiom) in chunks budgeted at 3ms of wall clock per chunk - the same diag_tickTime budget pattern amb_civ_placement already uses. A wall-clock budget rather than a fixed count because per-candidate cost varies about tenfold with envelope size and map object density (the Cam Lao Nam note in this file records 280 objects in range of one check). Attempt count, success path, result shape and the reject accounting are all unchanged; the chunking returns control to the scheduler between chunks, so nothing else starves.

This addresses the largest single contributor to the reported gap rather than all of it - the placement and analysis phases have other scheduled hot spots that would now be the next thing to profile. Verified the loop equivalence and scope behaviour locally; the dedicated-server timing improvement itself I can't measure here since our dedicated box is retired, so the reporter's setup would be the real test.

Ref #1008