### PR TITLE
[STRINGTABLES] Complete the Spanish translation

### DIFF
--- a/addons/composition_a3/stringtable.xml
+++ b/addons/composition_a3/stringtable.xml
@@ -4,4091 +4,5454 @@
 <Container name="STR_DN">
 <Key ID="STR_ZEC_Civilian">
     <English>Civilian</English>
+    <Spanish>Civil</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianDesert">
     <English>Civilian (Desert)</English>
+    <Spanish>Civil (desierto)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianWoodland">
     <English>Civilian (Woodland)</English>
+    <Spanish>Civil (bosque)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific">
     <English>Civilian (Pacific)</English>
+    <Spanish>Civil (Pacífico)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla">
     <English>Guerrilla</English>
+    <Spanish>Guerrilla</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaDesert">
     <English>Guerrilla (Desert)</English>
+    <Spanish>Guerrilla (desierto)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaWoodland">
     <English>Guerrilla (Woodland)</English>
+    <Spanish>Guerrilla (bosque)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific">
     <English>Guerrilla (Pacific)</English>
+    <Spanish>Guerrilla (Pacífico)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military">
     <English>Military</English>
+    <Spanish>Militar</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryDesert">
     <English>Military (Desert)</English>
+    <Spanish>Militar (desierto)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryWoodland">
     <English>Military (Woodland)</English>
+    <Spanish>Militar (bosque)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific">
     <English>Military (Pacific)</English>
+    <Spanish>Militar (Pacífico)</Spanish>
 </Key>
 <Key ID="STR_ZEC_AirportsLarge">
     <English>Airports (Large)</English>
+    <Spanish>Aeropuertos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_AirportsMedium">
     <English>Airports (Medium)</English>
+    <Spanish>Aeropuertos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZEC_AirportsSmall">
     <English>Airports (Small)</English>
+    <Spanish>Aeropuertos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CampsLarge">
     <English>Camps (Large)</English>
+    <Spanish>Campamentos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CampsMedium">
     <English>Camps (Medium)</English>
+    <Spanish>Campamentos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CampsSmall">
     <English>Camps (Small)</English>
+    <Spanish>Campamentos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CheckpointsBarricadesLarge">
     <English>Checkpoints &amp; Barricades (Large)</English>
+    <Spanish>Controles y barricadas (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CheckpointsBarricadesMedium">
     <English>Checkpoints &amp; Barricades (Medium)</English>
+    <Spanish>Controles y barricadas (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CheckpointsBarricadesSmall">
     <English>Checkpoints &amp; Barricades (Small)</English>
+    <Spanish>Controles y barricadas (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CommunicationsLarge">
     <English>Communications (Large)</English>
+    <Spanish>Comunicaciones (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CommunicationsMedium">
     <English>Communications (Medium)</English>
+    <Spanish>Comunicaciones (medianas)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CommunicationsSmall">
     <English>Communications (Small)</English>
+    <Spanish>Comunicaciones (pequeñas)</Spanish>
 </Key>
 <Key ID="STR_ZEC_ConstructionLarge">
     <English>Construction (Large)</English>
+    <Spanish>Construcción (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_ConstructionMedium">
     <English>Construction (Medium)</English>
+    <Spanish>Construcción (mediana)</Spanish>
 </Key>
 <Key ID="STR_ZEC_ConstructionSmall">
     <English>Construction (Small)</English>
+    <Spanish>Construcción (pequeña)</Spanish>
 </Key>
 <Key ID="STR_ZEC_ConstructionSuppliesLarge">
     <English>Construction Supplies (Large)</English>
+    <Spanish>Suministros de construcción (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_ConstructionSuppliesMedium">
     <English>Construction Supplies (Medium)</English>
+    <Spanish>Suministros de construcción (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZEC_ConstructionSuppliesSmall">
     <English>Construction Supplies (Small)</English>
+    <Spanish>Suministros de construcción (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CrashsitesLarge">
     <English>Crash Sites (Large)</English>
+    <Spanish>Zonas de accidente (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CrashsitesMedium">
     <English>Crash Sites (Medium)</English>
+    <Spanish>Zonas de accidente (medianas)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CrashsitesSmall">
     <English>Crash Sites (Small)</English>
+    <Spanish>Zonas de accidente (pequeñas)</Spanish>
 </Key>
 <Key ID="STR_ZEC_FieldHQLarge">
     <English>Field HQ (Large)</English>
+    <Spanish>HQ de campaña (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_FieldHQMedium">
     <English>Field HQ (Medium)</English>
+    <Spanish>HQ de campaña (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZEC_FieldHQSmall">
     <English>Field HQ (Small)</English>
+    <Spanish>HQ de campaña (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_FortLarge">
     <English>Fortifications &amp; Bunkers (Large)</English>
+    <Spanish>Fortificaciones y búnkeres (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_FortMedium">
     <English>Fortifications &amp; Bunkers (Medium)</English>
+    <Spanish>Fortificaciones y búnkeres (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZEC_FortSmall">
     <English>Fortifications &amp; Bunkers (Small)</English>
+    <Spanish>Fortificaciones y búnkeres (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZEC_FuelLarge">
     <English>Fuel (Large)</English>
+    <Spanish>Combustible (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_FuelMedium">
     <English>Fuel (Medium)</English>
+    <Spanish>Combustible (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZEC_FuelSmall">
     <English>Fuel (Small)</English>
+    <Spanish>Combustible (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GeneralLarge">
     <English>General (Large)</English>
+    <Spanish>General (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GeneralMedium">
     <English>General (Medium)</English>
+    <Spanish>General (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GeneralSmall">
     <English>General (Small)</English>
+    <Spanish>General (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_HeliportsLarge">
     <English>Heliports (Large)</English>
+    <Spanish>Helipuertos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_HeliportsMedium">
     <English>Heliports (Medium)</English>
+    <Spanish>Helipuertos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZEC_HeliportsSmall">
     <English>Heliports (Small)</English>
+    <Spanish>Helipuertos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZEC_HqLarge">
     <English>HQ (Large)</English>
+    <Spanish>HQ (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_HqMedium">
     <English>HQ (Medium)</English>
+    <Spanish>HQ (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZEC_HqSmall">
     <English>HQ (Small)</English>
+    <Spanish>HQ (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_IndustrialLarge">
     <English>Industrial (Large)</English>
+    <Spanish>Industrial (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_IndustrialMedium">
     <English>Industrial (Medium)</English>
+    <Spanish>Industrial (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZEC_IndustrialSmall">
     <English>Industrial (Small)</English>
+    <Spanish>Industrial (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MarineLarge">
     <English>Marine (Large)</English>
+    <Spanish>Marítimo (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MarineMedium">
     <English>Marine (Medium)</English>
+    <Spanish>Marítimo (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MarineSmall">
     <English>Marine (Small)</English>
+    <Spanish>Marítimo (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MedicalLarge">
     <English>Medical (Large)</English>
+    <Spanish>Sanitario (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MedicalMedium">
     <English>Medical (Medium)</English>
+    <Spanish>Sanitario (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MedicalSmall">
     <English>Medical (Small)</English>
+    <Spanish>Sanitario (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MiningOilLarge">
     <English>Mining, Refining &amp; Oil (Large)</English>
+    <Spanish>Minería, refinado y petróleo (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MiningOilMedium">
     <English>Mining, Refining &amp; Oil (Medium)</English>
+    <Spanish>Minería, refinado y petróleo (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MiningOilSmall">
     <English>Mining, Refining &amp; Oil (Small)</English>
+    <Spanish>Minería, refinado y petróleo (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZEC_OutpostsLarge">
     <English>Outposts (Large)</English>
+    <Spanish>Puestos avanzados (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_OutpostsMedium">
     <English>Outposts (Medium)</English>
+    <Spanish>Puestos avanzados (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZEC_OutpostsSmall">
     <English>Outposts (Small)</English>
+    <Spanish>Puestos avanzados (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZEC_PowerLarge">
     <English>Power (Large)</English>
+    <Spanish>Energía (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_PowerMedium">
     <English>Power (Medium)</English>
+    <Spanish>Energía (mediana)</Spanish>
 </Key>
 <Key ID="STR_ZEC_PowerSmall">
     <English>Power (Small)</English>
+    <Spanish>Energía (pequeña)</Spanish>
 </Key>
 <Key ID="STR_ZEC_RailLarge">
     <English>Rail (Large)</English>
+    <Spanish>Ferrocarril (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_RailMedium">
     <English>Rail (Medium)</English>
+    <Spanish>Ferrocarril (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZEC_RailSmall">
     <English>Rail (Small)</English>
+    <Spanish>Ferrocarril (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_SettlementsLarge">
     <English>Settlements (Large)</English>
+    <Spanish>Asentamientos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_SettlementsMedium">
     <English>Settlements (Medium)</English>
+    <Spanish>Asentamientos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZEC_SettlementsSmall">
     <English>Settlements (Small)</English>
+    <Spanish>Asentamientos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZEC_SuppliesLarge">
     <English>Supplies &amp; Storage (Large)</English>
+    <Spanish>Suministros y almacenamiento (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_SuppliesMedium">
     <English>Supplies &amp; Storage (Medium)</English>
+    <Spanish>Suministros y almacenamiento (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZEC_SuppliesSmall">
     <English>Supplies &amp; Storage (Small)</English>
+    <Spanish>Suministros y almacenamiento (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZEC_SupportsLarge">
     <English>Support (Large)</English>
+    <Spanish>Apoyo (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_SupportsMedium">
     <English>Support (Medium)</English>
+    <Spanish>Apoyo (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZEC_SupportsSmall">
     <English>Support (Small)</English>
+    <Spanish>Apoyo (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_TrainingLarge">
     <English>Training (Large)</English>
+    <Spanish>Instrucción (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_TrainingMedium">
     <English>Training (Medium)</English>
+    <Spanish>Instrucción (mediana)</Spanish>
 </Key>
 <Key ID="STR_ZEC_TrainingSmall">
     <English>Training (Small)</English>
+    <Spanish>Instrucción (pequeña)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_ConstructionLarge_BuildingSite1">
     <English>Building Site #1</English>
+    <Spanish>Obra #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_ConstructionLarge_BuildingSite2">
     <English>Building Site #2</English>
+    <Spanish>Obra #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_ConstructionSuppliesLarge_AllWalls">
     <English>Walls</English>
+    <Spanish>Muros</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_ConstructionSuppliesLarge_AllWrecks">
     <English>Wrecks</English>
+    <Spanish>Restos</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_ConstructionSuppliesLarge_FillerJunk">
     <English>Filler - Junk</English>
+    <Spanish>Relleno - chatarra</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_ConstructionSuppliesLarge_FillerBox1">
     <English>Filler - Boxes #1</English>
+    <Spanish>Relleno - cajas #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_ConstructionSuppliesLarge_FillerBox2">
     <English>Filler - Boxes #2</English>
+    <Spanish>Relleno - cajas #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_ConstructionSuppliesLarge_FillerBoxSmall">
     <English>Filler - Boxes (Small)</English>
+    <Spanish>Relleno - cajas (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_IndustrialLarge_SugarCaneRefinery">
     <English>Sugar Cane Refinery</English>
+    <Spanish>Refinería de caña de azúcar</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_IndustrialLarge_SugarCanePlant">
     <English>Sugar Cane Plant</English>
+    <Spanish>Planta de caña de azúcar</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_IndustrialLarge_ContainersYard">
     <English>Container Yard</English>
+    <Spanish>Patio de contenedores</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_IndustrialMedium_UnfinishedFactory">
     <English>Unfinished Factory</English>
+    <Spanish>Fábrica sin terminar</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_IndustrialMedium_SmugglersFactory">
     <English>Smugglers Factory</English>
+    <Spanish>Fábrica de contrabandistas</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_IndustrialMedium_Scrapyard">
     <English>Scrapyard</English>
+    <Spanish>Desguace</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_IndustrialMedium_ContainerYard">
     <English>Container Yard</English>
+    <Spanish>Patio de contenedores</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_IndustrialSmall_Factory1">
     <English>Factory #1</English>
+    <Spanish>Fábrica #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_IndustrialSmall_Factory2">
     <English>Factory #2</English>
+    <Spanish>Fábrica #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_IndustrialSmall_Factory3">
     <English>Factory #3</English>
+    <Spanish>Fábrica #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_IndustrialSmall_WaterStorage">
     <English>Water Storage</English>
+    <Spanish>Almacenamiento de agua</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_MiningOilLarge_ProcessingPlant">
     <English>Processing Plant</English>
+    <Spanish>Planta de procesado</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_MiningOilLarge_OreQuarry">
     <English>Ore Quarry</English>
+    <Spanish>Cantera de mineral</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_MiningOilMedium_OreProcessing">
     <English>Ore Processing</English>
+    <Spanish>Procesado de mineral</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_MiningOilMedium_OreStorageYard">
     <English>Ore Storage Yard</English>
+    <Spanish>Patio de almacenamiento de mineral</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_MiningOilSmall_OreStockpile">
     <English>Ore Stockpile</English>
+    <Spanish>Acopio de mineral</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_MiningOilSmall_LargeDigger">
     <English>Large Digger</English>
+    <Spanish>Excavadora grande</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_PowerLarge_DieselPlant1">
     <English>Diesel Plant 1</English>
+    <Spanish>Planta de diésel 1</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_PowerLarge_DieselPlant2">
     <English>Diesel Plant 2</English>
+    <Spanish>Planta de diésel 2</Spanish>
 </Key>
 <Key ID="STR_ZEC_CivilianPacific_PowerSmall_DieselPlant">
     <English>Diesel Plant</English>
+    <Spanish>Planta de diésel</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_AirportsLarge_AltisTerminal">
     <English>Altis Terminal</English>
+    <Spanish>Terminal de Altis</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_CommunicationsSmall_TransmitterTower">
     <English>Transmitter Tower</English>
+    <Spanish>Torre de transmisión</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionMedium_BuildingSite">
     <English>Building Site 1</English>
+    <Spanish>Obra 1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionMedium_TwoFloorRuin">
     <English>Two Floor Ruin</English>
+    <Spanish>Ruina de dos plantas</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionMedium_ConstructionSiteShed">
     <English>Construction Site - Shed</English>
+    <Spanish>Obra - cobertizo</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSmall_OneFloorRuin">
     <English>Construction Site - Shed</English>
+    <Spanish>Obra - cobertizo</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSmall_ConstructionSite1">
     <English>Construction Site #1</English>
+    <Spanish>Obra #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSmall_ConstructionSite2">
     <English>Construction Site #2</English>
+    <Spanish>Obra #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSmall_ConstructionSite3">
     <English>Construction Site #3</English>
+    <Spanish>Obra #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_CommsSupports">
     <English>Comms &amp; Supports</English>
+    <Spanish>Comunicaciones y apoyos</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_FillerClutter1">
     <English>Filler - Clutter #1</English>
+    <Spanish>Relleno - trastos #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_FillerClutter2">
     <English>Filler - Clutter #2</English>
+    <Spanish>Relleno - trastos #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_FillerClutter3">
     <English>Filler - Clutter #3</English>
+    <Spanish>Relleno - trastos #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_FillerJunkLarge">
     <English>Filler - Junk (Large)</English>
+    <Spanish>Relleno - chatarra (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_FillerJunkSmall">
     <English>Filler - Junk (Small)</English>
+    <Spanish>Relleno - chatarra (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_FillerWrecks">
     <English>Filler - Wrecks</English>
+    <Spanish>Relleno - restos</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_FillerConstruction">
     <English>Filler - Construction</English>
+    <Spanish>Relleno - construcción</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_EdenJunkWrecks">
     <English>Junk and Wrecks</English>
+    <Spanish>Chatarra y restos</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_EdenTablesShelves">
     <English>Tables and Shelves</English>
+    <Spanish>Mesas y estanterías</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_EdenExteriorItems">
     <English>Exterior Items</English>
+    <Spanish>Objetos de exterior</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_EdenSmallItems">
     <English>Small Items</English>
+    <Spanish>Objetos pequeños</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_EdenWalls">
     <English>Walls</English>
+    <Spanish>Muros</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_ConstructionSuppliesLarge_EdenPipes">
     <English>Pipes</English>
+    <Spanish>Tuberías</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_FuelLarge_FuelStationNew">
     <English>Fuel Station - Modern</English>
+    <Spanish>Gasolinera - moderna</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_FuelLarge_FuelStationOld">
     <English>Fuel Station - Old</English>
+    <Spanish>Gasolinera - antigua</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_FuelLarge_FuelDepot">
     <English>Fuel Depot</English>
+    <Spanish>Depósito de combustible</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_FuelLarge_DieselStorage">
     <English>Diesel Storage</English>
+    <Spanish>Almacén de diésel</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_FuelMedium_TankerShed">
     <English>Tanker Shed</English>
+    <Spanish>Cobertizo de cisternas</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_FuelMedium_FuelDepot">
     <English>Fuel Depot</English>
+    <Spanish>Depósito de combustible</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_GeneralLarge_SportsGround">
     <English>Sports Ground</English>
+    <Spanish>Campo deportivo</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_GeneralLarge_GhostHotel">
     <English>Ghost Hotel</English>
+    <Spanish>Hotel fantasma</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_GeneralMedium_Church">
     <English>Church</English>
+    <Spanish>Iglesia</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_GeneralMedium_BasketballCourt">
     <English>Basketball Court</English>
+    <Spanish>Cancha de baloncesto</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_GeneralSmall_MarketStall1">
     <English>Market Stall #1</English>
+    <Spanish>Puesto de mercado #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_GeneralSmall_MarketStall2">
     <English>Market Stall #2</English>
+    <Spanish>Puesto de mercado #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_GeneralSmall_MarketStall3">
     <English>Market Stall #3</English>
+    <Spanish>Puesto de mercado #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_HeliportsMedium_Heliport">
     <English>Heliport</English>
+    <Spanish>Helipuerto</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialLarge_IndustrialSite">
     <English>Industrial Site</English>
+    <Spanish>Recinto industrial</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialLarge_FactorySite">
     <English>Factory Site</English>
+    <Spanish>Recinto fabril</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialLarge_StorageComplex">
     <English>Storage Complex</English>
+    <Spanish>Complejo de almacenamiento</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialMedium_Factory1">
     <English>Factory #1</English>
+    <Spanish>Fábrica #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialMedium_Factory2">
     <English>Factory #2</English>
+    <Spanish>Fábrica #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialMedium_ContainerYard">
     <English>Container Yard</English>
+    <Spanish>Patio de contenedores</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialMedium_StorageYard">
     <English>Storage Yard</English>
+    <Spanish>Patio de almacenamiento</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialMedium_StorageShed1">
     <English>Storage Shed #1</English>
+    <Spanish>Cobertizo de almacenamiento #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialMedium_StorageShed2">
     <English>Storage Shed #2</English>
+    <Spanish>Cobertizo de almacenamiento #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialMedium_StorageShed3">
     <English>Storage Shed #3</English>
+    <Spanish>Cobertizo de almacenamiento #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialSmall_TinShed">
     <English>Tin Shed</English>
+    <Spanish>Cobertizo de chapa</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_IndustrialSmall_MetalSheds">
     <English>Metal Sheds</English>
+    <Spanish>Cobertizos metálicos</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_MedicalLarge_Hospital">
     <English>Hospital</English>
+    <Spanish>Hospital</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_MedicalMedium_MedicalCenter">
     <English>Medical Center</English>
+    <Spanish>Centro sanitario</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_MiningOilLarge_Refinery">
     <English>Refinery</English>
+    <Spanish>Refinería</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_PowerLarge_SolarPlant">
     <English>Solar Plant</English>
+    <Spanish>Planta solar</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_PowerLarge_DieselPowerPlant">
     <English>Diesel Power Plant</English>
+    <Spanish>Central eléctrica de diésel</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_PowerLarge_PowerPlant1">
     <English>Power Plant 1</English>
+    <Spanish>Central eléctrica 1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_PowerLarge_PowerPlant2">
     <English>Power Plant 2</English>
+    <Spanish>Central eléctrica 2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_PowerSmall_PowerTransformer">
     <English>Power Transformer</English>
+    <Spanish>Transformador eléctrico</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_SettlementsLarge_ShantyTown">
     <English>Shanty Town</English>
+    <Spanish>Poblado de chabolas</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_SettlementsSmall_CampSite">
     <English>Camp Site</English>
+    <Spanish>Campamento</Spanish>
 </Key>
 <Key ID="STR_ZEC_Civilian_SettlementsSmall_WalledStoneHouse">
     <English>Walled Stone House</English>
+    <Spanish>Casa de piedra amurallada</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_AirportsLarge_Hangar">
     <English>Hangar</English>
+    <Spanish>Hangar</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsMedium_CampJungle1">
     <English>Jungle Camp #1</English>
+    <Spanish>Campamento en la jungla #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsMedium_CampJungle2">
     <English>Jungle Camp #2</English>
+    <Spanish>Campamento en la jungla #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsMedium_CampJungle3">
     <English>Jungle Camp #3</English>
+    <Spanish>Campamento en la jungla #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsMedium_CampJungle4">
     <English>Jungle Camp #4</English>
+    <Spanish>Campamento en la jungla #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsMedium_CampJungle5">
     <English>Jungle Camp #5</English>
+    <Spanish>Campamento en la jungla #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite1">
     <English>Camp Site #01</English>
+    <Spanish>Campamento #01</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite2">
     <English>Camp Site #02</English>
+    <Spanish>Campamento #02</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite3">
     <English>Camp Site #03</English>
+    <Spanish>Campamento #03</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite4">
     <English>Camp Site #04</English>
+    <Spanish>Campamento #04</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite5">
     <English>Camp Site #05</English>
+    <Spanish>Campamento #05</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite6">
     <English>Camp Site #06</English>
+    <Spanish>Campamento #06</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite7">
     <English>Camp Site #07</English>
+    <Spanish>Campamento #07</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite8">
     <English>Camp Site #08</English>
+    <Spanish>Campamento #08</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite9">
     <English>Camp Site #09</English>
+    <Spanish>Campamento #09</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite10">
     <English>Camp Site #10</English>
+    <Spanish>Campamento #10</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite11">
     <English>Camp Site #11</English>
+    <Spanish>Campamento #11</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite12">
     <English>Camp Site #12</English>
+    <Spanish>Campamento #12</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite13">
     <English>Camp Site #13</English>
+    <Spanish>Campamento #13</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSite14">
     <English>Camp Site #14</English>
+    <Spanish>Campamento #14</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_PicnicSite">
     <English>Picnic Site</English>
+    <Spanish>Zona de pícnic</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_JungleCamp">
     <English>Jungle Camp</English>
+    <Spanish>Campamento en la jungla</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_MortarCamp1">
     <English>Mortar Camp #1</English>
+    <Spanish>Campamento de morteros #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_MortarCamp2">
     <English>Mortar Camp #2</English>
+    <Spanish>Campamento de morteros #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampSiteHMG">
     <English>Camp Site (HMG)</English>
+    <Spanish>Campamento (HMG)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampCargoPost1">
     <English>Camp (Cargo Post) #1</English>
+    <Spanish>Campamento (puesto de carga) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CampsSmall_CampCargoPost2">
     <English>Camp (Cargo Post) #2</English>
+    <Spanish>Campamento (puesto de carga) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CheckpointsBarricadesMedium_Barricade1">
     <English>Road Barricade #1</English>
+    <Spanish>Barricada de carretera #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CheckpointsBarricadesMedium_Barricade2">
     <English>Road Barricade #2</English>
+    <Spanish>Barricada de carretera #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CheckpointsBarricadesMedium_Barricade3">
     <English>Road Barricade #3</English>
+    <Spanish>Barricada de carretera #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CheckpointsBarricadesMedium_Barricade4">
     <English>Road Barricade #4</English>
+    <Spanish>Barricada de carretera #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CheckpointsBarricadesMedium_Barricade5">
     <English>Road Barricade #5</English>
+    <Spanish>Barricada de carretera #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CommunicationsLarge_FortifiedCommsTower">
     <English>Fortified Comms Tower</English>
+    <Spanish>Torre de comunicaciones fortificada</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CommunicationsLarge_RadarDome">
     <English>Radar Dome</English>
+    <Spanish>Radomo</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CommunicationsLarge_CommunicationsPost">
     <English>Communications Post</English>
+    <Spanish>Puesto de comunicaciones</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CommunicationsMedium_RadioPost">
     <English>Radio Post (Bunker)</English>
+    <Spanish>Puesto de radio (búnker)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CommunicationsMedium_UAVDepot">
     <English>UAV Depot</English>
+    <Spanish>Depósito de UAV</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CommunicationsSmall_DataTerminal">
     <English>Data Terminal</English>
+    <Spanish>Terminal de datos</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CommunicationsSmall_OperationsArea">
     <English>Operations Area</English>
+    <Spanish>Zona de operaciones</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CommunicationsSmall_RadioPostHidden">
     <English>Radio Post (Hidden)</English>
+    <Spanish>Puesto de radio (oculto)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_CommunicationsSmall_RadioPostTemp">
     <English>Radio Post (Temp)</English>
+    <Spanish>Puesto de radio (temporal)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesLarge_YardFortified">
     <English>Yard Fortified</English>
+    <Spanish>Patio fortificado</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesLarge_WarehouseUrban">
     <English>Warehouse Urban</English>
+    <Spanish>Nave de almacenamiento urbana</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesMedium_StorageCovered">
     <English>Storage Covered</English>
+    <Spanish>Almacenamiento cubierto</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesMedium_StorageUrban">
     <English>Storage Urban</English>
+    <Spanish>Almacenamiento urbano</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesSmall_CargoFortifiedRusty">
     <English>Depot (Rusted)</English>
+    <Spanish>Depósito (oxidado)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesSmall_AmmoCache1">
     <English>Cache (Ammo Boxes) #1</English>
+    <Spanish>Alijo (cajas de munición) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesSmall_AmmoCache2">
     <English>Cache (Ammo Boxes) #2</English>
+    <Spanish>Alijo (cajas de munición) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesSmall_ContainerStorage">
     <English>Container Storage</English>
+    <Spanish>Almacén de contenedores</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesSmall_Cache1">
     <English>Cache #1</English>
+    <Spanish>Alijo #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesSmall_Cache2">
     <English>Cache #2</English>
+    <Spanish>Alijo #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesSmall_Cache3">
     <English>Cache #3</English>
+    <Spanish>Alijo #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesSmall_StorageArea1">
     <English>Storage Area #1</English>
+    <Spanish>Zona de almacenamiento #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesSmall_StorageArea2">
     <English>Storage Area #2</English>
+    <Spanish>Zona de almacenamiento #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_ConstructionSuppliesSmall_StorageArea3">
     <English>Storage Area #3</English>
+    <Spanish>Zona de almacenamiento #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQLarge_Factory">
     <English>Factory</English>
+    <Spanish>Fábrica</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQLarge_CargoTowerHQ">
     <English>Cargo Tower HQ</English>
+    <Spanish>HQ en torre de carga</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQLarge_CargoHQ">
     <English>Cargo HQ</English>
+    <Spanish>HQ de carga</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQLarge_CargoPostHQ">
     <English>Cargo Post HQ</English>
+    <Spanish>HQ en puesto de carga</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQMedium_ObservationTower">
     <English>Observation Tower</English>
+    <Spanish>Torre de observación</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQMedium_FieldHQ">
     <English>Field HQ</English>
+    <Spanish>HQ de campaña</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQMedium_CargoHQ1">
     <English>Cargo HQ #1</English>
+    <Spanish>HQ de carga #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQMedium_CargoHQ2">
     <English>Cargo HQ #2</English>
+    <Spanish>HQ de carga #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQMedium_BunkerHQ1">
     <English>Bunker HQ #1</English>
+    <Spanish>HQ en búnker #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQMedium_BunkerHQ2">
     <English>Bunker HQ #2</English>
+    <Spanish>HQ en búnker #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQMedium_CargoHouseHQ1">
     <English>Cargo House HQ #1</English>
+    <Spanish>HQ en casa de carga #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQMedium_CargoHouseHQ2">
     <English>Cargo House HQ #2</English>
+    <Spanish>HQ en casa de carga #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQSmall_ObservationTower">
     <English>Observation Tower</English>
+    <Spanish>Torre de observación</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FieldHQSmall_ObservationPost">
     <English>Observation Post</English>
+    <Spanish>Puesto de observación</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortLarge_OldWarBunker">
     <English>Old War Bunker</English>
+    <Spanish>Búnker de guerra antiguo</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortLarge_ShopFortified">
     <English>Shop (Fortified)</English>
+    <Spanish>Tienda (fortificada)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortLarge_GarageFortified">
     <English>Garage (Fortified)</English>
+    <Spanish>Garaje (fortificado)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortMedium_OldWarBunker">
     <English>Old War Bunker</English>
+    <Spanish>Búnker de guerra antiguo</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortMedium_AAPosition">
     <English>AA Position</English>
+    <Spanish>Posición antiaérea</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortMedium_MortarBunker">
     <English>Mortar Bunker</English>
+    <Spanish>Búnker de morteros</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortMedium_TowerBunker1">
     <English>Tower Bunker #1</English>
+    <Spanish>Búnker torre #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortMedium_TowerBunker2">
     <English>Tower Bunker #2</English>
+    <Spanish>Búnker torre #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortMedium_TowerBunker3">
     <English>Tower Bunker #3</English>
+    <Spanish>Búnker torre #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortMedium_BunkerLarge1">
     <English>Bunker (Large) #1</English>
+    <Spanish>Búnker (grande) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortMedium_BunkerLarge2">
     <English>Bunker (Large) #2</English>
+    <Spanish>Búnker (grande) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortMedium_BunkerLarge3">
     <English>Bunker (Large) #3</English>
+    <Spanish>Búnker (grande) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortMedium_BunkerLarge4">
     <English>Bunker (Large) #4</English>
+    <Spanish>Búnker (grande) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortSmall_StaticAANet">
     <English>Static AA (Net)</English>
+    <Spanish>Antiaéreo estático (red)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortSmall_BunkerHBbarNet">
     <English>Bunker (H-Barrier)t</English>
+    <Spanish>Búnker (H-Barrier)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortSmall_BunkerSandbagsNet">
     <English>Bunker (Sandbags)</English>
+    <Spanish>Búnker (sacos terreros)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortSmall_Net1">
     <English>Net #1</English>
+    <Spanish>Red de camuflaje #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortSmall_Net2">
     <English>Net #2</English>
+    <Spanish>Red de camuflaje #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortSmall_Net3">
     <English>Net #3</English>
+    <Spanish>Red de camuflaje #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortSmall_Net4">
     <English>Net #4</English>
+    <Spanish>Red de camuflaje #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortSmall_Net5">
     <English>Net #5</English>
+    <Spanish>Red de camuflaje #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortSmall_Net6">
     <English>Net #6</English>
+    <Spanish>Red de camuflaje #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FortSmall_OldWarBunker">
     <English>Old War Bunker</English>
+    <Spanish>Búnker de guerra antiguo</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FuelSmall_StorageArea">
     <English>Storage Area</English>
+    <Spanish>Zona de almacenamiento</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FuelSmall_StorageTanks">
     <English>Storage Tanks</English>
+    <Spanish>Depósitos de almacenamiento</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FuelMedium_StorageTank">
     <English>Storage Tank</English>
+    <Spanish>Depósito de almacenamiento</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FuelLarge_Depot">
     <English>Depot</English>
+    <Spanish>Depósito</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_FuelLarge_Refinery">
     <English>Refinery</English>
+    <Spanish>Refinería</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_HeliportsLarge_HelipadSquare">
     <English>Helipad (Square)</English>
+    <Spanish>Plataforma de helicóptero (cuadrada)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_HeliportsMedium_HelipadSquare">
     <English>Helipad (Square)</English>
+    <Spanish>Plataforma de helicóptero (cuadrada)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_HeliportsSmall_HelipadCircle">
     <English>Helipad (Circle)</English>
+    <Spanish>Plataforma de helicóptero (círculo)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_HeliportsSmall_HelipadSquare">
     <English>Helipad (Square)</English>
+    <Spanish>Plataforma de helicóptero (cuadrada)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_HQLarge_MainHQ">
     <English>Main Headquarters</English>
+    <Spanish>Cuartel general principal</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_HQLarge_FactoryHQ">
     <English>Factory Headquarters</English>
+    <Spanish>Cuartel general de fábrica</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_MedicalLarge_AirAmbulance">
     <English>Air Ambulance</English>
+    <Spanish>Ambulancia aérea</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_MedicalLarge_MedicalLabs">
     <English>Medical Laboratory</English>
+    <Spanish>Laboratorio médico</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_MedicalLarge_Hospital">
     <English>Hospital</English>
+    <Spanish>Hospital</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_MedicalLarge_EvacHospital">
     <English>Evacuation Hospital</English>
+    <Spanish>Hospital de evacuación</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_MedicalMedium_FieldHospital">
     <English>Field Hospital</English>
+    <Spanish>Hospital de campaña</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_MedicalMedium_UrbanSurgery">
     <English>Urban Surgery</English>
+    <Spanish>Quirófano urbano</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_MedicalMedium_StationHospital">
     <English>Station Hospital</English>
+    <Spanish>Hospital de base</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_MedicalMedium_JungleSurgery">
     <English>Jungle Surgery</English>
+    <Spanish>Quirófano en la jungla</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_MedicalSmall_UrbanSurgery">
     <English>Urban Surgery</English>
+    <Spanish>Quirófano urbano</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_MedicalSmall_FieldHospital">
     <English>Field Hospital</English>
+    <Spanish>Hospital de campaña</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_MedicalSmall_CollectionStation">
     <English>Collection Station</English>
+    <Spanish>Estación de recogida</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsLarge_LargeBungalow1">
     <English>Large Bungalow #1</English>
+    <Spanish>Bungaló grande #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsLarge_LargeBungalow2">
     <English>Large Bungalow #2</English>
+    <Spanish>Bungaló grande #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsLarge_Villa">
     <English>Villa</English>
+    <Spanish>Villa</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsLarge_Apartment">
     <English>Apartment</English>
+    <Spanish>Apartamento</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsLarge_Factory">
     <English>Factory</English>
+    <Spanish>Fábrica</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsLarge_Warehouse">
     <English>Warehouse</English>
+    <Spanish>Nave de almacenamiento</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_Bungalow">
     <English>Bungalow</English>
+    <Spanish>Bungaló</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_BrickBungalow">
     <English>BrickBungalow</English>
+    <Spanish>Bungaló de ladrillo</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_GreyBungalow">
     <English>Grey Bungalow</English>
+    <Spanish>Bungaló gris</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_YellowBungalow">
     <English>Yellow Bungalow</English>
+    <Spanish>Bungaló amarillo</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_BlueBungalow">
     <English>Blue Bungalow</English>
+    <Spanish>Bungaló azul</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_Shack">
     <English>Shack</English>
+    <Spanish>Chabola</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_ParkingHouse">
     <English>Parking House</English>
+    <Spanish>Aparcamiento cubierto</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_GuardHouse">
     <English>GuardHouse</English>
+    <Spanish>Garita</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_Junkyard">
     <English>Junkyard</English>
+    <Spanish>Desguace</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_BunkerLarge">
     <English>BunkerLarge</English>
+    <Spanish>Búnker grande</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_SmugglersOutpost1">
     <English>Smugglers Outpost #1</English>
+    <Spanish>Puesto avanzado de contrabandistas #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsMedium_SmugglersOutpost2">
     <English>Smugglers Outpost #2</English>
+    <Spanish>Puesto avanzado de contrabandistas #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsSmall_NativeHut">
     <English>Native Hut</English>
+    <Spanish>Choza autóctona</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsSmall_SlumShack">
     <English>Slum Shack</English>
+    <Spanish>Chabola de suburbio</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsSmall_Shed">
     <English>Shed</English>
+    <Spanish>Cobertizo</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsSmall_ShedSmall">
     <English>Shed (Small)</English>
+    <Spanish>Cobertizo (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsSmall_Shack">
     <English>Shack</English>
+    <Spanish>Chabola</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsSmall_ShedTiny">
     <English>Shed (Tiny)</English>
+    <Spanish>Cobertizo (diminuto)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_OutpostsSmall_OldBungalow">
     <English>Old Bungalow</English>
+    <Spanish>Bungaló antiguo</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_SupportsLarge_Workshop">
     <English>Workshop</English>
+    <Spanish>Taller</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_SupportsLarge_PumpingStation">
     <English>Pumping Station</English>
+    <Spanish>Estación de bombeo</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_SupportsLarge_MotorPool">
     <English>Motor Pool</English>
+    <Spanish>Parque de vehículos</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_SupportsLarge_MilitaryFactory">
     <English>Military Factory</English>
+    <Spanish>Fábrica militar</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_SupportsMedium_Device">
     <English>Device (Nuclear)</English>
+    <Spanish>Dispositivo (nuclear)</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_SupportsMedium_VehicleShed">
     <English>Vehicle Shed</English>
+    <Spanish>Cobertizo para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_SupportsMedium_CargoPosts">
     <English>Cargo Posts</English>
+    <Spanish>Puestos de carga</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_SupportsSmall_RepairBay">
     <English>Repair Bay</English>
+    <Spanish>Taller de reparación</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_SupportsSmall_WaterStation">
     <English>Water Station</English>
+    <Spanish>Estación de agua</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_SupportsSmall_Canteen">
     <English>Canteen</English>
+    <Spanish>Comedor</Spanish>
 </Key>
 <Key ID="STR_ZEC_GuerrillaPacific_SupportsSmall_BriefingArea">
     <English>Briefing Area</English>
+    <Spanish>Zona de briefing</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CampsSmall_MortarCamp">
     <English>Mortar Camp</English>
+    <Spanish>Campamento de morteros</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CampsSmall_CampSiteHMG">
     <English>Camp Site (HMG)</English>
+    <Spanish>Campamento (HMG)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CampsSmall_CampCargoPost">
     <English>Camp (Cargo Post)</English>
+    <Spanish>Campamento (puesto de carga)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CampsSmall_CampSite1">
     <English>Camp Site #1</English>
+    <Spanish>Campamento #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CampsSmall_CampSite2">
     <English>Camp Site #2</English>
+    <Spanish>Campamento #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CampsSmall_CampSite3">
     <English>Camp Site #3</English>
+    <Spanish>Campamento #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CampsSmall_CampSite4">
     <English>Camp Site #4</English>
+    <Spanish>Campamento #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CampsSmall_CampSite5">
     <English>Camp Site #5</English>
+    <Spanish>Campamento #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CampsSmall_CampSite6">
     <English>Camp Site #6</English>
+    <Spanish>Campamento #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CampsSmall_CampSite7">
     <English>Camp Site #7</English>
+    <Spanish>Campamento #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesMedium_Checkpoint">
     <English>Checkpoint (Basic)</English>
+    <Spanish>Puesto de control (básico)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesSmall_CheckpointLight">
     <English>Checkpoint (Light)</English>
+    <Spanish>Puesto de control (ligero)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesSmall_RoadblockImprov1sed1">
     <English>Roadblock Improv1sed #1</English>
+    <Spanish>Control de carretera improvisado #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesSmall_RoadblockImprov1sed2">
     <English>Roadblock Improv1sed #2</English>
+    <Spanish>Control de carretera improvisado #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesSmall_RoadblockImprov1sed3">
     <English>Roadblock Improv1sed #3</English>
+    <Spanish>Control de carretera improvisado #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesMedium_Barricade1">
     <English>Road Barricade #1</English>
+    <Spanish>Barricada de carretera #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesMedium_Barricade2">
     <English>Road Barricade #2</English>
+    <Spanish>Barricada de carretera #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesMedium_Barricade3">
     <English>Road Barricade #3</English>
+    <Spanish>Barricada de carretera #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesMedium_Barricade4">
     <English>Road Barricade #4</English>
+    <Spanish>Barricada de carretera #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesMedium_Barricade5">
     <English>Road Barricade #5</English>
+    <Spanish>Barricada de carretera #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesMedium_Barricade6">
     <English>Road Barricade #6</English>
+    <Spanish>Barricada de carretera #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_CheckpointsBarricadesMedium_Barricade7">
     <English>Road Barricade #7</English>
+    <Spanish>Barricada de carretera #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_ConstructionMedium_ConstructionFortified1">
     <English>Construction (Fortified) #1</English>
+    <Spanish>Construcción (fortificada) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_ConstructionMedium_ConstructionFortified2">
     <English>Construction (Fortified) #2</English>
+    <Spanish>Construcción (fortificada) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_ConstructionSmall_StorageShed">
     <English>Storage Shed</English>
+    <Spanish>Cobertizo de almacenamiento</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_ConstructionSmall_CacheAmmoBoxes">
     <English>Cache (Ammo Boxes)</English>
+    <Spanish>Alijo (cajas de munición)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_ConstructionSmall_CacheHiddenAmmoBox">
     <English>Cache - Hidden (Ammo Box)</English>
+    <Spanish>Alijo - oculto (caja de munición)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FieldHQLarge_CargoTowerHQ">
     <English>Cargo Tower HQ</English>
+    <Spanish>HQ en torre de carga</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FieldHQLarge_CargoHQ">
     <English>Cargo HQ</English>
+    <Spanish>HQ de carga</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FieldHQLarge_CargoPostHQ">
     <English>Cargo Post HQ</English>
+    <Spanish>HQ en puesto de carga</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FieldHQMedium_CargoHQ1">
     <English>Cargo HQ #1</English>
+    <Spanish>HQ de carga #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FieldHQMedium_CargoHQ2">
     <English>Cargo HQ #2</English>
+    <Spanish>HQ de carga #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FieldHQMedium_BunkerHQ1">
     <English>Bunker HQ #1</English>
+    <Spanish>HQ en búnker #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FieldHQMedium_BunkerHQ2">
     <English>Bunker HQ #2</English>
+    <Spanish>HQ en búnker #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FieldHQMedium_CargoHouseHQ1">
     <English>Cargo House HQ #1</English>
+    <Spanish>HQ en casa de carga #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FieldHQMedium_CargoHouseHQ2">
     <English>Cargo House HQ #2</English>
+    <Spanish>HQ en casa de carga #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FieldHQSmall_FieldHQ">
     <English>Field HQ</English>
+    <Spanish>HQ de campaña</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FuelSmall_FuelDrop">
     <English>Fuel Drop</English>
+    <Spanish>Lanzamiento de combustible</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FuelSmall_StorageArea">
     <English>Storage Area</English>
+    <Spanish>Zona de almacenamiento</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FuelMedium_StorageTanks">
     <English>Storage Tanks</English>
+    <Spanish>Depósitos de almacenamiento</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FuelMedium_DieselStorage">
     <English>Diesel Storage</English>
+    <Spanish>Almacén de diésel</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FuelLarge_Depot">
     <English>Depot</English>
+    <Spanish>Depósito</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FuelLarge_Refinery">
     <English>Refinery</English>
+    <Spanish>Refinería</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortLarge_MortarBunker">
     <English>Mortar Bunker</English>
+    <Spanish>Búnker de morteros</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortMedium_BunkerLarge">
     <English>Bunker (Large)</English>
+    <Spanish>Búnker (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_BunkerConcrete">
     <English>Bunker (Concrete)</English>
+    <Spanish>Búnker (hormigón)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_Bunkerx2">
     <English>Bunker (Concrete)</English>
+    <Spanish>Búnker (hormigón)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_Bunker1">
     <English>Bunker #1</English>
+    <Spanish>Búnker #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_Bunker2">
     <English>Bunker #2</English>
+    <Spanish>Búnker #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_Bunker3">
     <English>Bunker #3</English>
+    <Spanish>Búnker #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_BunkerHBarrier1">
     <English>Bunker H-Barrier #1</English>
+    <Spanish>Búnker de H-Barrier #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_BunkerHBarrier2">
     <English>Bunker H-Barrier #2</English>
+    <Spanish>Búnker de H-Barrier #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_BunkerHBarrier3">
     <English>Bunker H-Barrier #3</English>
+    <Spanish>Búnker de H-Barrier #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_BunkerHBarrier4">
     <English>Bunker H-Barrier #4</English>
+    <Spanish>Búnker de H-Barrier #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_BunkerUrban">
     <English>Bunker (Urban)</English>
+    <Spanish>Búnker (urbano)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_BunkerSandbags1">
     <English>Bunker (Sandbags) #1</English>
+    <Spanish>Búnker (sacos terreros) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_BunkerSandbags2">
     <English>Bunker (Sandbags) #2</English>
+    <Spanish>Búnker (sacos terreros) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_Sandbags1">
     <English>Sandbags #1</English>
+    <Spanish>Sacos terreros #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_Sandbags2">
     <English>Sandbags #2</English>
+    <Spanish>Sacos terreros #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_Sandbags3">
     <English>Sandbags #3</English>
+    <Spanish>Sacos terreros #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_FortSmall_MortarSandbag">
     <English>Mortar (Sandbag)</English>
+    <Spanish>Mortero (saco terrero)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_HeliportsMedium_SupplyDropPoint">
     <English>Supply Drop Point</English>
+    <Spanish>Punto de lanzamiento de suministros</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_HQMedium_RuinFortified">
     <English>Ruin (Fortified)</English>
+    <Spanish>Ruina (fortificada)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_HQMedium_HangarFortified">
     <English>Hangar (Fortified)</English>
+    <Spanish>Hangar (fortificado)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_HQMedium_ShedSandbags">
     <English>Shed (Sandbags)</English>
+    <Spanish>Cobertizo (sacos terreros)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalLarge_AirAmbulance">
 	<English>Air Ambulance</English>
+	<Spanish>Ambulancia aérea</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalLarge_MedicalLab">
 	<English>Medical Laboratory</English>
+	<Spanish>Laboratorio médico</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalLarge_Hospital">
 	<English>Hospital</English>
+	<Spanish>Hospital</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalLarge_EvacHospital">
 	<English>Evacuation Hospital</English>
+	<Spanish>Hospital de evacuación</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalMedium_FieldHospital">
 	<English>Field Hospital</English>
+	<Spanish>Hospital de campaña</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalMedium_AirStationHospital">
 	<English>Air Station Hospital</English>
+	<Spanish>Hospital de base aérea</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalMedium_Surgery">
 	<English>Surgery</English>
+	<Spanish>Quirófano</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalSmall_UrbanSurgery">
 	<English>Urban Surgery</English>
+	<Spanish>Quirófano urbano</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalSmall_FieldHospital">
 	<English>Field Hospital</English>
+	<Spanish>Hospital de campaña</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalSmall_CollectionStation">
 	<English>Collection Station</English>
+	<Spanish>Estación de recogida</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalSmall_Surgery1">
 	<English>Surgery #1</English>
+	<Spanish>Quirófano #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_MedicalSmall_Surgery2">
 	<English>Surgery #2</English>
+	<Spanish>Quirófano #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_OutpostsMedium_DestroyedHouse">
     <English>Destroyed House</English>
+    <Spanish>Casa destruida</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_OutpostsMedium_LongHouse">
     <English>Long House</English>
+    <Spanish>Casa alargada</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_OutpostsMedium_HouseFortified">
     <English>Fortified House</English>
+    <Spanish>Casa fortificada</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_OutpostsSmall_SmallHouse">
     <English>Small House</English>
+    <Spanish>Casa pequeña</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_SupportsSmall_Workshop">
     <English>Workshop</English>
+    <Spanish>Taller</Spanish>
 </Key>
 <Key ID="STR_ZEC_Guerrilla_SupportsSmall_ServiceStation">
     <English>Service Station</English>
+    <Spanish>Estación de servicio</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsLarge_PumpingStation_OPF_T_F">
     <English>Pumping Station [OPF]</English>
+    <Spanish>Estación de bombeo [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsLarge_PumpingStation_BLU_T_F">
     <English>Pumping Station [BLU]</English>
+    <Spanish>Estación de bombeo [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsLarge_MotorPool_OPF_T_F">
     <English>Motor Pool [OPF]</English>
+    <Spanish>Parque de vehículos [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsLarge_MotorPool_BLU_T_F">
     <English>Motor Pool [BLU]</English>
+    <Spanish>Parque de vehículos [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsLarge_BarracksGrey">
     <English>Barracks Grey</English>
+    <Spanish>Barracones grises</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsLarge_BarracksCamo">
     <English>Barracks Camo</English>
+    <Spanish>Barracones camuflados</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsLarge_BarracksOld">
     <English>Barracks Old</English>
+    <Spanish>Barracones viejos</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsLarge_BarracksFortified">
     <English>Barracks Fortified</English>
+    <Spanish>Barracones fortificados</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsLarge_ResearchComplex">
     <English>Research Complex</English>
+    <Spanish>Complejo de investigación</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_DeviceNuclear_OPF_T_F">
     <English>Device (Nuclear) [OPF]</English>
+    <Spanish>Dispositivo (nuclear) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_DeviceNuclear_BLU_T_F">
     <English>Device (Nuclear) [BLU]</English>
+    <Spanish>Dispositivo (nuclear) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_VehicleShed_BLU_T_F">
     <English>Vehicle Shed [BLU]</English>
+    <Spanish>Cobertizo para vehículos [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_VehicleShed_OPF_T_F">
     <English>Vehicle Shed [OPF]</English>
+    <Spanish>Cobertizo para vehículos [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_WindTurbine1">
     <English>Wind Turbine #1</English>
+    <Spanish>Aerogenerador #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_WindTurbine2">
     <English>Wind Turbine #2</English>
+    <Spanish>Aerogenerador #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_CargoPosts">
     <English>Cargo Posts</English>
+    <Spanish>Puestos de carga</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_ResearchCompound">
     <English>Research Compound</English>
+    <Spanish>Recinto de investigación</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_CargoPostFortified">
     <English>CargoPost (Fortified)</English>
+    <Spanish>Puesto de carga (fortificado)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_CargoPost">
     <English>Cargo Post</English>
+    <Spanish>Puesto de carga</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_CargoHouse1">
     <English>Cargo Post #1</English>
+    <Spanish>Puesto de carga #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_CargoHouse2">
     <English>Cargo Post #2</English>
+    <Spanish>Puesto de carga #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_BriefingArea_OPF_T_F">
     <English>Briefing Area [OPF]</English>
+    <Spanish>Zona de briefing [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_BriefingArea_BLU_T_F">
     <English>Briefing Area [BLU]</English>
+    <Spanish>Zona de briefing [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_RepairBay_OPF_T_F">
     <English>Repair Bay [OPF]</English>
+    <Spanish>Taller de reparación [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_RepairBay_BLU_T_F">
     <English>Repair Bay [BLU]</English>
+    <Spanish>Taller de reparación [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_WaterStation_OPF_T_F">
     <English>Water Station [OPF]</English>
+    <Spanish>Estación de agua [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_WaterStation_BLU_T_F">
     <English>Water Station [BLU]</English>
+    <Spanish>Estación de agua [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_Canteen_OPF_T_F">
     <English>Canteen [OPF]</English>
+    <Spanish>Comedor [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_Canteen_BLU_T_F">
     <English>Canteen [BLU]</English>
+    <Spanish>Comedor [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_ResearchCentre">
     <English>Research Centre</English>
+    <Spanish>Centro de investigación</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SuppliesLarge_WarehouseUrban_OPF_T_F">
     <English>Warehouse (Urban) [OPF]</English>
+    <Spanish>Nave de almacenamiento (urbana) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SuppliesLarge_WarehouseUrban_BLU_T_F">
     <English>Warehouse (Urban) [BLU]</English>
+    <Spanish>Nave de almacenamiento (urbana) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_StorageShed">
     <English>Storage Shed</English>
+    <Spanish>Cobertizo de almacenamiento</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_DeviceYard">
     <English>Device (Yard)</English>
+    <Spanish>Dispositivo (patio)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_StorageCovered_OPF_T_F">
     <English>Storage (Covered) [OPF]</English>
+    <Spanish>Almacenamiento (cubierto) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_StorageCovered_BLU_T_F">
     <English>Storage (Covered) [BLU]</English>
+    <Spanish>Almacenamiento (cubierto) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_StorageUrban_OPF_T_F">
     <English>Storage Urban [OPF]</English>
+    <Spanish>Almacenamiento urbano [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsMedium_StorageUrban_BLU_T_F">
     <English>Storage Urban [BLU]</English>
+    <Spanish>Almacenamiento urbano [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_AmmoCache1_OPF_T_F">
     <English>Cache (Ammo Boxes) [OPF] #1</English>
+    <Spanish>Alijo (cajas de munición) [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_AmmoCache2_OPF_T_F">
     <English>Cache (Ammo Boxes) [OPF] #2</English>
+    <Spanish>Alijo (cajas de munición) [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_ContainerStorage_OPF_T_F">
     <English>Container Storage [OPF]</English>
+    <Spanish>Almacén de contenedores [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_Cache1_OPF_T_F">
     <English>Cache [OPF] #1</English>
+    <Spanish>Alijo [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_Cache2_OPF_T_F">
     <English>Cache [OPF] #2</English>
+    <Spanish>Alijo [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_Cache3_OPF_T_F">
     <English>Cache [OPF] #3</English>
+    <Spanish>Alijo [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_StorageArea1_OPF_T_F">
     <English>Storage Area [OPF] #1</English>
+    <Spanish>Zona de almacenamiento [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_StorageArea2_OPF_T_F">
     <English>Storage Area [OPF] #2</English>
+    <Spanish>Zona de almacenamiento [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_StorageArea3_OPF_T_F">
     <English>Storage Area [OPF] #3</English>
+    <Spanish>Zona de almacenamiento [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_AmmoCache1_BLU_T_F">
     <English>Cache (Ammo Boxes) [BLU] #1</English>
+    <Spanish>Alijo (cajas de munición) [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_AmmoCache2_BLU_T_F">
     <English>Cache (Ammo Boxes) [BLU] #2</English>
+    <Spanish>Alijo (cajas de munición) [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_ContainerStorage_BLU_T_F">
     <English>Container Storage [BLU]</English>
+    <Spanish>Almacén de contenedores [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_Cache1_BLU_T_F">
     <English>Cache [BLU] #1</English>
+    <Spanish>Alijo [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_Cache2_BLU_T_F">
     <English>Cache [BLU] #2</English>
+    <Spanish>Alijo [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_Cache3_BLU_T_F">
     <English>Cache [BLU] #3</English>
+    <Spanish>Alijo [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_StorageArea1_BLU_T_F">
     <English>Storage Area [BLU] #1</English>
+    <Spanish>Zona de almacenamiento [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_StorageArea2_BLU_T_F">
     <English>Storage Area [BLU] #2</English>
+    <Spanish>Zona de almacenamiento [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_SupportsSmall_StorageArea3_BLU_T_F">
     <English>Storage Area [BLU] #3</English>
+    <Spanish>Zona de almacenamiento [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsLarge_LargeBungalow_OPF_T_F">
     <English>Large Bungalow [OPF]</English>
+    <Spanish>Bungaló grande [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsLarge_BungalowCompound_OPF_T_F">
     <English>Large Compound [OPF]</English>
+    <Spanish>Recinto grande [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsLarge_Villa_OPF_T_F">
     <English>Villa [OPF]</English>
+    <Spanish>Villa [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsLarge_Apartment_OPF_T_F">
     <English>Apartment [OPF]</English>
+    <Spanish>Apartamento [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsLarge_LargeBungalow1_BLU_T_F">
     <English>Large Bungalow [BLU]</English>
+    <Spanish>Bungaló grande [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsLarge_LargeBungalow2_BLU_T_F">
     <English>Large Compound [BLU]</English>
+    <Spanish>Recinto grande [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsLarge_Villa_BLU_T_F">
     <English>Villa [BLU]</English>
+    <Spanish>Villa [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsLarge_Apartment_BLU_T_F">
     <English>Apartment [BLU]</English>
+    <Spanish>Apartamento [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsLarge_OutpostHBarrier">
     <English>Outpost (H-Barrier)</English>
+    <Spanish>Puesto avanzado (H-Barrier)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsLarge_OutpostMilWall">
     <English>Outpost (MilWall)</English>
+    <Spanish>Puesto avanzado (MilWall)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsLarge_OutpostConcrete">
     <English>Outpost (Concrete)</English>
+    <Spanish>Puesto avanzado (hormigón)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost01">
     <English>Simple Outpost #01</English>
+    <Spanish>Puesto avanzado sencillo #01</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost02">
     <English>Simple Outpost #02</English>
+    <Spanish>Puesto avanzado sencillo #02</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost03">
     <English>Simple Outpost #03</English>
+    <Spanish>Puesto avanzado sencillo #03</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost04">
     <English>Simple Outpost #04</English>
+    <Spanish>Puesto avanzado sencillo #04</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost05">
     <English>Simple Outpost #05</English>
+    <Spanish>Puesto avanzado sencillo #05</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost06">
     <English>Simple Outpost #06</English>
+    <Spanish>Puesto avanzado sencillo #06</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost07">
     <English>Simple Outpost #07</English>
+    <Spanish>Puesto avanzado sencillo #07</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost08">
     <English>Simple Outpost #08</English>
+    <Spanish>Puesto avanzado sencillo #08</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost09">
     <English>Simple Outpost #09</English>
+    <Spanish>Puesto avanzado sencillo #09</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost10">
     <English>Simple Outpost #10</English>
+    <Spanish>Puesto avanzado sencillo #10</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost11">
     <English>Simple Outpost #11</English>
+    <Spanish>Puesto avanzado sencillo #11</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost12">
     <English>Simple Outpost #12</English>
+    <Spanish>Puesto avanzado sencillo #12</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost13">
     <English>Simple Outpost #13</English>
+    <Spanish>Puesto avanzado sencillo #13</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost14">
     <English>Simple Outpost #14</English>
+    <Spanish>Puesto avanzado sencillo #14</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_SimpleOutpost15">
     <English>Simple Outpost #15</English>
+    <Spanish>Puesto avanzado sencillo #15</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_Bungalow_OPF_T_F">
     <English>Bungalow [OPF]</English>
+    <Spanish>Bungaló [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_BrickBungalow_OPF_T_F">
     <English>Brick Bungalow [OPF]</English>
+    <Spanish>Bungaló de ladrillo [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_GreyBungalow_OPF_T_F">
     <English>Grey Bungalow [OPF]</English>
+    <Spanish>Bungaló gris [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_YellowBungalow_OPF_T_F">
     <English>Yellow Bungalow [OPF]</English>
+    <Spanish>Bungaló amarillo [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_BlueBungalow_OPF_T_F">
     <English>Blue Bungalow [OPF]</English>
+    <Spanish>Bungaló azul [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_Shack_OPF_T_F">
     <English>Shack [OPF]</English>
+    <Spanish>Chabola [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_ParkingHouse_OPF_T_F">
     <English>Parking House [OPF]</English>
+    <Spanish>Aparcamiento cubierto [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_GuardCompound_OPF_T_F">
     <English>Guard Compound [OPF]</English>
+    <Spanish>Recinto de guardia [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_Junkyard_OPF_T_F">
     <English>Junkyard [OPF]</English>
+    <Spanish>Desguace [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_Bungalow_BLU_T_F">
     <English>Bungalow [BLU]</English>
+    <Spanish>Bungaló [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_BrickBungalow_BLU_T_F">
     <English>Brick Bungalow [BLU]</English>
+    <Spanish>Bungaló de ladrillo [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_GreyBungalow_BLU_T_F">
     <English>Grey Bungalow [BLU]</English>
+    <Spanish>Bungaló gris [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_YellowBungalow_BLU_T_F">
     <English>Yellow Bungalow [BLU]</English>
+    <Spanish>Bungaló amarillo [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_BlueBungalow_BLU_T_F">
     <English>Blue Bungalow [BLU]</English>
+    <Spanish>Bungaló azul [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_Shack_BLU_T_F">
     <English>Shack [BLU]</English>
+    <Spanish>Chabola [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_ParkingHouse_BLU_T_F">
     <English>Parking House [BLU]</English>
+    <Spanish>Aparcamiento cubierto [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_GuardCompound_BLU_T_F">
     <English>Guard Compound [BLU]</English>
+    <Spanish>Recinto de guardia [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsMedium_Junkyard_BLU_T_F">
     <English>Junkyard [BLU]</English>
+    <Spanish>Desguace [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_OldBungalow_BLU_T_F">
     <English>Old Bungalow [BLU]</English>
+    <Spanish>Bungaló antiguo [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_NativeHouse_BLU_T_F">
     <English>Native Hut [BLU]</English>
+    <Spanish>Choza autóctona [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_SlumShack_BLU_T_F">
     <English>SlumShack [BLU]</English>
+    <Spanish>Chabola de suburbio [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_Shed_BLU_T_F">
     <English>Shed [BLU]</English>
+    <Spanish>Cobertizo [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_ShedSmall_BLU_T_F">
     <English>Shed Small [BLU]</English>
+    <Spanish>Cobertizo pequeño [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_Shack_BLU_T_F">
     <English>Shack [BLU]</English>
+    <Spanish>Chabola [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_ShedTiny_BLU_T_F">
     <English>Shed Tiny [BLU]</English>
+    <Spanish>Cobertizo diminuto [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_OldBungalow_OPF_T_F">
     <English>Old Bungalow [OPF]</English>
+    <Spanish>Bungaló antiguo [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_NativeHouse_OPF_T_F">
     <English>Native Hut [OPF]</English>
+    <Spanish>Choza autóctona [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_SlumShack_OPF_T_F">
     <English>SlumShack [OPF]</English>
+    <Spanish>Chabola de suburbio [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_Shed_OPF_T_F">
     <English>Shed [OPF]</English>
+    <Spanish>Cobertizo [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_ShedSmall_OPF_T_F">
     <English>Shed Small [OPF]</English>
+    <Spanish>Cobertizo pequeño [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_Shack_OPF_T_F">
     <English>Shack [OPF]</English>
+    <Spanish>Chabola [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_OutpostsSmall_ShedTiny_OPF_T_F">
     <English>Shed Tiny [OPF]</English>
+    <Spanish>Cobertizo diminuto [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalLarge_MedicalComplex">
     <English>Medical Complex</English>
+    <Spanish>Complejo sanitario</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalMedium_MedicalCompound">
     <English>Medical Compound</English>
+    <Spanish>Recinto sanitario</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalSmall_MedicalCentre">
     <English>Medical Centre</English>
+    <Spanish>Centro sanitario</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalLarge_AirAmbulance_BLU_T_F">
 	<English>Air Ambulance [BLU]</English>
+	<Spanish>Ambulancia aérea [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalLarge_AirAmbulance_OPF_T_F">
 	<English>Air Ambulance [OPF]</English>
+	<Spanish>Ambulancia aérea [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalLarge_MedicalLabs_BLU_T_F">
 	<English>Medical Laboratory [BLU]</English>
+	<Spanish>Laboratorio médico [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalLarge_MedicalLabs_OPF_T_F">
 	<English>Medical Laboratory [OPF]</English>
+	<Spanish>Laboratorio médico [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalLarge_Hospital_BLU_T_F">
 	<English>Hospital [BLU]</English>
+	<Spanish>Hospital [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalLarge_Hospital_OPF_T_F">
 	<English>Hospital [OPF]</English>
+	<Spanish>Hospital [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalLarge_EvacHospital_BLU_T_F">
 	<English>Evacuation Hospital [BLU]</English>
+	<Spanish>Hospital de evacuación [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalLarge_EvacHospital_OPF_T_F">
 	<English>Evacuation Hospital [OPF]</English>
+	<Spanish>Hospital de evacuación [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalMedium_FieldHospital_BLU_T_F">
 	<English>Field Hospital [BLU]</English>
+	<Spanish>Hospital de campaña [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalMedium_UrbanSurgery1_BLU_T_F">
 	<English>Urban Surgery #1 [BLU]</English>
+	<Spanish>Quirófano urbano #1 [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalMedium_UrbanSurgery2_BLU_T_F">
 	<English>Urban Surgery #2 [BLU]</English>
+	<Spanish>Quirófano urbano #2 [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalMedium_AirStationHospital_BLU_T_F">
 	<English>Air Station Hospital [BLU]</English>
+	<Spanish>Hospital de base aérea [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalMedium_AirStationHospital_OPF_T_F">
 	<English>Air Station Hospital [OPF]</English>
+	<Spanish>Hospital de base aérea [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalMedium_JungleSurgery_BLU_T_F">
 	<English>Jungle Surgery [BLU]</English>
+	<Spanish>Quirófano en la jungla [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalMedium_UrbanHospital_OPF_T_F">
 	<English>Urban Hospital [OPF]</English>
+	<Spanish>Hospital urbano [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalMedium_JungleSurgery_OPF_T_F">
 	<English>Jungle Surgery [OPF]</English>
+	<Spanish>Quirófano en la jungla [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalMedium_FieldHospital1_OPF_T_F">
 	<English>Field Hospital #1 [OPF]</English>
+	<Spanish>Hospital de campaña #1 [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalMedium_FieldHospital2_OPF_T_F">
 	<English>Field Hospital #2 [OPF]</English>
+	<Spanish>Hospital de campaña #2 [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalSmall_UrbanEvacPoint1">
 	<English>Urban Evac Point #1</English>
+	<Spanish>Punto de evacuación urbano #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalSmall_UrbanEvacPoint2">
 	<English>Urban Evac Point #2</English>
+	<Spanish>Punto de evacuación urbano #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalSmall_FieldHospital_BLU_T_F">
 	<English>Field Hospital [BLU]</English>
+	<Spanish>Hospital de campaña [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalSmall_FieldHospital_OPF_T_F">
 	<English>Field Hospital [OPF]</English>
+	<Spanish>Hospital de campaña [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalSmall_CollectionStation_BLU_T_F">
 	<English>Collection Station [BLU]</English>
+	<Spanish>Estación de recogida [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_MedicalSmall_CollectionStation_OPF_T_F">
 	<English>Collection Station [OPF]</English>
+	<Spanish>Estación de recogida [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HQLarge_HQSquare">
     <English>Headquarters Square</English>
+    <Spanish>Cuartel general cuadrado</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HQLarge_HQCircle">
     <English>Headquarters Circle</English>
+    <Spanish>Cuartel general circular</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HQLarge_HQLShape">
     <English>Headquarters L-Shape</English>
+    <Spanish>Cuartel general en L</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HQLarge_MainHQ_OPF_T_F">
     <English>Main Headquarters [OPF]</English>
+    <Spanish>Cuartel general principal [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HQLarge_MainHQ_BLU_T_F">
     <English>Main Headquarters [BLU]</English>
+    <Spanish>Cuartel general principal [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HQLarge_TrainingCompound">
     <English>Training Compound</English>
+    <Spanish>Recinto de instrucción</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HQLarge_VIPCompound">
     <English>VIP Compound</English>
+    <Spanish>Recinto para VIP</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HeliportsLarge_HeliportTemp">
     <English>Heliport (Temp)</English>
+    <Spanish>Helipuerto (temporal)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HeliportsLarge_HelipadSquare_OPF_T_F">
     <English>Helipad (Square) [OPF]</English>
+    <Spanish>Plataforma de helicóptero (cuadrada) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HeliportsLarge_HelipadSquare_BLU_CTRG_F">
     <English>Helipad (Square) [BLU]</English>
+    <Spanish>Plataforma de helicóptero (cuadrada) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HeliportsLarge_HeliportFortified">
     <English>HeliportFortified</English>
+    <Spanish>Helipuerto fortificado</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HeliportsLarge_HeliportDual">
     <English>Heliport (Dual)</English>
+    <Spanish>Helipuerto (doble)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HeliportsMedium_HelipadSquare">
     <English>Helipad (Square)</English>
+    <Spanish>Plataforma de helicóptero (cuadrada)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HeliportsMedium_HelipadCircle">
     <English>Helipad (Circle)</English>
+    <Spanish>Plataforma de helicóptero (círculo)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HeliportsMedium_HelipadSquare_BLU_CTRG_F">
     <English>Helipad (Square) [BLU]</English>
+    <Spanish>Plataforma de helicóptero (cuadrada) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HeliportsMedium_HelipadSquare_OPF_T_F">
     <English>Helipad (Square) [OPF]</English>
+    <Spanish>Plataforma de helicóptero (cuadrada) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HeliportsSmall_HelipadSquare">
     <English>Helipad (Square)</English>
+    <Spanish>Plataforma de helicóptero (cuadrada)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_HeliportsSmall_HelipadCircle">
     <English>Helipad (Circle)</English>
+    <Spanish>Plataforma de helicóptero (círculo)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FieldHQLarge_ObservationTower_OPF_T_F">
     <English>Observation Tower [OPF]</English>
+    <Spanish>Torre de observación [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FieldHQLarge_ObservationTower_BLU_T_F">
     <English>Observation Tower [BLU]</English>
+    <Spanish>Torre de observación [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FieldHQMedium_CargoHQRadio">
     <English>Cargo HQ (Radio)</English>
+    <Spanish>HQ de carga (radio)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FieldHQMedium_CargoHQ">
     <English>Cargo HQ</English>
+    <Spanish>HQ de carga</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FieldHQMedium_FieldHQ_OPF_T_F">
     <English>Field HQ [OPF]</English>
+    <Spanish>HQ de campaña [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FieldHQMedium_ObservationPost_OPF_T_F">
     <English>Observation Post [OPF]</English>
+    <Spanish>Puesto de observación [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FieldHQMedium_FieldHQ_BLU_T_F">
     <English>Field HQ [BLU]</English>
+    <Spanish>HQ de campaña [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FieldHQMedium_ObservationPost_BLU_T_F">
     <English>Observation Post [BLU]</English>
+    <Spanish>Puesto de observación [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FieldHQSmall_ObservationTower1">
     <English>Observation Tower #1</English>
+    <Spanish>Torre de observación #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FieldHQSmall_ObservationTower2">
     <English>Observation Tower #2</English>
+    <Spanish>Torre de observación #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FuelSmall_StorageArea_BLU_T_F">
     <English>Storage Area [BLU]</English>
+    <Spanish>Zona de almacenamiento [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FuelSmall_StorageTanks_BLU_T_F">
     <English>Storage Tanks [BLU]</English>
+    <Spanish>Depósitos de almacenamiento [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FuelSmall_StorageArea_OPF_T_F">
     <English>Storage Area [OPF]</English>
+    <Spanish>Zona de almacenamiento [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FuelSmall_StorageTanks_OPF_T_F">
     <English>Storage Tanks [OPF]</English>
+    <Spanish>Depósitos de almacenamiento [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FuelMedium_StorageTank_BLU_T_F">
     <English>Storage Tank [BLU]</English>
+    <Spanish>Depósito de almacenamiento [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FuelMedium_StorageTank_OPF_T_F">
     <English>Storage Tank [OPF]</English>
+    <Spanish>Depósito de almacenamiento [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FuelLarge_Depot_BLU_T_F">
     <English>Depot [BLU]</English>
+    <Spanish>Depósito [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FuelLarge_Refinery_BLU_T_F">
     <English>Refinery [BLU]</English>
+    <Spanish>Refinería [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FuelLarge_Depot_OPF_T_F">
     <English>Depot [OPF]</English>
+    <Spanish>Depósito [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FuelLarge_Refinery_OPF_T_F">
     <English>Refinery [OPF]</English>
+    <Spanish>Refinería [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_ConstructionSuppliesLarge_MilitaryFortifications">
     <English>Military Fortifications</English>
+    <Spanish>Fortificaciones militares</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_ConstructionSuppliesLarge_MilitaryItems">
     <English>Military Items</English>
+    <Spanish>Objetos militares</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_ConstructionSuppliesLarge_Sandbags">
     <English>Sandbags</English>
+    <Spanish>Sacos terreros</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsLarge_RadarDome_OPF_T_F">
     <English>Radar Dome [OPF]</English>
+    <Spanish>Radomo [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsLarge_CommunicationsPost_OPF_T_F">
     <English>Communications Post [OPF]</English>
+    <Spanish>Puesto de comunicaciones [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsLarge_UAVDepot_OPF_T_F">
     <English>UAV Depot [OPF]</English>
+    <Spanish>Depósito de UAV [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsLarge_RadarDome_BLU_T_F">
     <English>Radar Dome [BLU]</English>
+    <Spanish>Radomo [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsLarge_CommunicationsPost_BLU_T_F">
     <English>Communications Post [BLU]</English>
+    <Spanish>Puesto de comunicaciones [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsLarge_UAVDepot_BLU_T_F">
     <English>UAV Depot [BLU]</English>
+    <Spanish>Depósito de UAV [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsMedium_BunkerListeningPost_OPF_T_F">
     <English>Bunker Listening Post [OPF]</English>
+    <Spanish>Puesto de escucha en búnker [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsMedium_BunkerListeningPost_BLU_T_F">
     <English>Bunker Listening Post [BLU]</English>
+    <Spanish>Puesto de escucha en búnker [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsMedium_BunkerLarge_BLU_T_F">
     <English>Radio Bunker [BLU]</English>
+    <Spanish>Búnker de radio [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsMedium_BunkerLarge_OPF_T_F">
     <English>Radio Bunker [OPF]</English>
+    <Spanish>Búnker de radio [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsSmall_RadioPostFortified">
     <English>Radio Post (Fortified)</English>
+    <Spanish>Puesto de radio (fortificado)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsSmall_RadioPostCargo">
     <English>Radio Post (Cargo)</English>
+    <Spanish>Puesto de radio (carga)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsSmall_OperationsArea_BLU_T_F">
     <English>Operations Area [BLU]</English>
+    <Spanish>Zona de operaciones [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CommunicationsSmall_OperationsArea_OPF_T_F">
     <English>Operations Area [OPF]</English>
+    <Spanish>Zona de operaciones [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_AirportsLarge_Hangar_OPF_T_F">
     <English>Hangar [OPF]</English>
+    <Spanish>Hangar [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_AirportsLarge_Hangar_BLU_T_F">
     <English>Hangar [BLU]</English>
+    <Spanish>Hangar [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_ReconCampTerminal_OPF_T_F">
     <English>Recon Camp (Terminal) [OPF]</English>
+    <Spanish>Campamento de reconocimiento (terminal) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_PicnicSite_OPF_T_F">
     <English>Picnic Site [OPF]</English>
+    <Spanish>Zona de pícnic [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampJungle_OPF_T_F">
     <English>Camp (Jungle) [OPF]</English>
+    <Spanish>Campamento (jungla) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSite1_OPF_T_F">
     <English>Camp Site [OPF] #1</English>
+    <Spanish>Campamento [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSite2_OPF_T_F">
     <English>Camp Site [OPF] #2</English>
+    <Spanish>Campamento [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSite3_OPF_T_F">
     <English>Camp Site [OPF] #3</English>
+    <Spanish>Campamento [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSite4_OPF_T_F">
     <English>Camp Site [OPF] #4</English>
+    <Spanish>Campamento [OPF] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSite5_OPF_T_F">
     <English>Camp Site [OPF] #5</English>
+    <Spanish>Campamento [OPF] #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSiteHMG1_OPF_T_F">
     <English>Camp Site (HMG) [OPF] #1</English>
+    <Spanish>Campamento (HMG) [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSiteHMG2_OPF_T_F">
     <English>Camp Site (HMG) [OPF] #2</English>
+    <Spanish>Campamento (HMG) [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_MortarSite_OPF_T_F">
     <English>Mortar Site [OPF]</English>
+    <Spanish>Posición de morteros [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampCargoPost_OPF_T_F">
     <English>Cargo Post [OPF]</English>
+    <Spanish>Puesto de carga [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_ReconCampTerminal_BLU_T_F">
     <English>Recon Camp (Terminal) [BLU]</English>
+    <Spanish>Campamento de reconocimiento (terminal) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_PicnicSite_BLU_T_F">
     <English>Picnic Site [BLU]</English>
+    <Spanish>Zona de pícnic [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampJungle_BLU_T_F">
     <English>Camp (Jungle) [BLU]</English>
+    <Spanish>Campamento (jungla) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSite1_BLU_T_F">
     <English>Camp Site [BLU] #1</English>
+    <Spanish>Campamento [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSite2_BLU_T_F">
     <English>Camp Site [BLU] #2</English>
+    <Spanish>Campamento [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSite3_BLU_T_F">
     <English>Camp Site [BLU] #3</English>
+    <Spanish>Campamento [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSite4_BLU_T_F">
     <English>Camp Site [BLU] #4</English>
+    <Spanish>Campamento [BLU] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSite5_BLU_T_F">
     <English>Camp Site [BLU] #5</English>
+    <Spanish>Campamento [BLU] #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSiteHMG1_BLU_T_F">
     <English>Camp Site (HMG) [BLU] #1</English>
+    <Spanish>Campamento (HMG) [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampSiteHMG2_BLU_T_F">
     <English>Camp Site (HMG) [BLU] #2</English>
+    <Spanish>Campamento (HMG) [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_MortarSite_BLU_T_F">
     <English>Mortar Site [BLU]</English>
+    <Spanish>Posición de morteros [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CampsSmall_CampCargoPost_BLU_T_F">
     <English>Cargo Post [BLU]</English>
+    <Spanish>Puesto de carga [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesLarge_CheckpointHeavyWatchtower">
     <English>Checkpoint (Watchtower)</English>
+    <Spanish>Puesto de control (torre de vigilancia)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesLarge_CheckpointHBarrier">
     <English>Checkpoint (H-Barrier)</English>
+    <Spanish>Puesto de control (H-Barrier)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesLarge_CheckpointCargoPost">
     <English>Checkpoint (Cargo Post)</English>
+    <Spanish>Puesto de control (puesto de carga)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesLarge_Checkpoint_BLU_T_F">
     <English>Checkpoint [BLU]</English>
+    <Spanish>Puesto de control [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesLarge_Checkpoint_OPF_T_F">
     <English>Checkpoint [OFP]</English>
+    <Spanish>Puesto de control [OFP]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesMedium_CheckpointBunker">
     <English>Checkpoint (Bunker)</English>
+    <Spanish>Puesto de control (búnker)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesMedium_Checkpoint_BLU_T_F">
     <English>Checkpoint [BLU]</English>
+    <Spanish>Puesto de control [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesMedium_Checkpoint_OPF_T_F">
     <English>Checkpoint [OPF]</English>
+    <Spanish>Puesto de control [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesMedium_CheckpointConcrete1">
     <English>Checkpoint (Concrete) #1</English>
+    <Spanish>Puesto de control (hormigón) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesMedium_CheckpointConcrete2">
     <English>Checkpoint (Concrete) #2</English>
+    <Spanish>Puesto de control (hormigón) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesMedium_CheckpointTowers">
     <English>Checkpoint (Towers)</English>
+    <Spanish>Puesto de control (torres)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesMedium_CheckpointVehicle">
     <English>Checkpoint (Vehicle Bunker)</English>
+    <Spanish>Puesto de control (búnker para vehículos)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesMedium_CheckpointWatchtower">
     <English>Checkpoint (Watchtower)</English>
+    <Spanish>Puesto de control (torre de vigilancia)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesMedium_CheckpointCargoPosts">
     <English>Checkpoint (Cargo Posts)</English>
+    <Spanish>Puesto de control (puestos de carga)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesSmall_CheckpointSandbags1">
     <English>Checkpoint (Sandbags) #1</English>
+    <Spanish>Puesto de control (sacos terreros) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesSmall_CheckpointSandbags2">
     <English>Checkpoint (Sandbags) #2</English>
+    <Spanish>Puesto de control (sacos terreros) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesSmall_CheckpointBunkers1">
     <English>Checkpoint (Bunkers) #1</English>
+    <Spanish>Puesto de control (búnkeres) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesSmall_CheckpointBunkers2">
     <English>Checkpoint (Bunkers) #2</English>
+    <Spanish>Puesto de control (búnkeres) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesSmall_CheckpointTower">
     <English>Checkpoint (Tower)</English>
+    <Spanish>Puesto de control (torre)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesSmall_Checkpoint_BLU_T_F">
     <English>Checkpoint [BLU]</English>
+    <Spanish>Puesto de control [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesSmall_Checkpoint_OPF_T_F">
     <English>Checkpoint [OPF]</English>
+    <Spanish>Puesto de control [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesSmall_CheckpointConcretePost">
     <English>Checkpoint (Concrete Post)</English>
+    <Spanish>Puesto de control (poste de hormigón)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_CheckpointsBarricadesSmall_CheckpointSmallBunker">
     <English>Checkpoint (Small Bunker)</English>
+    <Spanish>Puesto de control (búnker pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortLarge_ArtilleryBattery">
     <English>Artillery Battery</English>
+    <Spanish>Batería de artillería</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortLarge_TankBunkers">
     <English>Tank Bunkers</English>
+    <Spanish>Búnkeres para carros</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortLarge_CircularBunkers">
     <English>Circular Bunkers</English>
+    <Spanish>Búnkeres circulares</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortLarge_WatchtowerLine">
     <English>Watchtower Line</English>
+    <Spanish>Línea de torres de vigilancia</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_ArtilleryBunker">
     <English>Artillery Bunker</English>
+    <Spanish>Búnker de artillería</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_TankPositionFortified">
     <English>Tank Position (Fortified)</English>
+    <Spanish>Posición de carros (fortificada)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLargeRazor">
     <English>Bunker Large (Razor)</English>
+    <Spanish>Búnker grande (concertina)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_TowerBunkerRazor">
     <English>Tower Bunker (Razor)</English>
+    <Spanish>Búnker torre (concertina)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerRazor">
     <English>Bunker (Razor)</English>
+    <Spanish>Búnker (concertina)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_MortarBunkerSandbags">
     <English>Mortar Bunker (Sandbags)</English>
+    <Spanish>Búnker de morteros (sacos terreros)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_MortarBunkerHBarrier">
     <English>Mortar Bunker (H-Barrier)</English>
+    <Spanish>Búnker de morteros (H-Barrier)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_MortarBunkerPit">
     <English>Mortar Bunker (Pit)</English>
+    <Spanish>Búnker de morteros (foso)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_WatchtowerRazor">
     <English>Watchtower (Razor)</English>
+    <Spanish>Torre de vigilancia (concertina)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_SandbagsRazor">
     <English>Sandbags (Razor)</English>
+    <Spanish>Sacos terreros (concertina)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge1_OPF_T_F">
     <English>Bunker Large [OPF] #1</English>
+    <Spanish>Búnker grande [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge2_OPF_T_F">
     <English>Bunker Large [OPF] #2</English>
+    <Spanish>Búnker grande [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge3_OPF_T_F">
     <English>Bunker Large [OPF] #3</English>
+    <Spanish>Búnker grande [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge4_OPF_T_F">
     <English>Bunker Large [OPF] #4</English>
+    <Spanish>Búnker grande [OPF] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_AAAPosition_OPF_T_F">
     <English>AAA Position [OPF]</English>
+    <Spanish>Posición de artillería antiaérea [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_ArtilleryPosition_OPF_T_F">
     <English>Artillery Position [OPF]</English>
+    <Spanish>Posición de artillería [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_TowerBunker1_OPF_T_F">
     <English>Tower Bunker [OPF] #1</English>
+    <Spanish>Búnker torre [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_TowerBunker2_OPF_T_F">
     <English>Tower Bunker [OPF] #2</English>
+    <Spanish>Búnker torre [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_TowerBunker3_OPF_T_F">
     <English>Tower Bunker [OPF] #3</English>
+    <Spanish>Búnker torre [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge1_BLU_T_F">
     <English>Bunker Large [BLU] #1</English>
+    <Spanish>Búnker grande [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge2_BLU_T_F">
     <English>Bunker Large [BLU] #2</English>
+    <Spanish>Búnker grande [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge3_BLU_T_F">
     <English>Bunker Large [BLU] #3</English>
+    <Spanish>Búnker grande [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge4_BLU_T_F">
     <English>Bunker Large [BLU] #4</English>
+    <Spanish>Búnker grande [BLU] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_AAAPosition_BLU_T_F">
     <English>AAA Position [BLU]</English>
+    <Spanish>Posición de artillería antiaérea [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_ArtilleryPosition_BLU_T_F">
     <English>Artillery Position [BLU]</English>
+    <Spanish>Posición de artillería [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_TowerBunker1_BLU_T_F">
     <English>Tower Bunker [BLU] #1</English>
+    <Spanish>Búnker torre [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_TowerBunker2_BLU_T_F">
     <English>Tower Bunker [BLU] #2</English>
+    <Spanish>Búnker torre [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_TowerBunker3_BLU_T_F">
     <English>Tower Bunker [BLU] #3</English>
+    <Spanish>Búnker torre [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_UndergroundBunker">
     <English>Underground Bunker</English>
+    <Spanish>Búnker subterráneo</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerConcrete">
     <English>Bunker (Concrete)</English>
+    <Spanish>Búnker (hormigón)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Bunkerx2">
     <English>Bunker (Dual)</English>
+    <Spanish>Búnker (doble)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Bunker1">
     <English>Bunker #1</English>
+    <Spanish>Búnker #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Bunker2">
     <English>Bunker #2</English>
+    <Spanish>Búnker #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Bunker3">
     <English>Bunker #3</English>
+    <Spanish>Búnker #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSandbags1">
     <English>Bunker (Sandbags) #1</English>
+    <Spanish>Búnker (sacos terreros) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSandbags2">
     <English>Bunker (Sandbags) #2</English>
+    <Spanish>Búnker (sacos terreros) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerHBarrier1">
     <English>Bunker (H-Barrier) #1</English>
+    <Spanish>Búnker (H-Barrier) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerHBarrier2">
     <English>Bunker (H-Barrier) #2</English>
+    <Spanish>Búnker (H-Barrier) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerHBarrier3">
     <English>Bunker (H-Barrier) #3</English>
+    <Spanish>Búnker (H-Barrier) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerHBarrier4">
     <English>Bunker (H-Barrier) #4</English>
+    <Spanish>Búnker (H-Barrier) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerHBarrier5">
     <English>Bunker (H-Barrier) #5</English>
+    <Spanish>Búnker (H-Barrier) #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_AANet_OPF_T_F">
     <English>Static AA Net [OPF]</English>
+    <Spanish>Antiaéreo estático con red [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSandbags_OPF_T_F">
     <English>Bunker (Sandbags) [OPF]</English>
+    <Spanish>Búnker (sacos terreros) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerHBarrierNet_OPF_T_F">
     <English>Bunker Net (H-Barrier) [OPF]</English>
+    <Spanish>Búnker con red (H-Barrier) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net1_OPF_T_F">
     <English>Net [OPF] #1</English>
+    <Spanish>Red de camuflaje [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net2_OPF_T_F">
     <English>Net [OPF] #2</English>
+    <Spanish>Red de camuflaje [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net3_OPF_T_F">
     <English>Net [OPF] #3</English>
+    <Spanish>Red de camuflaje [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net4_OPF_T_F">
     <English>Net [OPF] #4</English>
+    <Spanish>Red de camuflaje [OPF] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net5_OPF_T_F">
     <English>Net [OPF] #5</English>
+    <Spanish>Red de camuflaje [OPF] #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net6_OPF_T_F">
     <English>Net [OPF] #6</English>
+    <Spanish>Red de camuflaje [OPF] #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_AANet_BLU_T_F">
     <English>Static AA Net [BLU]</English>
+    <Spanish>Antiaéreo estático con red [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSandbags_BLU_T_F">
     <English>Bunker (Sandbags) [BLU]</English>
+    <Spanish>Búnker (sacos terreros) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerHBarrierNet_BLU_T_F">
     <English>Bunker Net (H-Barrier) [BLU]</English>
+    <Spanish>Búnker con red (H-Barrier) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net1_BLU_T_F">
     <English>Net [BLU] #1</English>
+    <Spanish>Red de camuflaje [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net2_BLU_T_F">
     <English>Net [BLU] #2</English>
+    <Spanish>Red de camuflaje [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net3_BLU_T_F">
     <English>Net [BLU] #3</English>
+    <Spanish>Red de camuflaje [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net4_BLU_T_F">
     <English>Net [BLU] #4</English>
+    <Spanish>Red de camuflaje [BLU] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net5_BLU_T_F">
     <English>Net [BLU] #5</English>
+    <Spanish>Red de camuflaje [BLU] #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Net6_BLU_T_F">
     <English>Net [BLU] #6</English>
+    <Spanish>Red de camuflaje [BLU] #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_TankPosition">
     <English>Tank Position</English>
+    <Spanish>Posición de carros</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSmall1">
     <English>Bunker (Small) #1</English>
+    <Spanish>Búnker (pequeño) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSmall2">
     <English>Bunker (Small) #2</English>
+    <Spanish>Búnker (pequeño) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSmall3">
     <English>Bunker (Small) #3</English>
+    <Spanish>Búnker (pequeño) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSmall4">
     <English>Bunker (Small) #4</English>
+    <Spanish>Búnker (pequeño) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSmall5">
     <English>Bunker (Small) #5</English>
+    <Spanish>Búnker (pequeño) #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSmall6">
     <English>Bunker (Small) #6</English>
+    <Spanish>Búnker (pequeño) #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSmall7">
     <English>Bunker (Small) #7</English>
+    <Spanish>Búnker (pequeño) #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSmall8">
     <English>Bunker (Small) #8</English>
+    <Spanish>Búnker (pequeño) #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerSmall9">
     <English>Bunker (Small) #9</English>
+    <Spanish>Búnker (pequeño) #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge1">
     <English>Bunker (Large) #1</English>
+    <Spanish>Búnker (grande) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge2">
     <English>Bunker (Large) #2</English>
+    <Spanish>Búnker (grande) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge3">
     <English>Bunker (Large) #3</English>
+    <Spanish>Búnker (grande) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge4">
     <English>Bunker (Large) #4</English>
+    <Spanish>Búnker (grande) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge5">
     <English>Bunker (Large) #5</English>
+    <Spanish>Búnker (grande) #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge6">
     <English>Bunker (Large) #6</English>
+    <Spanish>Búnker (grande) #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge7">
     <English>Bunker (Large) #7</English>
+    <Spanish>Búnker (grande) #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge8">
     <English>Bunker (Large) #8</English>
+    <Spanish>Búnker (grande) #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_BunkerLarge9">
     <English>Bunker (Large) #9</English>
+    <Spanish>Búnker (grande) #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_VehicleWatchtower">
     <English>Vehicle Watchtower</English>
+    <Spanish>Torre de vigilancia para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_VehicleCargoPost">
     <English>Vehicle Cargo Post</English>
+    <Spanish>Puesto de carga para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_VehicleLargeBunker">
     <English>Vehicle Bunker (Large)</English>
+    <Spanish>Búnker para vehículos (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_VehicleTower">
     <English>Vehicle Tower</English>
+    <Spanish>Torre para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_VehicleSmallBunker">
     <English>Vehicle Bunker (Small)</English>
+    <Spanish>Búnker para vehículos (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerHBar1">
     <English>Cargo Tower (HBar) #1</English>
+    <Spanish>Torre de carga (H-Barrier) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerHBar2">
     <English>Cargo Tower (HBar) #2</English>
+    <Spanish>Torre de carga (H-Barrier) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerHBar3">
     <English>Cargo Tower (HBar) #3</English>
+    <Spanish>Torre de carga (H-Barrier) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerHBar4">
     <English>Cargo Tower (HBar) #4</English>
+    <Spanish>Torre de carga (H-Barrier) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerHBar5">
     <English>Cargo Tower (HBar) #5</English>
+    <Spanish>Torre de carga (H-Barrier) #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerHBar6">
     <English>Cargo Tower (HBar) #6</English>
+    <Spanish>Torre de carga (H-Barrier) #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerHBar7">
     <English>Cargo Tower (HBar) #7</English>
+    <Spanish>Torre de carga (H-Barrier) #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerHBar8">
     <English>Cargo Tower (HBar) #8</English>
+    <Spanish>Torre de carga (H-Barrier) #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerHBar9">
     <English>Cargo Tower (HBar) #9</English>
+    <Spanish>Torre de carga (H-Barrier) #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerSandbag1">
     <English>Cargo Tower (Sandbag) #1</English>
+    <Spanish>Torre de carga (saco terrero) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerSandbag2">
     <English>Cargo Tower (Sandbag) #2</English>
+    <Spanish>Torre de carga (saco terrero) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerSandbag3">
     <English>Cargo Tower (Sandbag) #3</English>
+    <Spanish>Torre de carga (saco terrero) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerSandbag4">
     <English>Cargo Tower (Sandbag) #4</English>
+    <Spanish>Torre de carga (saco terrero) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerSandbag5">
     <English>Cargo Tower (Sandbag) #5</English>
+    <Spanish>Torre de carga (saco terrero) #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerSandbag6">
     <English>Cargo Tower (Sandbag) #6</English>
+    <Spanish>Torre de carga (saco terrero) #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerSandbag7">
     <English>Cargo Tower (Sandbag) #7</English>
+    <Spanish>Torre de carga (saco terrero) #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerSandbag8">
     <English>Cargo Tower (Sandbag) #8</English>
+    <Spanish>Torre de carga (saco terrero) #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortMedium_CargoTowerSandbag9">
     <English>Cargo Tower (Sandbag) #9</English>
+    <Spanish>Torre de carga (saco terrero) #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_CargoPost1">
     <English>Cargo Post #1</English>
+    <Spanish>Puesto de carga #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_CargoPost2">
     <English>Cargo Post #2</English>
+    <Spanish>Puesto de carga #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_CargoPost3">
     <English>Cargo Post #3</English>
+    <Spanish>Puesto de carga #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_CargoPost4">
     <English>Cargo Post #4</English>
+    <Spanish>Puesto de carga #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_CargoPost5">
     <English>Cargo Post #5</English>
+    <Spanish>Puesto de carga #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_CargoPost6">
     <English>Cargo Post #6</English>
+    <Spanish>Puesto de carga #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_CargoPost7">
     <English>Cargo Post #7</English>
+    <Spanish>Puesto de carga #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_CargoPost8">
     <English>Cargo Post #8</English>
+    <Spanish>Puesto de carga #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_CargoPost9">
     <English>Cargo Post #9</English>
+    <Spanish>Puesto de carga #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Watchtower1">
     <English>Watchtower #1</English>
+    <Spanish>Torre de vigilancia #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Watchtower2">
     <English>Watchtower #2</English>
+    <Spanish>Torre de vigilancia #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Watchtower3">
     <English>Watchtower #3</English>
+    <Spanish>Torre de vigilancia #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Watchtower4">
     <English>Watchtower #4</English>
+    <Spanish>Torre de vigilancia #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Watchtower5">
     <English>Watchtower #5</English>
+    <Spanish>Torre de vigilancia #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Watchtower6">
     <English>Watchtower #6</English>
+    <Spanish>Torre de vigilancia #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Watchtower7">
     <English>Watchtower #7</English>
+    <Spanish>Torre de vigilancia #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Watchtower8">
     <English>Watchtower #8</English>
+    <Spanish>Torre de vigilancia #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_Watchtower9">
     <English>Watchtower #9</English>
+    <Spanish>Torre de vigilancia #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerTower1">
     <English>Bunker (Tower) #1</English>
+    <Spanish>Búnker (torre) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerTower2">
     <English>Bunker (Tower) #2</English>
+    <Spanish>Búnker (torre) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerTower3">
     <English>Bunker (Tower) #3</English>
+    <Spanish>Búnker (torre) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerTower4">
     <English>Bunker (Tower) #4</English>
+    <Spanish>Búnker (torre) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerTower5">
     <English>Bunker (Tower) #5</English>
+    <Spanish>Búnker (torre) #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerTower6">
     <English>Bunker (Tower) #6</English>
+    <Spanish>Búnker (torre) #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerTower7">
     <English>Bunker (Tower) #7</English>
+    <Spanish>Búnker (torre) #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerTower8">
     <English>Bunker (Tower) #8</English>
+    <Spanish>Búnker (torre) #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_MilitaryPacific_FortSmall_BunkerTower9">
     <English>Bunker (Tower) #9</English>
+    <Spanish>Búnker (torre) #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_ConstructionSuppliesLarge_MilitaryItems">
     <English>Military Items</English>
+    <Spanish>Objetos militares</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_ConstructionSuppliesLarge_MilitaryFortifications">
     <English>Military Fortifications</English>
+    <Spanish>Fortificaciones militares</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_ConstructionSuppliesLarge_Sandbags">
     <English>Sandbags</English>
+    <Spanish>Sacos terreros</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_ConstructionSuppliesLarge_CargoBrown">
     <English>Cargo Houses (Brown)</English>
+    <Spanish>Casas de carga (marrónes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_ConstructionSuppliesLarge_CargoGreen">
     <English>Cargo Houses (Green)</English>
+    <Spanish>Casas de carga (verdes)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_ConstructionSuppliesLarge_CargoRusty">
     <English>Cargo Houses (Rusty)</English>
+    <Spanish>Casas de carga (oxidadas)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_ConstructionSuppliesLarge_FillerBoxSmall">
     <English>Filler - Boxes (Small)</English>
+    <Spanish>Relleno - cajas (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_ConstructionSuppliesLarge_FillerBox1">
     <English>Filler - Boxes #1</English>
+    <Spanish>Relleno - cajas #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_ConstructionSuppliesLarge_FillerBox2">
     <English>Filler - Boxes #2</English>
+    <Spanish>Relleno - cajas #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsMedium_RadarDome_OPF_F">
     <English>Radar Dome [OPF]</English>
+    <Spanish>Radomo [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsMedium_CommPost_OPF_F">
     <English>Comms Post [OPF]</English>
+    <Spanish>Puesto de comunicaciones [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsMedium_TransTower_OPF_F">
     <English>Tall Transmitter Tower [OPF]</English>
+    <Spanish>Torre de transmisión alta [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsMedium_RadarDome_BLU_F">
     <English>Radar Dome [BLU]</English>
+    <Spanish>Radomo [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsMedium_CommPost_BLU_F">
     <English>Comms Post [BLU]</English>
+    <Spanish>Puesto de comunicaciones [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsMedium_TransTower_BLU_F">
     <English>Tall Transmitter Tower [BLU]</English>
+    <Spanish>Torre de transmisión alta [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsMedium_RadarDome_IND_F">
     <English>Radar Dome [IND]</English>
+    <Spanish>Radomo [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsMedium_CommPost_IND_F">
     <English>Comms Post [IND]</English>
+    <Spanish>Puesto de comunicaciones [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsMedium_TransTower_IND_F">
     <English>Tall Transmitter Tower [IND]</English>
+    <Spanish>Torre de transmisión alta [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsSmall_RadarDome">
     <English>Radar Dome</English>
+    <Spanish>Radomo</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsSmall_RadioShed">
     <English>Radio Shed</English>
+    <Spanish>Cobertizo de radio</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsSmall_RadioPostCargoBrown">
     <English>Radio Post (Cargo Brown)</English>
+    <Spanish>Puesto de radio (carga marrón)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsSmall_RadioPostCargoGreen">
     <English>Radio Post (Cargo Green)</English>
+    <Spanish>Puesto de radio (carga verde)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsSmall_RadioTowerTemp">
     <English>Radio Tower (Temp)</English>
+    <Spanish>Torre de radio (temporal)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsSmall_OpsControl1_OPF_F">
     <English>Ops Control [OPF] #1</English>
+    <Spanish>Control de operaciones [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsSmall_OpsControl2_OPF_F">
     <English>Ops Control [OPF] #2</English>
+    <Spanish>Control de operaciones [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsSmall_OpsControl1_BLU_F">
     <English>Ops Control [BLU] #1</English>
+    <Spanish>Control de operaciones [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsSmall_OpsControl2_BLU_F">
     <English>Ops Control [BLU] #2</English>
+    <Spanish>Control de operaciones [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsSmall_OpsControl1_IND_F">
     <English>Ops Control [IND] #1</English>
+    <Spanish>Control de operaciones [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CommunicationsSmall_OpsControl2_IND_F">
     <English>Ops Control [IND] #2</English>
+    <Spanish>Control de operaciones [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_MedicalComplex">
     <English>Medical Complex</English>
+    <Spanish>Complejo sanitario</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_AirAmbulance_BLU_F">
 	<English>Air Ambulance [BLU]</English>
+	<Spanish>Ambulancia aérea [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_MedicalLab_BLU_F">
 	<English>Medical Laboratory [BLU]</English>
+	<Spanish>Laboratorio médico [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_Hospital_BLU_F">
 	<English>Hospital [BLU]</English>
+	<Spanish>Hospital [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_EvacHospital_BLU_F">
 	<English>Evacuation Hospital [BLU]</English>
+	<Spanish>Hospital de evacuación [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_AirAmbulance_OPF_F">
 	<English>Air Ambulance [OPF]</English>
+	<Spanish>Ambulancia aérea [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_MedicalLab_OPF_F">
 	<English>Medical Laboratory [OPF]</English>
+	<Spanish>Laboratorio médico [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_Hospital_OPF_F">
 	<English>Hospital [OPF]</English>
+	<Spanish>Hospital [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_EvacHospital_OPF_F">
 	<English>Evacuation Hospital [OPF]</English>
+	<Spanish>Hospital de evacuación [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_AirAmbulance_IND_F">
 	<English>Air Ambulance [IND]</English>
+	<Spanish>Ambulancia aérea [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_MedicalLab_IND_F">
 	<English>Medical Laboratory [IND]</English>
+	<Spanish>Laboratorio médico [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_Hospital_IND_F">
 	<English>Hospital [IND]</English>
+	<Spanish>Hospital [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalLarge_EvacHospital_IND_F">
 	<English>Evacuation Hospital [IND]</English>
+	<Spanish>Hospital de evacuación [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalMedium_MedicalCompound">
     <English>Medical Compound</English>
+    <Spanish>Recinto sanitario</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalMedium_FieldHospital_BLU_F">
 	<English>Field Hospital [BLU]</English>
+	<Spanish>Hospital de campaña [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalMedium_AirStationHospital_BLU_F">
 	<English>Air Station Hospital [BLU]</English>
+	<Spanish>Hospital de base aérea [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalMedium_Surgery_BLU_F">
 	<English>Surgery [BLU]</English>
+	<Spanish>Quirófano [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalMedium_FieldHospital_OPF_F">
 	<English>Field Hospital [OPF]</English>
+	<Spanish>Hospital de campaña [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalMedium_AirStationHospital_OPF_F">
 	<English>Air Station Hospital [OPF]</English>
+	<Spanish>Hospital de base aérea [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalMedium_Surgery_OPF_F">
 	<English>Surgery [OPF]</English>
+	<Spanish>Quirófano [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalMedium_FieldHospital_IND_F">
 	<English>Field Hospital [IND]</English>
+	<Spanish>Hospital de campaña [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalMedium_AirStationHospital_IND_F">
 	<English>Air Station Hospital [IND]</English>
+	<Spanish>Hospital de base aérea [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalMedium_Surgery_IND_F">
 	<English>Surgery [IND]</English>
+	<Spanish>Quirófano [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_MedicalCentre">
     <English>Medical Centre</English>
+    <Spanish>Centro sanitario</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_UrbanSurgery_BLU_F">
 	<English>Urban Surgery [BLU]</English>
+	<Spanish>Quirófano urbano [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_FieldHospital_BLU_F">
 	<English>Field Hospital [BLU]</English>
+	<Spanish>Hospital de campaña [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_CollectionStation_BLU_F">
 	<English>Collection Station [BLU]</English>
+	<Spanish>Estación de recogida [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_Surgery1_BLU_F">
 	<English>Surgery [BLU] #1</English>
+	<Spanish>Quirófano [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_Surgery2_BLU_F">
 	<English>Surgery [BLU] #2</English>
+	<Spanish>Quirófano [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_UrbanSurgery_OPF_F">
 	<English>Urban Surgery [OPF]</English>
+	<Spanish>Quirófano urbano [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_FieldHospital_OPF_F">
 	<English>Field Hospital [OPF]</English>
+	<Spanish>Hospital de campaña [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_CollectionStation_OPF_F">
 	<English>Collection Station [OPF]</English>
+	<Spanish>Estación de recogida [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_Surgery1_OPF_F">
 	<English>Surgery [OPF] #1</English>
+	<Spanish>Quirófano [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_Surgery2_OPF_F">
 	<English>Surgery [OPF] #2</English>
+	<Spanish>Quirófano [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_UrbanSurgery_IND_F">
 	<English>Urban Surgery [IND]</English>
+	<Spanish>Quirófano urbano [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_FieldHospital_IND_F">
 	<English>Field Hospital [IND]</English>
+	<Spanish>Hospital de campaña [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_CollectionStation_IND_F">
 	<English>Collection Station [IND]</English>
+	<Spanish>Estación de recogida [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_Surgery1_IND_F">
 	<English>Surgery [IND] #1</English>
+	<Spanish>Quirófano [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_MedicalSmall_Surgery2_IND_F">
 	<English>Surgery [IND] #2</English>
+	<Spanish>Quirófano [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesLarge_CheckpointWatchtower">
     <English>Checkpoint Watchtower</English>
+    <Spanish>Puesto de control con torre de vigilancia</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesLarge_CheckpointBunker">
     <English>Checkpoint Bunker</English>
+    <Spanish>Puesto de control con búnker</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesLarge_CheckpointHBarrier">
     <English>Checkpoint H-Barrier</English>
+    <Spanish>Puesto de control de H-Barrier</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesLarge_Checkpoint_BLU_F">
     <English>Checkpoint [BLU]</English>
+    <Spanish>Puesto de control [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesLarge_Checkpoint_OPF_F">
     <English>Checkpoint [OPF]</English>
+    <Spanish>Puesto de control [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesLarge_Checkpoint_IND_F">
     <English>Checkpoint [IND]</English>
+    <Spanish>Puesto de control [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesMedium_CheckpointConcrete">
     <English>Checkpoint Concrete</English>
+    <Spanish>Puesto de control de hormigón</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesMedium_CheckpointTowers">
     <English>Checkpoint Towers</English>
+    <Spanish>Puesto de control con torres</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesMedium_CheckpointBunker">
     <English>Checkpoint Bunker</English>
+    <Spanish>Puesto de control con búnker</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesMedium_CheckpointWatchtower">
     <English>Checkpoint Watchtower</English>
+    <Spanish>Puesto de control con torre de vigilancia</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesMedium_Checkpoint_BLU_F">
     <English>Checkpoint [BLU]</English>
+    <Spanish>Puesto de control [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesMedium_Checkpoint_OPF_F">
     <English>Checkpoint [OPF]</English>
+    <Spanish>Puesto de control [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesMedium_Checkpoint_IND_F">
     <English>Checkpoint [IND]</English>
+    <Spanish>Puesto de control [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesMedium_CheckpointCargoPosts">
     <English>Checkpoint Cargo Posts</English>
+    <Spanish>Puesto de control con puestos de carga</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesSmall_CheckpointSandbags1">
     <English>Checkpoint Sandbags #1</English>
+    <Spanish>Puesto de control con sacos terreros #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesSmall_CheckpointSandbags2">
     <English>Checkpoint Sandbags #2</English>
+    <Spanish>Puesto de control con sacos terreros #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesSmall_CheckpointTower">
     <English>Checkpoint Tower</English>
+    <Spanish>Puesto de control con torre</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesSmall_CheckpointBunkers">
     <English>Checkpoint Bunkers</English>
+    <Spanish>Puesto de control con búnkeres</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesSmall_CheckpointHBarrier">
     <English>Checkpoint H-Barrier</English>
+    <Spanish>Puesto de control de H-Barrier</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesSmall_Checkpoint_BLU_F">
     <English>Checkpoint [BLU]</English>
+    <Spanish>Puesto de control [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesSmall_Checkpoint_OPF_F">
     <English>Checkpoint [OPF]</English>
+    <Spanish>Puesto de control [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesSmall_CheckpointConcretePost">
     <English>Checkpoint Concrete Post</English>
+    <Spanish>Puesto de control con poste de hormigón</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CheckpointsBarricadesSmall_CheckpointSmallBunker">
     <English>Checkpoint Bunker (Small)</English>
+    <Spanish>Puesto de control con búnker (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite1_OPF_F">
     <English>Camp Site [OPF] #1</English>
+    <Spanish>Campamento [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite2_OPF_F">
     <English>Camp Site [OPF] #2</English>
+    <Spanish>Campamento [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite3_OPF_F">
     <English>Camp Site [OPF] #3</English>
+    <Spanish>Campamento [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite4_OPF_F">
     <English>Camp Site [OPF] #4</English>
+    <Spanish>Campamento [OPF] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite5_OPF_F">
     <English>Camp Site [OPF] #5</English>
+    <Spanish>Campamento [OPF] #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSiteHMG1_OPF_F">
     <English>Camp Site (HMG) [OPF] #1</English>
+    <Spanish>Campamento (HMG) [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSiteHMG2_OPF_F">
     <English>Camp Site (HMG) [OPF] #2</English>
+    <Spanish>Campamento (HMG) [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_MortarSite_OPF_F">
     <English>Mortar Site [OPF]</English>
+    <Spanish>Posición de morteros [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampCargoPost_OPF_F">
     <English>Cargo Post [OPF]</English>
+    <Spanish>Puesto de carga [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite1_BLU_F">
     <English>Camp Site [BLU] #1</English>
+    <Spanish>Campamento [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite2_BLU_F">
     <English>Camp Site [BLU] #2</English>
+    <Spanish>Campamento [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite3_BLU_F">
     <English>Camp Site [BLU] #3</English>
+    <Spanish>Campamento [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite4_BLU_F">
     <English>Camp Site [BLU] #4</English>
+    <Spanish>Campamento [BLU] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite5_BLU_F">
     <English>Camp Site [BLU] #5</English>
+    <Spanish>Campamento [BLU] #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite6_BLU_F">
     <English>Camp Site [BLU] #6</English>
+    <Spanish>Campamento [BLU] #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite7_BLU_F">
     <English>Camp Site [BLU] #7</English>
+    <Spanish>Campamento [BLU] #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSiteHMG1_BLU_F">
     <English>Camp Site (HMG) [BLU] #1</English>
+    <Spanish>Campamento (HMG) [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSiteHMG2_BLU_F">
     <English>Camp Site (HMG) [BLU] #2</English>
+    <Spanish>Campamento (HMG) [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_MortarSite_BLU_F">
     <English>Mortar Site [BLU]</English>
+    <Spanish>Posición de morteros [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampCargoPost_BLU_F">
     <English>Cargo Post [BLU]</English>
+    <Spanish>Puesto de carga [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite1_IND_F">
     <English>Camp Site [IND] #1</English>
+    <Spanish>Campamento [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite2_IND_F">
     <English>Camp Site [IND] #2</English>
+    <Spanish>Campamento [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite3_IND_F">
     <English>Camp Site [IND] #3</English>
+    <Spanish>Campamento [IND] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite4_IND_F">
     <English>Camp Site [IND] #4</English>
+    <Spanish>Campamento [IND] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSite5_IND_F">
     <English>Camp Site [IND] #5</English>
+    <Spanish>Campamento [IND] #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSiteHMG1_IND_F">
     <English>Camp Site (HMG) [IND] #1</English>
+    <Spanish>Campamento (HMG) [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampSiteHMG2_IND_F">
     <English>Camp Site (HMG) [IND] #2</English>
+    <Spanish>Campamento (HMG) [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_MortarSite_IND_F">
     <English>Mortar Site [IND]</English>
+    <Spanish>Posición de morteros [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_CampsSmall_CampCargoPost_IND_F">
     <English>Cargo Post [IND]</English>
+    <Spanish>Puesto de carga [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HangarConverted_BLU_F">
     <English>Hangar (Converted) [BLU]</English>
+    <Spanish>Hangar (reconvertido) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HangarConverted_OPF_F">
     <English>Hangar (Converted) [OPF]</English>
+    <Spanish>Hangar (reconvertido) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HangarConverted_IND_F">
     <English>Hangar (Converted) [IND]</English>
+    <Spanish>Hangar (reconvertido) [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_MilitaryLabs">
     <English>Military Labs</English>
+    <Spanish>Laboratorios militares</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_MilitaryOffice1">
     <English>Military Office #1</English>
+    <Spanish>Oficina militar #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_MilitaryOffice2">
     <English>Military Office #2</English>
+    <Spanish>Oficina militar #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_MilitaryQuarters">
     <English>Military Quarters</English>
+    <Spanish>Alojamientos militares</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_ResearchOutpost">
     <English>Research Outpost</English>
+    <Spanish>Puesto avanzado de investigación</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_ServiceDepot_BLU_F">
     <English>Service Depot [BLU]</English>
+    <Spanish>Depósito de servicio [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_ServiceDepot_OPF_F">
     <English>Service Depot [OPF]</English>
+    <Spanish>Depósito de servicio [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_ServiceDepot_IND_F">
     <English>Service Depot [IND]</English>
+    <Spanish>Depósito de servicio [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_BarracksCamo">
     <English>Barracks Camo</English>
+    <Spanish>Barracones camuflados</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_BarracksWhite">
     <English>Barracks White</English>
+    <Spanish>Barracones blancos</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_ResearchComplex">
     <English>Research Complex</English>
+    <Spanish>Complejo de investigación</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsLarge_DetentionCentrePrison">
     <English>Detention Centre (Prison)</English>
+    <Spanish>Centro de detención (prisión)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_DetentionCompound">
     <English>Detention Compound (Prison)</English>
+    <Spanish>Recinto de detención (prisión)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_DomeResearch">
     <English>Dome - Research</English>
+    <Spanish>Cúpula - investigación</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_DomeWorkshop">
     <English>Dome - Workshop</English>
+    <Spanish>Cúpula - taller</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_VehicleYard_BLU_F">
     <English>Vehicle Yard [BLU]</English>
+    <Spanish>Patio de vehículos [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_VehicleYard_OPF_F">
     <English>Vehicle Yard [OPF]</English>
+    <Spanish>Patio de vehículos [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_VehicleYard_IND_F">
     <English>Vehicle Yard [IND]</English>
+    <Spanish>Patio de vehículos [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_WaterTower_BLU_F">
     <English>Water Tower [BLU]</English>
+    <Spanish>Torre de agua [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_WaterTower_OPF_F">
     <English>Water Tower [OPF]</English>
+    <Spanish>Torre de agua [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_WaterTower_IND_F">
     <English>Water Tower [IND]</English>
+    <Spanish>Torre de agua [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_CargoPosts_BLU_F">
     <English>Cargo Posts [BLU]</English>
+    <Spanish>Puestos de carga [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_CargoPosts_OPF_F">
     <English>Cargo Posts [OPF]</English>
+    <Spanish>Puestos de carga [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_CargoPosts_IND_F">
     <English>Cargo Posts [IND]</English>
+    <Spanish>Puestos de carga [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_FieldSupport_BLU_F">
     <English>Field Support [BLU]</English>
+    <Spanish>Apoyo de campaña [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_FieldSupport_OPF_F">
     <English>Field Support [OPF]</English>
+    <Spanish>Apoyo de campaña [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_FieldSupport_IND_F">
     <English>Field Support [IND]</English>
+    <Spanish>Apoyo de campaña [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsMedium_ResearchCompound">
     <English>Research Compound</English>
+    <Spanish>Recinto de investigación</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_DetentionCamp">
     <English>Detention Camp (Prison)</English>
+    <Spanish>Campo de detención (prisión)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Canteen1">
     <English>Canteen #1</English>
+    <Spanish>Comedor #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Canteen2">
     <English>Canteen #2</English>
+    <Spanish>Comedor #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_BriefingAreaHBarrier">
     <English>Briefing Area (H-Barrier)</English>
+    <Spanish>Zona de briefing (H-Barrier)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_BriefingArea">
     <English>Briefing Area</English>
+    <Spanish>Zona de briefing</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_CargoPostBrown">
     <English>Cargo Post (Brown)</English>
+    <Spanish>Puesto de carga (marrón)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_CargoPostGreen">
     <English>Cargo Post (Green)</English>
+    <Spanish>Puesto de carga (verde)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Toilets_BLU_F">
     <English>Toilets [BLU]</English>
+    <Spanish>Aseos [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Toilets_OPF_F">
     <English>Toilets [OPF]</English>
+    <Spanish>Aseos [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Toilets_IND_F">
     <English>Toilets [IND]</English>
+    <Spanish>Aseos [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_ServiceStation_BLU_F">
     <English>Service Station [BLU]</English>
+    <Spanish>Estación de servicio [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_ServiceStation_OPF_F">
     <English>Service Station [OPF]</English>
+    <Spanish>Estación de servicio [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_ServiceStation_IND_F">
     <English>Service Station [IND]</English>
+    <Spanish>Estación de servicio [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Workshop_BLU_F">
     <English>Workshop [BLU]</English>
+    <Spanish>Taller [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Workshop_OPF_F">
     <English>Workshop [OPF]</English>
+    <Spanish>Taller [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Workshop_IND_F">
     <English>Workshop [IND]</English>
+    <Spanish>Taller [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_LivingQuarters_BLU_F">
     <English>Living Quarters [BLU]</English>
+    <Spanish>Alojamientos [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_LivingQuarters_OPF_F">
     <English>Living Quarters [OPF]</English>
+    <Spanish>Alojamientos [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_LivingQuarters_IND_F">
     <English>Living Quarters [IND]</English>
+    <Spanish>Alojamientos [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Canteen1_BLU_F">
     <English>Canteen [BLU] #1</English>
+    <Spanish>Comedor [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Canteen1_OPF_F">
     <English>Canteen [OPF] #1</English>
+    <Spanish>Comedor [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Canteen1_IND_F">
     <English>Canteen [IND] #1</English>
+    <Spanish>Comedor [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_Canteen2_OPF_F">
     <English>Canteen [OPF] #2</English>
+    <Spanish>Comedor [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_CargoFortifiedGreen">
     <English>Cargo Fortified (Green)</English>
+    <Spanish>Carga fortificada (verde)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_CargoFortifiedBrown">
     <English>Cargo Fortified (Brown)</English>
+    <Spanish>Carga fortificada (marrón)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SupportsSmall_ResearchCentre">
     <English>Research Centre</English>
+    <Spanish>Centro de investigación</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_ForwardBase_BLU_F">
     <English>Forward Base [BLU]</English>
+    <Spanish>Base avanzada [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_ForwardBase_OPF_F">
     <English>Forward Base [OPF]</English>
+    <Spanish>Base avanzada [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_CommandOutpost">
     <English>Command Outpost</English>
+    <Spanish>Puesto avanzado de mando</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_ObservationTowerGreen">
     <English>Observation Tower (Green)</English>
+    <Spanish>Torre de observación (verde)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_ObservationTowerBrown">
     <English>Observation Tower (Brown)</English>
+    <Spanish>Torre de observación (marrón)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_CargoHQ1_IND_F">
     <English>Cargo HQ [IND] #1</English>
+    <Spanish>HQ de carga [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_CargoHQ2_IND_F">
     <English>Cargo HQ [IND] #2</English>
+    <Spanish>HQ de carga [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_CargoTower_IND_F">
     <English>Cargo Tower [IND]</English>
+    <Spanish>Torre de carga [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_FieldDepot_IND_F">
     <English>Field Depot [IND]</English>
+    <Spanish>Depósito de campaña [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_FieldHQ_IND_F">
     <English>Field HQ [IND]</English>
+    <Spanish>HQ de campaña [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_CargoHQ1_BLU_F">
     <English>Cargo HQ [BLU] #1</English>
+    <Spanish>HQ de carga [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_CargoHQ2_BLU_F">
     <English>Cargo HQ [BLU] #2</English>
+    <Spanish>HQ de carga [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_CargoTower_BLU_F">
     <English>Cargo Tower [BLU]</English>
+    <Spanish>Torre de carga [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_FieldDepot_BLU_F">
     <English>Field Depot [BLU]</English>
+    <Spanish>Depósito de campaña [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_FieldHQ_BLU_F">
     <English>Field HQ [BLU]</English>
+    <Spanish>HQ de campaña [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_CargoHQ1_OPF_F">
     <English>Cargo HQ [OPF] #1</English>
+    <Spanish>HQ de carga [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_CargoHQ2_OPF_F">
     <English>Cargo HQ [OPF] #2</English>
+    <Spanish>HQ de carga [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_CargoTower_OPF_F">
     <English>Cargo Tower [OPF]</English>
+    <Spanish>Torre de carga [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_FieldDepot_OPF_F">
     <English>Field Depot [OPF]</English>
+    <Spanish>Depósito de campaña [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQLarge_FieldHQ_OPF_F">
     <English>Field HQ [OPF]</English>
+    <Spanish>HQ de campaña [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQMedium_FieldHQ_BLU_F">
     <English>Field HQ [BLU]</English>
+    <Spanish>HQ de campaña [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQMedium_FieldHQ_OPF_F">
     <English>Field HQ [OPF]</English>
+    <Spanish>HQ de campaña [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQMedium_FieldHQ_IND_F">
     <English>Field HQ [IND]</English>
+    <Spanish>HQ de campaña [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQSmall_ForwardOP">
     <English>Forward OP Bunker OP</English>
+    <Spanish>Puesto de observación avanzado en búnker</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQSmall_FieldReconPost_BLU_F">
     <English>Field Recon Post [BLU]</English>
+    <Spanish>Puesto de reconocimiento de campaña [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQSmall_FieldReconPost_OPF_F">
     <English>Field Recon Post [OPF]</English>
+    <Spanish>Puesto de reconocimiento de campaña [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FieldHQSmall_FieldReconPost_IND_F">
     <English>Field Recon Post [IND]</English>
+    <Spanish>Puesto de reconocimiento de campaña [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesMedium_StorageShed">
     <English>StorageShed</English>
+    <Spanish>Cobertizo de almacenamiento</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesMedium_StoreYardDevice">
     <English>Store Yard (Device)</English>
+    <Spanish>Patio de almacén (dispositivo)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesMedium_StorageShed_BLU_F">
     <English>Storage Shed [BLU]</English>
+    <Spanish>Cobertizo de almacenamiento [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesMedium_StorageShed_OPF_F">
     <English>Storage Shed [OPF]</English>
+    <Spanish>Cobertizo de almacenamiento [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesMedium_StorageShed_IND_F">
     <English>Storage Shed [IND]</English>
+    <Spanish>Cobertizo de almacenamiento [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesMedium_StorageNets_BLU_F">
     <English>Storage Nets [BLU]</English>
+    <Spanish>Redes de almacenamiento [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesMedium_StorageNets_OPF_F">
     <English>Storage Nets [OPF]</English>
+    <Spanish>Redes de almacenamiento [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesMedium_StorageNets_IND_F">
     <English>Storage Nets [IND]</English>
+    <Spanish>Redes de almacenamiento [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_CargoCacheBrown">
     <English>Cargo Cache - Brown</English>
+    <Spanish>Alijo de carga - marrón</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_CargoCacheTower">
     <English>Cargo Cache - Tower</English>
+    <Spanish>Alijo de carga - torre</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_CacheAmmoBoxes_OPF_F">
     <English>Ammo Boxes [OPF]</English>
+    <Spanish>Cajas de munición [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_Storage1_OPF_F">
     <English>Storage [OPF] #1</English>
+    <Spanish>Almacenamiento [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_Storage2_OPF_F">
     <English>Storage [OPF] #2</English>
+    <Spanish>Almacenamiento [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_Storage3_OPF_F">
     <English>Storage [OPF] #3</English>
+    <Spanish>Almacenamiento [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageHBarrier1_OPF_F">
     <English>H-Barrier Supplies [OPF] #1</English>
+    <Spanish>Suministros tras H-Barrier [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageHBarrier2_OPF_F">
     <English>H-Barrier Supplies [OPF] #2</English>
+    <Spanish>Suministros tras H-Barrier [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageLamp_OPF_F">
     <English>Storage (Lamp) [OPF]</English>
+    <Spanish>Almacenamiento (farola) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageSandbags1_OPF_F">
     <English>Sandbags [OPF] #1</English>
+    <Spanish>Sacos terreros [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageSandbags2_OPF_F">
     <English>Sandbags [OPF] #2</English>
+    <Spanish>Sacos terreros [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageFortified_OPF_F">
     <English>Fortified Supplies [OPF]</English>
+    <Spanish>Suministros fortificados [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_CacheAmmoBoxes_BLU_F">
     <English>Cache Ammo [BLU]</English>
+    <Spanish>Alijo de munición [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_Storage1_BLU_F">
     <English>Storage [BLU] #1</English>
+    <Spanish>Almacenamiento [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_Storage2_BLU_F">
     <English>Storage [BLU] #2</English>
+    <Spanish>Almacenamiento [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_Storage3_BLU_F">
     <English>Storage [BLU] #3</English>
+    <Spanish>Almacenamiento [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageHBarrier2_BLU_F">
     <English>H-Barrier Supplies [BLU] #2</English>
+    <Spanish>Suministros tras H-Barrier [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageHBarrier3_BLU_F">
     <English>H-Barrier Supplies [BLU] #3</English>
+    <Spanish>Suministros tras H-Barrier [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageLamp_BLU_F">
     <English>Storage (Lamp) [BLU]</English>
+    <Spanish>Almacenamiento (farola) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageSandbags1_BLU_F">
     <English>Sandbags [BLU] #1</English>
+    <Spanish>Sacos terreros [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageSandbags2_BLU_F">
     <English>Sandbags [BLU] #2</English>
+    <Spanish>Sacos terreros [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageFortified_BLU_F">
     <English>Fortified Supplies [BLU]</English>
+    <Spanish>Suministros fortificados [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_Storage1_IND_F">
     <English>Storage [IND] #1</English>
+    <Spanish>Almacenamiento [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_Storage2_IND_F">
     <English>Storage [IND] #2</English>
+    <Spanish>Almacenamiento [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_Storage3_IND_F">
     <English>Storage [IND] #3</English>
+    <Spanish>Almacenamiento [IND] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageHBarrier1_IND_F">
     <English>H-Barrier Supplies [IND] #1</English>
+    <Spanish>Suministros tras H-Barrier [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageHBarrier2_IND_F">
     <English>H-Barrier Supplies [IND] #2</English>
+    <Spanish>Suministros tras H-Barrier [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageLamp_IND_F">
     <English>Storage (Lamp) [IND]</English>
+    <Spanish>Almacenamiento (farola) [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageSandbags1_IND_F">
     <English>Sandbags [IND] #1</English>
+    <Spanish>Sacos terreros [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageSandbags2_IND_F">
     <English>Sandbags [IND] #2</English>
+    <Spanish>Sacos terreros [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_StorageFortified_IND_F">
     <English>Fortified Supplies [IND]</English>
+    <Spanish>Suministros fortificados [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_FencedCache">
     <English>Fenced Cache</English>
+    <Spanish>Alijo vallado</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_FencedCache_BLU_F">
     <English>Fenced Cache [BLU]</English>
+    <Spanish>Alijo vallado [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_FencedCache_OPF_F">
     <English>Fenced Cache [OPF]</English>
+    <Spanish>Alijo vallado [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_SuppliesSmall_FencedCache_IND_F">
     <English>Fenced Cache [IND]</English>
+    <Spanish>Alijo vallado [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQLarge_Headquarters">
     <English>Headquarters</English>
+    <Spanish>Cuartel general</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQLarge_HeadquartersFortified">
     <English>Headquarters (Fortified)</English>
+    <Spanish>Cuartel general (fortificado)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQLarge_VIPCompound">
     <English>VIP Compound</English>
+    <Spanish>Recinto para VIP</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQLarge_Headquarters_OPF_F">
     <English>Main Headquarters [OPF]</English>
+    <Spanish>Cuartel general principal [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQLarge_Headquarters_BLU_F">
     <English>Main Headquarters [BLU]</English>
+    <Spanish>Cuartel general principal [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQLarge_MilitaryCompound">
     <English>Military Compound</English>
+    <Spanish>Recinto militar</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQLarge_CommandCentre">
     <English>Command Centre</English>
+    <Spanish>Centro de mando</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQMedium_OfficersHQ">
     <English>Officers HQ</English>
+    <Spanish>HQ de oficiales</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQMedium_Headquarters_BLU_F">
     <English>Headquarters [BLU]</English>
+    <Spanish>Cuartel general [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQMedium_Headquarters_OPF_F">
     <English>Headquarters [OPF]</English>
+    <Spanish>Cuartel general [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQMedium_Headquarters_IND_F">
     <English>Headquarters [IND]</English>
+    <Spanish>Cuartel general [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQMedium_OfficersHQ_BLU_F">
     <English>Officers HQ [BLU]</English>
+    <Spanish>HQ de oficiales [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQMedium_OfficersHQ_OPF_F">
     <English>Officers HQ [OPF]</English>
+    <Spanish>HQ de oficiales [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HQMedium_OfficersHQ_IND_F">
     <English>Officers HQ [IND]</English>
+    <Spanish>HQ de oficiales [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_TemporaryLZ">
     <English>Temporary LZ</English>
+    <Spanish>LZ temporal</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_HeliportHBarrier1">
     <English>H-Barrier LZ #1</English>
+    <Spanish>LZ de H-Barrier #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_HeliportHBarrier2">
     <English>H-Barrier LZ #2</English>
+    <Spanish>LZ de H-Barrier #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_ConcreteWallLZ">
     <English>Concrete Wall LZ</English>
+    <Spanish>LZ con muro de hormigón</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_HeliportTemporary_BLU_F">
     <English>Heliport - Temporary [BLU]</English>
+    <Spanish>Helipuerto - temporal [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_Heliport_BLU_F">
     <English>Heliport [BLU]</English>
+    <Spanish>Helipuerto [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_HeliportFortified_BLU_F">
     <English>Heliport - Fortified [BLU]</English>
+    <Spanish>Helipuerto - fortificado [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_HeliportTemporary_OPF_F">
     <English>Heliport - Temporary [OPF]</English>
+    <Spanish>Helipuerto - temporal [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_Heliport_OPF_F">
     <English>Heliport [OPF]</English>
+    <Spanish>Helipuerto [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_HeliportFortified_OPF_F">
     <English>Heliport - Fortified [OPF]</English>
+    <Spanish>Helipuerto - fortificado [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_HeliportTemporary_IND_F">
     <English>Heliport - Temporary [IND]</English>
+    <Spanish>Helipuerto - temporal [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_Heliport_IND_F">
     <English>Heliport [IND]</English>
+    <Spanish>Helipuerto [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsLarge_HeliportFortified_IND_F">
     <English>Heliport - Fortified [IND]</English>
+    <Spanish>Helipuerto - fortificado [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsMedium_SquareLZ">
     <English>Square LZ</English>
+    <Spanish>LZ cuadrada</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsMedium_CircleLZ">
     <English>Circle LZ</English>
+    <Spanish>LZ circular</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsMedium_CargoPods_OPF_F">
     <English>Cargo Pods (Taru) [OPF]</English>
+    <Spanish>Cápsulas de carga (Taru) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsMedium_CargoPods_BLU_F">
     <English>Cargo Pods (Huron) [BLU]</English>
+    <Spanish>Cápsulas de carga (Huron) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsSmall_SquareLZ">
     <English>Square LZ</English>
+    <Spanish>LZ cuadrada</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_HeliportsSmall_CircleLZ">
     <English>Circle LZ</English>
+    <Spanish>LZ circular</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsLarge_OutpostChain">
     <English>Chain Fence Outpost</English>
+    <Spanish>Puesto avanzado con valla metálica</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsLarge_OutpostCircle">
     <English>Circle Outpost</English>
+    <Spanish>Puesto avanzado circular</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsLarge_OutpostSquare">
     <English>Square Outpost</English>
+    <Spanish>Puesto avanzado cuadrado</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsLarge_OutpostAbandoned">
     <English>Abandoned Outpost</English>
+    <Spanish>Puesto avanzado abandonado</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsLarge_BunkerTower">
     <English>Bunker (Tower) Outpost</English>
+    <Spanish>Puesto avanzado con búnker (torre)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsLarge_BunkerSmall">
     <English>Bunker (Small) Outpost</English>
+    <Spanish>Puesto avanzado con búnker (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost01">
     <English>Simple Outpost #01</English>
+    <Spanish>Puesto avanzado sencillo #01</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost02">
     <English>Simple Outpost #02</English>
+    <Spanish>Puesto avanzado sencillo #02</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost03">
     <English>Simple Outpost #03</English>
+    <Spanish>Puesto avanzado sencillo #03</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost04">
     <English>Simple Outpost #04</English>
+    <Spanish>Puesto avanzado sencillo #04</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost05">
     <English>Simple Outpost #05</English>
+    <Spanish>Puesto avanzado sencillo #05</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost06">
     <English>Simple Outpost #06</English>
+    <Spanish>Puesto avanzado sencillo #06</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost07">
     <English>Simple Outpost #07</English>
+    <Spanish>Puesto avanzado sencillo #07</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost08">
     <English>Simple Outpost #08</English>
+    <Spanish>Puesto avanzado sencillo #08</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost09">
     <English>Simple Outpost #09</English>
+    <Spanish>Puesto avanzado sencillo #09</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost10">
     <English>Simple Outpost #10</English>
+    <Spanish>Puesto avanzado sencillo #10</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost11">
     <English>Simple Outpost #11</English>
+    <Spanish>Puesto avanzado sencillo #11</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost12">
     <English>Simple Outpost #12</English>
+    <Spanish>Puesto avanzado sencillo #12</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost13">
     <English>Simple Outpost #13</English>
+    <Spanish>Puesto avanzado sencillo #13</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost14">
     <English>Simple Outpost #14</English>
+    <Spanish>Puesto avanzado sencillo #14</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_SimpleOutpost15">
     <English>Simple Outpost #15</English>
+    <Spanish>Puesto avanzado sencillo #15</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin1_OPF_F">
     <English>Ruin [OPF] #1</English>
+    <Spanish>Ruina [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin2_OPF_F">
     <English>Ruin [OPF] #2</English>
+    <Spanish>Ruina [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin3_OPF_F">
     <English>Ruin [OPF] #3</English>
+    <Spanish>Ruina [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin4_OPF_F">
     <English>Ruin [OPF] #4</English>
+    <Spanish>Ruina [OPF] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Shed_OPF_F">
     <English>Shed [OPF]</English>
+    <Spanish>Cobertizo [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_HouseFortified1_OPF_F">
     <English>House Fortified [OPF] #1</English>
+    <Spanish>Casa fortificada [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_HouseFortified2_OPF_F">
     <English>House Fortified [OPF] #2</English>
+    <Spanish>Casa fortificada [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_HouseGarage_OPF_F">
     <English>House &amp; Garage [OPF]</English>
+    <Spanish>Casa y garaje [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_WaterTower_OPF_F">
     <English>Water Tower [OPF]</English>
+    <Spanish>Torre de agua [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Bungalow_OPF_F">
     <English>Bungalow [OPF]</English>
+    <Spanish>Bungaló [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_DamagedHouse_OPF_F">
     <English>Damaged House [OPF]</English>
+    <Spanish>Casa dañada [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_DestroyedHouse_OPF_F">
     <English>Destroyed House [OPF]</English>
+    <Spanish>Casa destruida [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Lighthouse_OPF_F">
     <English>Lighthouse [OPF]</English>
+    <Spanish>Faro [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin1_BLU_F">
     <English>Ruin [BLU] #1</English>
+    <Spanish>Ruina [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin2_BLU_F">
     <English>Ruin [BLU] #2</English>
+    <Spanish>Ruina [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin3_BLU_F">
     <English>Ruin [BLU] #3</English>
+    <Spanish>Ruina [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin4_BLU_F">
     <English>Ruin [BLU] #4</English>
+    <Spanish>Ruina [BLU] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Shed_BLU_F">
     <English>Shed [BLU]</English>
+    <Spanish>Cobertizo [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_HouseFortified1_BLU_F">
     <English>House Fortified [BLU] #1</English>
+    <Spanish>Casa fortificada [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_HouseFortified2_BLU_F">
     <English>House Fortified [BLU] #2</English>
+    <Spanish>Casa fortificada [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_HouseGarage_BLU_F">
     <English>House &amp; Garage [BLU]</English>
+    <Spanish>Casa y garaje [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_WaterTower_BLU_F">
     <English>Water Tower [BLU]</English>
+    <Spanish>Torre de agua [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Bungalow_BLU_F">
     <English>Bungalow [BLU]</English>
+    <Spanish>Bungaló [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_DamagedHouse_BLU_F">
     <English>Damaged House [BLU]</English>
+    <Spanish>Casa dañada [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_DestroyedHouse_BLU_F">
     <English>Destroyed House [BLU]</English>
+    <Spanish>Casa destruida [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Lighthouse_BLU_F">
     <English>Lighthouse [BLU]</English>
+    <Spanish>Faro [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin1_IND_F">
     <English>Ruin [IND] #1</English>
+    <Spanish>Ruina [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin2_IND_F">
     <English>Ruin [IND] #2</English>
+    <Spanish>Ruina [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin3_IND_F">
     <English>Ruin [IND] #3</English>
+    <Spanish>Ruina [IND] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Ruin4_IND_F">
     <English>Ruin [IND] #4</English>
+    <Spanish>Ruina [IND] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Shed_IND_F">
     <English>Shed [IND]</English>
+    <Spanish>Cobertizo [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_HouseFortified1_IND_F">
     <English>House Fortified [IND] #1</English>
+    <Spanish>Casa fortificada [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_HouseFortified2_IND_F">
     <English>House Fortified [IND] #2</English>
+    <Spanish>Casa fortificada [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_HouseGarage_IND_F">
     <English>House &amp; Garage [IND]</English>
+    <Spanish>Casa y garaje [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_WaterTower_IND_F">
     <English>Water Tower [IND]</English>
+    <Spanish>Torre de agua [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Bungalow_IND_F">
     <English>Bungalow [IND]</English>
+    <Spanish>Bungaló [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_DamagedHouse_IND_F">
     <English>Damaged House [IND]</English>
+    <Spanish>Casa dañada [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_DestroyedHouse_IND_F">
     <English>Destroyed House [IND]</English>
+    <Spanish>Casa destruida [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsMedium_Lighthouse_IND_F">
     <English>Lighthouse [IND]</English>
+    <Spanish>Faro [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_SmallHouse1_BLU_F">
     <English>Small House [BLU] #1</English>
+    <Spanish>Casa pequeña [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_SmallHouse2_BLU_F">
     <English>Small House [BLU] #2</English>
+    <Spanish>Casa pequeña [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DestroyedHouse1_BLU_F">
     <English>Destroyed House [BLU] #1</English>
+    <Spanish>Casa destruida [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DestroyedHouse2_BLU_F">
     <English>Destroyed House [BLU] #2</English>
+    <Spanish>Casa destruida [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DestroyedHouse3_BLU_F">
     <English>Destroyed House [BLU] #3</English>
+    <Spanish>Casa destruida [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DamagedHouse_BLU_F">
     <English>Damaged House [BLU]</English>
+    <Spanish>Casa dañada [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_StoneHouse_BLU_F">
     <English>Stone House [BLU]</English>
+    <Spanish>Casa de piedra [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_SmallHouse1_OPF_F">
     <English>Small House [OPF] #1</English>
+    <Spanish>Casa pequeña [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_SmallHouse2_OPF_F">
     <English>Small House [OPF] #2</English>
+    <Spanish>Casa pequeña [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DestroyedHouse1_OPF_F">
     <English>Destroyed House [OPF] #1</English>
+    <Spanish>Casa destruida [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DestroyedHouse2_OPF_F">
     <English>Destroyed House [OPF] #2</English>
+    <Spanish>Casa destruida [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DestroyedHouse3_OPF_F">
     <English>Destroyed House [OPF] #3</English>
+    <Spanish>Casa destruida [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DamagedHouse_OPF_F">
     <English>Damaged House [OPF]</English>
+    <Spanish>Casa dañada [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_StoneHouse_OPF_F">
     <English>Stone House [OPF]</English>
+    <Spanish>Casa de piedra [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_SmallHouse1_IND_F">
     <English>Small House [IND] #1</English>
+    <Spanish>Casa pequeña [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_SmallHouse2_IND_F">
     <English>Small House [IND] #2</English>
+    <Spanish>Casa pequeña [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DestroyedHouse1_IND_F">
     <English>Destroyed House [IND] #1</English>
+    <Spanish>Casa destruida [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DestroyedHouse2_IND_F">
     <English>Destroyed House [IND] #2</English>
+    <Spanish>Casa destruida [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DestroyedHouse3_IND_F">
     <English>Destroyed House [IND] #3</English>
+    <Spanish>Casa destruida [IND] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_DamagedHouse_IND_F">
     <English>Damaged House [IND]</English>
+    <Spanish>Casa dañada [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_OutpostsSmall_StoneHouse_IND_F">
     <English>Stone House [IND]</English>
+    <Spanish>Casa de piedra [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_BunkerSystem_BLU_F">
     <English>Bunker System [BLU]</English>
+    <Spanish>Sistema de búnkeres [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_MortarBunker_BLU_F">
     <English>Mortar Bunker [BLU]</English>
+    <Spanish>Búnker de morteros [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_BunkerSystem_OPF_F">
     <English>Bunker System [OPF]</English>
+    <Spanish>Sistema de búnkeres [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_MortarBunker_OPF_F">
     <English>Mortar Bunker [OPF]</English>
+    <Spanish>Búnker de morteros [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_BunkerSystem_IND_F">
     <English>Bunker System [IND]</English>
+    <Spanish>Sistema de búnkeres [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_MortarBunker_IND_F">
     <English>Mortar Bunker [IND]</English>
+    <Spanish>Búnker de morteros [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_MortarBunkerSandbags">
     <English>Mortar Bunker (Sandbags)</English>
+    <Spanish>Búnker de morteros (sacos terreros)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_MortarBunkerHBarrier">
     <English>Mortar Bunker (H-Barrier)</English>
+    <Spanish>Búnker de morteros (H-Barrier)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_ObservationTowerRusty">
     <English>Observation Tower (Rusted)</English>
+    <Spanish>Torre de observación (oxidada)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_ObservationTowers">
     <English>Observation Towers</English>
+    <Spanish>Torres de observación</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_BunkerSystem">
     <English>Bunker System</English>
+    <Spanish>Sistema de búnkeres</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_ArtilleryBattery">
     <English>Artillery Battery</English>
+    <Spanish>Batería de artillería</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_TankBunkers">
     <English>Tank Bunkers</English>
+    <Spanish>Búnkeres para carros</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortLarge_UndergroundBunkers">
     <English>Underground Bunkers</English>
+    <Spanish>Búnkeres subterráneos</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_FortifiedCargoTower">
     <English>Fortified Cargo Tower</English>
+    <Spanish>Torre de carga fortificada</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_BunkerLargeRazor">
     <English>Bunker Large (Razor)</English>
+    <Spanish>Búnker grande (concertina)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_MortarBunkerPit">
     <English>Mortar Bunker (Pit)</English>
+    <Spanish>Búnker de morteros (foso)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_WatchtowerRazor">
     <English>Watchtower Razor</English>
+    <Spanish>Torre de vigilancia con concertina</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_TowerBunkerSandbags">
     <English>Tower Bunker (Sandbags)</English>
+    <Spanish>Búnker torre (sacos terreros)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_TowerBunkerRazor">
     <English>Tower Bunker (Razor)</English>
+    <Spanish>Búnker torre (concertina)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_BunkerRazor">
     <English>Bunker (Razor)</English>
+    <Spanish>Búnker (concertina)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_SandbagsRazor">
     <English>Sandbags (Razor)</English>
+    <Spanish>Sacos terreros (concertina)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_ArtilleryBunker">
     <English>Artillery Bunker</English>
+    <Spanish>Búnker de artillería</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_TankPositionFortified">
     <English>Tank Position (Fortified)</English>
+    <Spanish>Posición de carros (fortificada)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_VehicleBunker_IND_F">
     <English>Vehicle Bunker [IND]</English>
+    <Spanish>Búnker para vehículos [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower1_IND_F">
     <English>Tower [IND] #1</English>
+    <Spanish>Torre [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower2_IND_F">
     <English>Tower [IND] #2</English>
+    <Spanish>Torre [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower3_IND_F">
     <English>Tower [IND] #3</English>
+    <Spanish>Torre [IND] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower4_IND_F">
     <English>Tower [IND] #4</English>
+    <Spanish>Torre [IND] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Bunker1_IND_F">
     <English>Bunker [IND] #1</English>
+    <Spanish>Búnker [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Bunker2_IND_F">
     <English>Bunker [IND] #2</English>
+    <Spanish>Búnker [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Bunker3_IND_F">
     <English>Bunker [IND] #3</English>
+    <Spanish>Búnker [IND] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_VehicleBunker_BLU_F">
     <English>Vehicle Bunker [BLU]</English>
+    <Spanish>Búnker para vehículos [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower1_BLU_F">
     <English>Tower [BLU] #1</English>
+    <Spanish>Torre [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower2_BLU_F">
     <English>Tower [BLU] #2</English>
+    <Spanish>Torre [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower3_BLU_F">
     <English>Tower [BLU] #3</English>
+    <Spanish>Torre [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower4_BLU_F">
     <English>Tower [BLU] #4</English>
+    <Spanish>Torre [BLU] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Bunker1_BLU_F">
     <English>Bunker [BLU] #1</English>
+    <Spanish>Búnker [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Bunker2_BLU_F">
     <English>Bunker [BLU] #2</English>
+    <Spanish>Búnker [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Bunker3_BLU_F">
     <English>Bunker [BLU] #3</English>
+    <Spanish>Búnker [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_VehicleBunker_OPF_F">
     <English>Vehicle Bunker [OPF]</English>
+    <Spanish>Búnker para vehículos [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower1_OPF_F">
     <English>Tower [OPF] #1</English>
+    <Spanish>Torre [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower2_OPF_F">
     <English>Tower [OPF] #2</English>
+    <Spanish>Torre [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower3_OPF_F">
     <English>Tower [OPF] #3</English>
+    <Spanish>Torre [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Tower4_OPF_F">
     <English>Tower [OPF] #4</English>
+    <Spanish>Torre [OPF] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Bunker1_OPF_F">
     <English>Bunker [OPF] #1</English>
+    <Spanish>Búnker [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Bunker2_OPF_F">
     <English>Bunker [OPF] #2</English>
+    <Spanish>Búnker [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Bunker3_OPF_F">
     <English>Bunker [OPF] #3</English>
+    <Spanish>Búnker [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Artillery_OPF_F">
     <English>Artillery Bunker [OPF]</English>
+    <Spanish>Búnker de artillería [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_AAA_OPF_F">
     <English>AA Artillery Bunker [OPF]</English>
+    <Spanish>Búnker de artillería antiaérea [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_Artillery_BLU_F">
     <English>Artillery Bunker [BLU]</English>
+    <Spanish>Búnker de artillería [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_AAA_BLU_F">
     <English>AA Artillery Bunker [BLU]</English>
+    <Spanish>Búnker de artillería antiaérea [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_VehicleNet_BLU_F">
     <English>Vehicle Cover Net [BLU]</English>
+    <Spanish>Red de ocultación para vehículos [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_VehicleNet_OPF_F">
     <English>Vehicle Cover Net [OPF]</English>
+    <Spanish>Red de ocultación para vehículos [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_VehicleNet_IND_F">
     <English>Vehicle Cover Net [IND]</English>
+    <Spanish>Red de ocultación para vehículos [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_TankPosition">
     <English>Tank Position</English>
+    <Spanish>Posición de carros</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerConcrete_BLU_F">
     <English>Concrete Bunker [BLU]</English>
+    <Spanish>Búnker de hormigón [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker1_BLU_F">
     <English>Bunker [BLU] #1</English>
+    <Spanish>Búnker [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker2_BLU_F">
     <English>Bunker [BLU] #2</English>
+    <Spanish>Búnker [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker3_BLU_F">
     <English>Bunker [BLU] #3</English>
+    <Spanish>Búnker [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker4_BLU_F">
     <English>Bunker [BLU] #4</English>
+    <Spanish>Búnker [BLU] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunkerx2_BLU_F">
     <English>Bunker (Dual) [BLU]</English>
+    <Spanish>Búnker (doble) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_AntiAirBunker_BLU_F">
     <English>Static AA (Net) [BLU]</English>
+    <Spanish>Antiaéreo estático (red) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_AntiTankSandbag_BLU_F">
     <English>Static AT (Sandbags) [BLU]</English>
+    <Spanish>Antitanque estático (sacos terreros) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_AntiTankBunker_BLU_F">
     <English>Static AT (Net) [BLU]</English>
+    <Spanish>Antitanque estático (red) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net1_BLU_F">
     <English>Net [BLU] #1</English>
+    <Spanish>Red de camuflaje [BLU] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net2_BLU_F">
     <English>Net [BLU] #2</English>
+    <Spanish>Red de camuflaje [BLU] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net3_BLU_F">
     <English>Net [BLU] #3</English>
+    <Spanish>Red de camuflaje [BLU] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net4_BLU_F">
     <English>Net [BLU] #4</English>
+    <Spanish>Red de camuflaje [BLU] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net5_BLU_F">
     <English>Net [BLU] #5</English>
+    <Spanish>Red de camuflaje [BLU] #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net6_BLU_F">
     <English>Net [BLU] #6</English>
+    <Spanish>Red de camuflaje [BLU] #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net7_BLU_F">
     <English>Net [BLU] #7</English>
+    <Spanish>Red de camuflaje [BLU] #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_MortarSandbag_BLU_F">
     <English>Mortar (Sandbag) [BLU]</English>
+    <Spanish>Mortero (saco terrero) [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerConcrete_OPF_F">
     <English>Concrete Bunker [OPF]</English>
+    <Spanish>Búnker de hormigón [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker1_OPF_F">
     <English>Bunker [OPF] #1</English>
+    <Spanish>Búnker [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker2_OPF_F">
     <English>Bunker [OPF] #2</English>
+    <Spanish>Búnker [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker3_OPF_F">
     <English>Bunker [OPF] #3</English>
+    <Spanish>Búnker [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker4_OPF_F">
     <English>Bunker [OPF] #4</English>
+    <Spanish>Búnker [OPF] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunkerx2_OPF_F">
     <English>Bunker (Dual) [OPF]</English>
+    <Spanish>Búnker (doble) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_AntiAirBunker_OPF_F">
     <English>Static AA (Net) [OPF]</English>
+    <Spanish>Antiaéreo estático (red) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_AntiTankSandbag_OPF_F">
     <English>Static AT (Sandbags) [OPF]</English>
+    <Spanish>Antitanque estático (sacos terreros) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_AntiTankBunker_OPF_F">
     <English>Static AT (Net) [OPF]</English>
+    <Spanish>Antitanque estático (red) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net1_OPF_F">
     <English>Net [OPF] #1</English>
+    <Spanish>Red de camuflaje [OPF] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net2_OPF_F">
     <English>Net [OPF] #2</English>
+    <Spanish>Red de camuflaje [OPF] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net3_OPF_F">
     <English>Net [OPF] #3</English>
+    <Spanish>Red de camuflaje [OPF] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net4_OPF_F">
     <English>Net [OPF] #4</English>
+    <Spanish>Red de camuflaje [OPF] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net5_OPF_F">
     <English>Net [OPF] #5</English>
+    <Spanish>Red de camuflaje [OPF] #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net6_OPF_F">
     <English>Net [OPF] #6</English>
+    <Spanish>Red de camuflaje [OPF] #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net7_OPF_F">
     <English>Net [OPF] #7</English>
+    <Spanish>Red de camuflaje [OPF] #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_MortarSandbag_OPF_F">
     <English>Mortar (Sandbag) [OPF]</English>
+    <Spanish>Mortero (saco terrero) [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerConcrete_IND_F">
     <English>Concrete Bunker [IND]</English>
+    <Spanish>Búnker de hormigón [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker1_IND_F">
     <English>Bunker [IND] #1</English>
+    <Spanish>Búnker [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker2_IND_F">
     <English>Bunker [IND] #2</English>
+    <Spanish>Búnker [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker3_IND_F">
     <English>Bunker [IND] #3</English>
+    <Spanish>Búnker [IND] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunker4_IND_F">
     <English>Bunker [IND] #4</English>
+    <Spanish>Búnker [IND] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Bunkerx2_IND_F">
     <English>Bunker (Dual) [IND]</English>
+    <Spanish>Búnker (doble) [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_AntiAirBunker_IND_F">
     <English>Static AA (Net) [IND]</English>
+    <Spanish>Antiaéreo estático (red) [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_AntiTankSandbag_IND_F">
     <English>Static AT (Sandbags) [IND]</English>
+    <Spanish>Antitanque estático (sacos terreros) [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_AntiTankBunker_IND_F">
     <English>Static AT (Net) [IND]</English>
+    <Spanish>Antitanque estático (red) [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net1_IND_F">
     <English>Net [IND] #1</English>
+    <Spanish>Red de camuflaje [IND] #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net2_IND_F">
     <English>Net [IND] #2</English>
+    <Spanish>Red de camuflaje [IND] #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net3_IND_F">
     <English>Net [IND] #3</English>
+    <Spanish>Red de camuflaje [IND] #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net4_IND_F">
     <English>Net [IND] #4</English>
+    <Spanish>Red de camuflaje [IND] #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net5_IND_F">
     <English>Net [IND] #5</English>
+    <Spanish>Red de camuflaje [IND] #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net6_IND_F">
     <English>Net [IND] #6</English>
+    <Spanish>Red de camuflaje [IND] #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Net7_IND_F">
     <English>Net [IND] #7</English>
+    <Spanish>Red de camuflaje [IND] #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_MortarSandbag_IND_F">
     <English>Mortar (Sandbag) [IND]</English>
+    <Spanish>Mortero (saco terrero) [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerSmall1">
     <English>Bunker (Small) #1</English>
+    <Spanish>Búnker (pequeño) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerSmall2">
     <English>Bunker (Small) #2</English>
+    <Spanish>Búnker (pequeño) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerSmall3">
     <English>Bunker (Small) #3</English>
+    <Spanish>Búnker (pequeño) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerSmall4">
     <English>Bunker (Small) #4</English>
+    <Spanish>Búnker (pequeño) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerSmall5">
     <English>Bunker (Small) #5</English>
+    <Spanish>Búnker (pequeño) #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerSmall6">
     <English>Bunker (Small) #6</English>
+    <Spanish>Búnker (pequeño) #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerSmall7">
     <English>Bunker (Small) #7</English>
+    <Spanish>Búnker (pequeño) #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerSmall8">
     <English>Bunker (Small) #8</English>
+    <Spanish>Búnker (pequeño) #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerSmall9">
     <English>Bunker (Small) #9</English>
+    <Spanish>Búnker (pequeño) #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_BunkerLarge1">
     <English>Bunker (Large) #1</English>
+    <Spanish>Búnker (grande) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_BunkerLarge2">
     <English>Bunker (Large) #2</English>
+    <Spanish>Búnker (grande) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_BunkerLarge3">
     <English>Bunker (Large) #3</English>
+    <Spanish>Búnker (grande) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_BunkerLarge4">
     <English>Bunker (Large) #4</English>
+    <Spanish>Búnker (grande) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_BunkerLarge5">
     <English>Bunker (Large) #5</English>
+    <Spanish>Búnker (grande) #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_BunkerLarge6">
     <English>Bunker (Large) #6</English>
+    <Spanish>Búnker (grande) #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_BunkerLarge7">
     <English>Bunker (Large) #7</English>
+    <Spanish>Búnker (grande) #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_BunkerLarge8">
     <English>Bunker (Large) #8</English>
+    <Spanish>Búnker (grande) #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_BunkerLarge9">
     <English>Bunker (Large) #9</English>
+    <Spanish>Búnker (grande) #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_CargoPost1">
     <English>Cargo Post #1</English>
+    <Spanish>Puesto de carga #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_CargoPost2">
     <English>Cargo Post #2</English>
+    <Spanish>Puesto de carga #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_CargoPost3">
     <English>Cargo Post #3</English>
+    <Spanish>Puesto de carga #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_CargoPost4">
     <English>Cargo Post #4</English>
+    <Spanish>Puesto de carga #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_CargoPost5">
     <English>Cargo Post #5</English>
+    <Spanish>Puesto de carga #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_CargoPost6">
     <English>Cargo Post #6</English>
+    <Spanish>Puesto de carga #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_CargoPost7">
     <English>Cargo Post #7</English>
+    <Spanish>Puesto de carga #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_CargoPost8">
     <English>Cargo Post #8</English>
+    <Spanish>Puesto de carga #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_CargoPost9">
     <English>Cargo Post #9</English>
+    <Spanish>Puesto de carga #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Watchtower1">
     <English>Watchtower #1</English>
+    <Spanish>Torre de vigilancia #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Watchtower2">
     <English>Watchtower #2</English>
+    <Spanish>Torre de vigilancia #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Watchtower3">
     <English>Watchtower #3</English>
+    <Spanish>Torre de vigilancia #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Watchtower4">
     <English>Watchtower #4</English>
+    <Spanish>Torre de vigilancia #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Watchtower5">
     <English>Watchtower #5</English>
+    <Spanish>Torre de vigilancia #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Watchtower6">
     <English>Watchtower #6</English>
+    <Spanish>Torre de vigilancia #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Watchtower7">
     <English>Watchtower #7</English>
+    <Spanish>Torre de vigilancia #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Watchtower8">
     <English>Watchtower #8</English>
+    <Spanish>Torre de vigilancia #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_Watchtower9">
     <English>Watchtower #9</English>
+    <Spanish>Torre de vigilancia #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerTower1">
     <English>Bunker (Tower) #1</English>
+    <Spanish>Búnker (torre) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerTower2">
     <English>Bunker (Tower) #2</English>
+    <Spanish>Búnker (torre) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerTower3">
     <English>Bunker (Tower) #3</English>
+    <Spanish>Búnker (torre) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerTower4">
     <English>Bunker (Tower) #4</English>
+    <Spanish>Búnker (torre) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerTower5">
     <English>Bunker (Tower) #5</English>
+    <Spanish>Búnker (torre) #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerTower6">
     <English>Bunker (Tower) #6</English>
+    <Spanish>Búnker (torre) #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerTower7">
     <English>Bunker (Tower) #7</English>
+    <Spanish>Búnker (torre) #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerTower8">
     <English>Bunker (Tower) #8</English>
+    <Spanish>Búnker (torre) #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortSmall_BunkerTower9">
     <English>Bunker (Tower) #9</English>
+    <Spanish>Búnker (torre) #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_VehicleWatchtower">
     <English>Vehicle Watchtower</English>
+    <Spanish>Torre de vigilancia para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_VehicleCargoPost">
     <English>Vehicle Cargo Post</English>
+    <Spanish>Puesto de carga para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_VehicleLargeBunker">
     <English>Vehicle Bunker (Large)</English>
+    <Spanish>Búnker para vehículos (grande)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_VehicleTower">
     <English>Vehicle Tower</English>
+    <Spanish>Torre para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_VehicleSmallBunker">
     <English>Vehicle Bunker (Small)</English>
+    <Spanish>Búnker para vehículos (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerBrown1">
     <English>Cargo Tower (Brown) #1</English>
+    <Spanish>Torre de carga (marrón) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerBrown2">
     <English>Cargo Tower (Brown) #2</English>
+    <Spanish>Torre de carga (marrón) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerBrown3">
     <English>Cargo Tower (Brown) #3</English>
+    <Spanish>Torre de carga (marrón) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerBrown4">
     <English>Cargo Tower (Brown) #4</English>
+    <Spanish>Torre de carga (marrón) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerBrown5">
     <English>Cargo Tower (Brown) #5</English>
+    <Spanish>Torre de carga (marrón) #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerBrown6">
     <English>Cargo Tower (Brown) #6</English>
+    <Spanish>Torre de carga (marrón) #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerBrown7">
     <English>Cargo Tower (Brown) #7</English>
+    <Spanish>Torre de carga (marrón) #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerBrown8">
     <English>Cargo Tower (Brown) #8</English>
+    <Spanish>Torre de carga (marrón) #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerBrown9">
     <English>Cargo Tower (Brown) #9</English>
+    <Spanish>Torre de carga (marrón) #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerGreen1">
     <English>Cargo Tower (Green) #1</English>
+    <Spanish>Torre de carga (verde) #1</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerGreen2">
     <English>Cargo Tower (Green) #2</English>
+    <Spanish>Torre de carga (verde) #2</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerGreen3">
     <English>Cargo Tower (Green) #3</English>
+    <Spanish>Torre de carga (verde) #3</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerGreen4">
     <English>Cargo Tower (Green) #4</English>
+    <Spanish>Torre de carga (verde) #4</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerGreen5">
     <English>Cargo Tower (Green) #5</English>
+    <Spanish>Torre de carga (verde) #5</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerGreen6">
     <English>Cargo Tower (Green) #6</English>
+    <Spanish>Torre de carga (verde) #6</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerGreen7">
     <English>Cargo Tower (Green) #7</English>
+    <Spanish>Torre de carga (verde) #7</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerGreen8">
     <English>Cargo Tower (Green) #8</English>
+    <Spanish>Torre de carga (verde) #8</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FortMedium_CargoTowerGreen9">
     <English>Cargo Tower (Green) #9</English>
+    <Spanish>Torre de carga (verde) #9</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelLarge_Depot_BLU_F">
     <English>Depot [BLU]</English>
+    <Spanish>Depósito [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelLarge_Refinery_BLU_F">
     <English>Refinery [BLU]</English>
+    <Spanish>Refinería [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelLarge_Depot_OPF_F">
     <English>Depot [OPF]</English>
+    <Spanish>Depósito [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelLarge_Refinery_OPF_F">
     <English>Refinery [OPF]</English>
+    <Spanish>Refinería [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelLarge_Depot_IND_F">
     <English>Depot [IND]</English>
+    <Spanish>Depósito [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelLarge_Refinery_IND_F">
     <English>Refinery [IND]</English>
+    <Spanish>Refinería [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelMedium_StorageTanks_BLU_F">
     <English>Storage Tanks [BLU]</English>
+    <Spanish>Depósitos de almacenamiento [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelMedium_DieselStorage_BLU_F">
     <English>Diesel Storage [BLU]</English>
+    <Spanish>Almacén de diésel [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelMedium_StorageTanks_OPF_F">
     <English>Storage Tanks [OPF]</English>
+    <Spanish>Depósitos de almacenamiento [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelMedium_DieselStorage_OPF_F">
     <English>Diesel Storage [OPF]</English>
+    <Spanish>Almacén de diésel [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelMedium_StorageTanks_IND_F">
     <English>Storage Tanks [IND]</English>
+    <Spanish>Depósitos de almacenamiento [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelMedium_DieselStorage_IND_F">
     <English>Diesel Storage [IND]</English>
+    <Spanish>Almacén de diésel [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelSmall_StorageArea_BLU_F">
     <English>Storage Area [BLU]</English>
+    <Spanish>Zona de almacenamiento [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelSmall_StorageArea_OPF_F">
     <English>Storage Area [OPF]</English>
+    <Spanish>Zona de almacenamiento [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelSmall_StorageArea_IND_F">
     <English>Storage Area [IND]</English>
+    <Spanish>Zona de almacenamiento [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelSmall_FuelDepot_OPF_F">
     <English>Fuel Depot [OPF]</English>
+    <Spanish>Depósito de combustible [OPF]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelSmall_FuelDepot_BLU_F">
     <English>Fuel Depot [BLU]</English>
+    <Spanish>Depósito de combustible [BLU]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_FuelSmall_FuelDepot_IND_F">
     <English>Fuel Depot [IND]</English>
+    <Spanish>Depósito de combustible [IND]</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingLarge_ShootHouse01">
     <English>Shoot House</English>
+    <Spanish>Casa de tiro</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingMedium_ShootHouse01">
     <English>Shoot House #01</English>
+    <Spanish>Casa de tiro #01</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingMedium_ShootHouse02">
     <English>Shoot House #02</English>
+    <Spanish>Casa de tiro #02</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingMedium_ShootHouse03">
     <English>Shoot House #03</English>
+    <Spanish>Casa de tiro #03</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingMedium_ShootHouse04">
     <English>Shoot House #04</English>
+    <Spanish>Casa de tiro #04</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingMedium_ShootHouse05">
     <English>Shoot House #05</English>
+    <Spanish>Casa de tiro #05</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingMedium_ShootHouse06">
     <English>Shoot House #06</English>
+    <Spanish>Casa de tiro #06</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingMedium_ShootHouse07">
     <English>Shoot House #07</English>
+    <Spanish>Casa de tiro #07</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingMedium_ShootHouse08">
     <English>Shoot House #08</English>
+    <Spanish>Casa de tiro #08</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingMedium_ShootHouse09">
     <English>Shoot House #09</English>
+    <Spanish>Casa de tiro #09</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse01">
     <English>Shoot House #01</English>
+    <Spanish>Casa de tiro #01</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse02">
     <English>Shoot House #02</English>
+    <Spanish>Casa de tiro #02</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse03">
     <English>Shoot House #03</English>
+    <Spanish>Casa de tiro #03</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse04">
     <English>Shoot House #04</English>
+    <Spanish>Casa de tiro #04</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse05">
     <English>Shoot House #05</English>
+    <Spanish>Casa de tiro #05</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse06">
     <English>Shoot House #06</English>
+    <Spanish>Casa de tiro #06</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse07">
     <English>Shoot House #07</English>
+    <Spanish>Casa de tiro #07</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse08">
     <English>Shoot House #08</English>
+    <Spanish>Casa de tiro #08</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse09">
     <English>Shoot House #09</English>
+    <Spanish>Casa de tiro #09</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse10">
     <English>Shoot House #10</English>
+    <Spanish>Casa de tiro #10</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse11">
     <English>Shoot House #11</English>
+    <Spanish>Casa de tiro #11</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse12">
     <English>Shoot House #12</English>
+    <Spanish>Casa de tiro #12</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse13">
     <English>Shoot House #13</English>
+    <Spanish>Casa de tiro #13</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse14">
     <English>Shoot House #14</English>
+    <Spanish>Casa de tiro #14</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse15">
     <English>Shoot House #15</English>
+    <Spanish>Casa de tiro #15</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse16">
     <English>Shoot House #16</English>
+    <Spanish>Casa de tiro #16</Spanish>
 </Key>
 <Key ID="STR_ZEC_Military_TrainingSmall_ShootHouse17">
     <English>Shoot House #17</English>
+    <Spanish>Casa de tiro #17</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/composition_alive/stringtable.xml
+++ b/addons/composition_alive/stringtable.xml
@@ -4,91 +4,115 @@
 <Container name="STR_DN">
 <Key ID="STR_ALIVE_Military_FortMedium_AA_OPF_F">
     <English>AA Bunker [OPF]</English>
+    <Spanish>Búnker antiaéreo [OPF]</Spanish>
 </Key>
 <Key ID="STR_ALIVE_Military_FortLarge_SAM_OPF_F">
     <English>SAM Site [OPF]</English>
+    <Spanish>Emplazamiento SAM [OPF]</Spanish>
 </Key>
 <Key ID="STR_ALIVE_Military_FortMedium_SAM_OPF_F">
     <English>SAM Bunker [OPF]</English>
+    <Spanish>Búnker SAM [OPF]</Spanish>
 </Key>
 <Key ID="STR_ALIVE_Military_FortLarge_SAM_BLU_F">
     <English>SAM Site [BLU]</English>
+    <Spanish>Emplazamiento SAM [BLU]</Spanish>
 </Key>
 <Key ID="STR_ALIVE_Military_FortMedium_SAM_BLU_F">
     <English>SAM Bunker [BLU]</English>
+    <Spanish>Búnker SAM [BLU]</Spanish>
 </Key>
 <Key ID="STR_ALIVE_Military_FortMedium_Artillery_BLU_F">
     <English>Artillery Bunker [BLU]</English>
+    <Spanish>Búnker de artillería [BLU]</Spanish>
 </Key>
 <Key ID="STR_ALIVE_Military_FortMedium_AA_BLU_F">
     <English>AA Bunker [BLU]</English>
+    <Spanish>Búnker antiaéreo [BLU]</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMPOSITION_hq">
     <English>HQ</English>
+    <Spanish>Cuartel general</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_camps">
     <English>Camps</English>
+    <Spanish>Campamentos</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_mediumAirstation1">
     <English>Airstation 1 [Medium]</English>
+    <Spanish>Estación aérea 1 [Media]</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_power">
     <English>Power</English>
+    <Spanish>Energía</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_communications">
     <English>Communications</English>
+    <Spanish>Comunicaciones</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_fuel">
     <English>Fuel</English>
+    <Spanish>Combustible</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_smallFuelStation1">
     <English>Fuel Station 1 [Small]</English>
+    <Spanish>Estación de combustible 1 [Pequeña]</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_mediumFuelSilo1">
     <English>Fuel Silo 1 [Medium]</English>
+    <Spanish>Silo de combustible 1 [Medio]</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_marine">
     <English>Marine</English>
+    <Spanish>Marítimo</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_constructionSupplies">
     <English>Construct Supplies</English>
+    <Spanish>Suministros de construcción</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_settlement">
     <English>Settlement</English>
+    <Spanish>Asentamiento</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_crashsites">
     <English>Crashsites</English>
+    <Spanish>Zonas de accidente</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_smallOspreyCrashsite1">
     <English>Osprey site 1 [Small]</English>
+    <Spanish>Accidente de Osprey 1 [Pequeño]</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_smallAH99Crashsite1">
     <English>AH-99 site 1 [Small]</English>
+    <Spanish>Accidente de AH-99 1 [Pequeño]</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_mediumc192Crash1">
     <English>C192 site 1 [Medium]</English>
+    <Spanish>Accidente de C192 1 [Medio]</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_objectives">
     <English>Objectives</English>
+    <Spanish>Objetivos</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_COMPOSITION_IEDFactory1">
     <English>IED Factory 1 [Small]</English>
+    <Spanish>Fábrica de IED 1 [Pequeña]</Spanish>
 </Key>
 
 </Container></Package></Project>

--- a/addons/grp_a3/stringtable.xml
+++ b/addons/grp_a3/stringtable.xml
@@ -5,297 +5,370 @@
 <Key ID="str_a3_cfggroups_east_opf_f_infantry_oia_infwepteam0">
     <English>Weapons Team</English>
     <Chinesesimp>武器小组</Chinesesimp>
+    <Spanish>Equipo de armas</Spanish>
 </Key>
 <Key ID="str_a3_cfggroups_east_opf_f_infantry_oia_infsupteam0">
     <English>Support Team</English>
     <Chinesesimp>支援小组</Chinesesimp>
+    <Spanish>Equipo de apoyo</Spanish>
 </Key>
 <Key ID="str_a3_cfggroups_east_opf_f_infantry_oia_infhq0">
     <English>Infantry HQ</English>
     <Chinesesimp>步兵师指挥部</Chinesesimp>
+    <Spanish>HQ de infantería</Spanish>
 </Key>
 <Key ID="str_a3_cfggroups_east_opf_f_infantry_oia_infsniper0">
     <English>Sniper Team</English>
     <Chinesesimp>狙击小组</Chinesesimp>
+    <Spanish>Equipo de francotiradores</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Motorized_MTP_OIA_MotInfSection0">
     <English>Motorized Section</English>
     <Chinesesimp>机动部队</Chinesesimp>
+    <Spanish>Sección motorizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Motorized_MTP_OIA_MotInf_ATV0">
     <English>Motorized ATV Team</English>
     <Chinesesimp>全地形机动小组</Chinesesimp>
+    <Spanish>Equipo motorizado de quads</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Motorized_MTP_OIA_MotInf_HQ0">
     <English>Motorized HQ</English>
     <Chinesesimp>机动指挥部</Chinesesimp>
+    <Spanish>HQ motorizado</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Motorized_MTP_OIA_MotInf_Transport0">
     <English>Motorized Transport</English>
     <Chinesesimp>机动运输</Chinesesimp>
+    <Spanish>Transporte motorizado</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Mechanize_OIA_MechInf_Section10">
     <English>Mechanized 1st Rifle Section</English>
     <Chinesesimp>机械化第一步枪队</Chinesesimp>
+    <Spanish>1.ª sección de fusileros mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Mechanize_OIA_MechInf_Section20">
     <English>Mechanized 2nd Rifle Section</English>
     <Chinesesimp>机械化第二步枪队</Chinesesimp>
+    <Spanish>2.ª sección de fusileros mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Mechanize_OIA_MechInf_Section30">
     <English>Mechanized 3rd Rifle Section</English>
     <Chinesesimp>机械化第三步枪队</Chinesesimp>
+    <Spanish>3.ª sección de fusileros mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Mechanize_OIA_MechInf_CoyHQ0">
     <English>Mechanized Company HQ</English>
     <Chinesesimp>机械化指挥连队</Chinesesimp>
+    <Spanish>HQ de compañía mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Mechanize_OIA_MechInf_SectionAT0">
     <English>Mechanized Anti-Tank Section</English>
     <Chinesesimp>机械化反坦克部队</Chinesesimp>
+    <Spanish>Sección antitanque mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Mechanize_OIA_MechInf_SectionMG0">
     <English>Mechanized Weapons Section</English>
     <Chinesesimp>机械化步兵部队</Chinesesimp>
+    <Spanish>Sección de armas mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Air_OIA_PO30_Squadron0">
     <English>PO-30 Squadron</English>
     <Chinesesimp>PO-30中队</Chinesesimp>
+    <Spanish>Escuadrón PO-30</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Air_OIA_PO30_Transport0">
     <English>PO-30 Transport</English>
     <Chinesesimp>PO-30运输队</Chinesesimp>
+    <Spanish>Transporte PO-30</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Mech0">
     <English>Mechanized Infantry</English>
     <Chinesesimp>机械化步兵</Chinesesimp>
+    <Spanish>Infantería mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Air0">
     <English>Air</English>
     <Chinesesimp>空军</Chinesesimp>
+    <Spanish>Aéreo</Spanish>
 </Key>
 <Key ID="STR_A3_CfgVehicles_Quadbike_Light_F0">
     <English>Quadbike (Light)</English>
     <Chinesesimp>四轮摩托车(Light)</Chinesesimp>
+    <Spanish>Quad (ligero)</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_InfSentry0">
     <English>Sentry</English>
     <Chinesesimp>岗哨</Chinesesimp>
+    <Spanish>Centinela</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_InfSquad0">
     <English>Rifle Squad</English>
     <Chinesesimp>步兵班</Chinesesimp>
+    <Spanish>Escuadra de fusileros</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_InfSquad_Weapons0">
     <English>Weapons Squad</English>
     <Chinesesimp>武器班</Chinesesimp>
+    <Spanish>Escuadra de armas</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_InfTeam0">
     <English>Fire Team</English>
     <Chinesesimp>火力小组</Chinesesimp>
+    <Spanish>Equipo de fuego</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_InfTeam_AA0">
     <English>Air-defense Team</English>
     <Chinesesimp>防空小组</Chinesesimp>
+    <Spanish>Equipo de defensa antiaérea</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_InfTeam_AT0">
     <English>Anti-armor Team</English>
     <Chinesesimp>反装甲小组</Chinesesimp>
+    <Spanish>Equipo antiblindaje</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_InfWepTeam0">
     <English>Weapons Team</English>
     <Chinesesimp>武器小组</Chinesesimp>
+    <Spanish>Equipo de armas</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_InfSupTeam0">
     <English>Support Team</English>
     <Chinesesimp>支援小组</Chinesesimp>
+    <Spanish>Equipo de apoyo</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_InfHQ0">
     <English>Infantry HQ</English>
     <Chinesesimp>步兵师指挥部</Chinesesimp>
+    <Spanish>HQ de infantería</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_ReconSentry0">
     <English>Recon Sentry</English>
     <Chinesesimp>侦察哨兵</Chinesesimp>
+    <Spanish>Centinela de reconocimiento</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Motorized_MTP_ORG_MotInf_Team0">
     <English>Motorized Patrol</English>
     <Chinesesimp>机动巡逻</Chinesesimp>
+    <Spanish>Patrulla motorizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Motorized_MTP_ORG_Technicals0">
     <English>Technicals</English>
     <Chinesesimp>非标准战术车辆</Chinesesimp>
+    <Spanish>Technicals</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_Support_CLS0">
     <English>Support Team (CLS)</English>
     <Chinesesimp>支援小组(CLS)</Chinesesimp>
+    <Spanish>Equipo de apoyo (CLS)</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_Support_ENG0">
     <English>Support Team (Engineer)</English>
     <Chinesesimp>支援小组(工程维护)</Chinesesimp>
+    <Spanish>Equipo de apoyo (ingeniero)</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_G_F_Infantry_ORG_Support_EOD0">
     <English>Support Team (EOD)</English>
     <Chinesesimp>支援小组(爆炸物处理)</Chinesesimp>
+    <Spanish>Equipo de apoyo (EOD)</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Naval">
     <English>Naval</English>
     <Chinesesimp>海军</Chinesesimp>
+    <Spanish>Naval</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_West_BLU_F_Naval">
     <English>Naval</English>
     <Chinesesimp>海军</Chinesesimp>
+    <Spanish>Naval</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_F_Naval_OIA_sentryTeam_Boat0">
     <English>Sentry Team (Speed Boat)</English>
     <Chinesesimp>巡逻队(快艇)</Chinesesimp>
+    <Spanish>Equipo centinela (lancha rápida)</Spanish>
 </Key>
 
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_InfSentry0">
 	<English>Sentry</English>
     <Chinesesimp>岗哨</Chinesesimp>
+	<Spanish>Centinela</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_InfSquad0">
 	<English>Rifle Squad</English>
     <Chinesesimp>步兵班</Chinesesimp>
+	<Spanish>Escuadra de fusileros</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_InfSquad_Weapons0">
 	<English>Weapons Squad</English>
     <Chinesesimp>武器班</Chinesesimp>
+	<Spanish>Escuadra de armas</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_InfTeam0">
 	<English>Fire Team</English>
     <Chinesesimp>火力小组</Chinesesimp>
+	<Spanish>Equipo de fuego</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_InfTeam_AA0">
 	<English>Air-defense Team</English>
     <Chinesesimp>防空小组</Chinesesimp>
+	<Spanish>Equipo de defensa antiaérea</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_InfTeam_AT0">
 	<English>Anti-armor Team</English>
     <Chinesesimp>反装甲小组</Chinesesimp>
+	<Spanish>Equipo antiblindaje</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_InfWepTeam0">
 	<English>Weapons Team</English>
     <Chinesesimp>武器小组</Chinesesimp>
+	<Spanish>Equipo de armas</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_InfSupTeam0">
 	<English>Support Team</English>
     <Chinesesimp>支援小组</Chinesesimp>
+	<Spanish>Equipo de apoyo</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_InfHQ0">
 	<English>Infantry HQ</English>
     <Chinesesimp>步兵师指挥部</Chinesesimp>
+	<Spanish>HQ de infantería</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_ReconSentry0">
 	<English>Recon Sentry</English>
     <Chinesesimp>侦察哨兵</Chinesesimp>
+	<Spanish>Centinela de reconocimiento</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_Support_CLS0">
 	<English>Support Team (CLS)</English>
     <Chinesesimp>支援小组(外包?)</Chinesesimp>
+	<Spanish>Equipo de apoyo (CLS)</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_Support_ENG0">
 	<English>Support Team (Engineer)</English>
     <Chinesesimp>支援小组(工程维护)</Chinesesimp>
+	<Spanish>Equipo de apoyo (ingeniero)</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Infantry_HRG_Support_EOD0">
 	<English>Support Team (EOD)</English>
     <Chinesesimp>支援小组(爆炸物处理)</Chinesesimp>
+	<Spanish>Equipo de apoyo (EOD)</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Motorized_MTP_HRG_MotInf_Team0">
     <English>Motorized Patrol</English>
     <Chinesesimp>机动巡逻</Chinesesimp>
+    <Spanish>Patrulla motorizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_Independant_IND_G_F_Motorized_MTP_HRG_Technicals0">
     <English>Technicals</English>
     <Chinesesimp>主要参数</Chinesesimp>
+    <Spanish>Technicals</Spanish>
 </Key>
 
 // APEX
 <Key ID="str_a3_cfggroups_east_OPF_T_F_infantry_O_T_infwepteam0">
     <English>Weapons Team</English>
     <Chinesesimp>武器小组</Chinesesimp>
+    <Spanish>Equipo de armas</Spanish>
 </Key>
 <Key ID="str_a3_cfggroups_east_OPF_T_F_infantry_O_T_infsupteam0">
     <English>Support Team</English>
     <Chinesesimp>支援小组</Chinesesimp>
+    <Spanish>Equipo de apoyo</Spanish>
 </Key>
 <Key ID="str_a3_cfggroups_east_OPF_T_F_infantry_O_T_infhq0">
     <English>Infantry HQ</English>
     <Chinesesimp>步兵师指挥部</Chinesesimp>
+    <Spanish>HQ de infantería</Spanish>
 </Key>
 <Key ID="str_a3_cfggroups_east_OPF_T_F_infantry_O_T_infsniper0">
     <English>Sniper Team</English>
     <Chinesesimp>狙击小组</Chinesesimp>
+    <Spanish>Equipo de francotiradores</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Motorized_MTP_O_T_MotInfSection0">
     <English>Motorized Section</English>
     <Chinesesimp>机动部队</Chinesesimp>
+    <Spanish>Sección motorizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Motorized_MTP_O_T_MotInf_ATV0">
     <English>Motorized ATV Team</English>
     <Chinesesimp>全地形机动小组</Chinesesimp>
+    <Spanish>Equipo motorizado de quads</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Motorized_MTP_O_T_MotInf_HQ0">
     <English>Motorized HQ</English>
     <Chinesesimp>机动指挥部</Chinesesimp>
+    <Spanish>HQ motorizado</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Motorized_MTP_O_T_MotInf_Transport0">
     <English>Motorized Transport</English>
     <Chinesesimp>机动运输</Chinesesimp>
+    <Spanish>Transporte motorizado</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Mechanize_O_T_MechInf_Section10">
     <English>Mechanized 1st Rifle Section</English>
     <Chinesesimp>机械化第一步枪队</Chinesesimp>
+    <Spanish>1.ª sección de fusileros mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Mechanize_O_T_MechInf_Section20">
     <English>Mechanized 2nd Rifle Section</English>
     <Chinesesimp>机械化第二步枪队</Chinesesimp>
+    <Spanish>2.ª sección de fusileros mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Mechanize_O_T_MechInf_Section30">
     <English>Mechanized 3rd Rifle Section</English>
     <Chinesesimp>机械化第三步枪队</Chinesesimp>
+    <Spanish>3.ª sección de fusileros mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Mechanize_O_T_MechInf_CoyHQ0">
     <English>Mechanized Company HQ</English>
     <Chinesesimp>机械化指挥连队</Chinesesimp>
+    <Spanish>HQ de compañía mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Mechanize_O_T_MechInf_SectionAT0">
     <English>Mechanized Anti-Tank Section</English>
     <Chinesesimp>机械化反坦克部队</Chinesesimp>
+    <Spanish>Sección antitanque mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Mechanize_O_T_MechInf_SectionMG0">
     <English>Mechanized Weapons Section</English>
     <Chinesesimp>机械化步兵部队</Chinesesimp>
+    <Spanish>Sección de armas mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Air_O_T_PO30_Squadron0">
     <English>PO-30 Squadron</English>
     <Chinesesimp>PO-30中队</Chinesesimp>
+    <Spanish>Escuadrón PO-30</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Air_O_T_VTOL_Transport0">
     <English>Y-32 (VTOL) Transport</English>
     <Chinesesimp>Y-32 (垂直起降) 运输</Chinesesimp>
+    <Spanish>Transporte Y-32 (VTOL)</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Mech0">
     <English>Mechanized Infantry</English>
     <Chinesesimp>机械化运输</Chinesesimp>
+    <Spanish>Infantería mecanizada</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Air0">
     <English>Air</English>
     <Chinesesimp>空军</Chinesesimp>
+    <Spanish>Aéreo</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Naval">
     <English>Naval (Pacific)</English>
     <Chinesesimp>海军(太平洋)</Chinesesimp>
+    <Spanish>Naval (Pacífico)</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_West_BLU_T_F_Naval">
     <English>Naval (Pacific)</English>
     <Chinesesimp>海军(太平洋)</Chinesesimp>
+    <Spanish>Naval (Pacífico)</Spanish>
 </Key>
 <Key ID="STR_A3_CfgGroups_East_OPF_T_F_Naval_O_T_sentryTeam_Boat0">
     <English>Sentry Team (Speed Boat)</English>
     <Chinesesimp>巡逻队(快艇)</Chinesesimp>
+    <Spanish>Equipo centinela (lancha rápida)</Spanish>
 </Key>
         </Container>
     </Package>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -5,18 +5,22 @@
 <Key ID="STR_ALIVE_MODULE">
     <English>ALiVE Modules</English>
     <Chinesesimp>ALiVE 模块</Chinesesimp>
+    <Spanish>Módulos ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SYSTEM">
     <English>ALiVE System</English>
     <Chinesesimp>ALiVE 系统</Chinesesimp>
+    <Spanish>Sistema ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用调试:</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_DEBUG_COMMENT">
     <English>Enables Debug for ALiVE Base Systems</English>
     <Chinesesimp>对ALiVE基础系统启用调试</Chinesesimp>
+    <Spanish>Activa la depuración de los sistemas base de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_REQUIRES_ALIVE">
     <English>ALiVE (Required)</English>
@@ -33,70 +37,87 @@
 <Key ID="STR_ALIVE_REQUIRES_ALIVE_VERSIONING">
     <English>ALiVE Versioning:</English>
     <Chinesesimp>ALiVE 的版本:</Chinesesimp>
+    <Spanish>Control de versión de ALiVE:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_REQUIRES_ALIVE_VERSIONING_COMMENT">
     <English>Will output a warning or kick players on version mismatch.</English>
     <Chinesesimp>在版本不匹配时输出错误报告或将玩家踢出。</Chinesesimp>
+    <Spanish>Muestra un aviso o expulsa a los jugadores si la versión no coincide.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_DISABLESAVE">
     <English>Disable Default SP Save:</English>
     <Chinesesimp>禁用默认SP(偏好设定?)保存:</Chinesesimp>
+    <Spanish>Desactivar guardado SP por defecto:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_DISABLESAVE_COMMENT">
     <English>Default SP saving can cause out memory crashes.  Use local saving in ALiVE Data instead.</English>
     <Chinesesimp>默认SP保存可能会导致内存崩溃。使用本地保存ALiVE数据代替前者。</Chinesesimp>
+    <Spanish>El guardado SP por defecto puede provocar cierres por falta de memoria. Usa en su lugar el guardado local del módulo ALiVE Data.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_DISABLEMARKERS">
     <English>Disable Adv Markers:</English>
     <Chinesesimp>禁用高级标记:</Chinesesimp>
+    <Spanish>Desactivar marcadores avanzados:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_DISABLEMARKERS_COMMENT">
     <English>Disable persistent advanced Markers.</English>
     <Chinesesimp>禁用持久的高级标记。</Chinesesimp>
+    <Spanish>Desactiva los marcadores avanzados persistentes.</Spanish>
 </Key>
 <Key ID="STR_ALiVE_PAUSEMODULES">
     <English>Auto Pause:</English>
     <Chinesesimp>自动暂停:</Chinesesimp>
+    <Spanish>Pausa automática:</Spanish>
 </Key>
 <Key ID="STR_ALiVE_PAUSEMODULES_COMMENT">
     <English>Auto pauses vAI, AI Commander, CQB and Amb Civs if no players are on server.</English>
     <Chinesesimp>当没有玩家存在时,将自动暂停vAI、AI指挥官、CQB和Amb Civs。</Chinesesimp>
+    <Spanish>Pausa automáticamente la IA virtual, el Comandante IA, CQB y los civiles ambientales si no hay jugadores en el servidor.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_DISABLEADMINACTIONS">
     <English>Disable Admin Actions:</English>
     <Chinesesimp>禁用管理动作(Actions):</Chinesesimp>
+    <Spanish>Desactivar acciones de administrador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_DISABLEADMINACTIONS_COMMENT">
     <English>Disable the ALiVE Admin Action functions.</English>
     <Chinesesimp>禁用ALiVE管理动作功能。</Chinesesimp>
+    <Spanish>Desactiva las funciones de acciones de administrador de ALiVE.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_DISABLEPLAYERLOG">
     <English>Disable Player Logistics:</English>
     <Chinesesimp>禁用玩家后勤:</Chinesesimp>
+    <Spanish>Desactivar logística de jugador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_DISABLEPLAYERLOG_COMMENT">
     <English>Disable player logistics, such as pickup and move crates, objects etc.</English>
     <Chinesesimp>禁用玩家后勤,如拾取和移动板条箱,物品等。</Chinesesimp>
+    <Spanish>Desactiva la logística de jugador, como recoger y mover cajas, objetos, etc.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_REQUIRES_ALIVE_AI_DISTRIBUTION">
     <English>AI Distribution:</English>
     <Chinesesimp>AI智能分布:</Chinesesimp>
+    <Spanish>Distribución de IA:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_REQUIRES_ALIVE_AI_DISTRIBUTION_COMMENT">
     <English>Activates dynamic AI distribution of all AI to any available headless clients.</English>
     <Chinesesimp>激活动态AI分布,对于所有AI到任何可用的无头客户端。</Chinesesimp>
+    <Spanish>Activa la distribución dinámica de toda la IA entre los headless clients disponibles.</Spanish>
 </Key>
 <Key ID="STR_ALiVE_TABLET_MODEL">
     <English>ALiVE Tablet Model</English>
     <Chinesesimp>ALiVE 平板模型</Chinesesimp>
+    <Spanish>Modelo de tableta ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALiVE_TABLET_MODEL_COMMENT">
     <English>Model used for the ALiVE Tablet Background.</English>
     <Chinesesimp>用于ALiVE平板的背景。</Chinesesimp>
+    <Spanish>Modelo usado como fondo de la tableta ALiVE.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_REQUIRES_USAGE">
     <English>Simply place ALiVE (Required) in the editor and choose the settings as desired. Do not sync it to anything.</English>
     <Chinesesimp>只需在编辑器中放置ALiVE (必需)并根据需要选择设置。不要将它同步到任何东西。</Chinesesimp>
+    <Spanish>Simplemente coloca ALiVE (Requerido) en el editor y elige los ajustes que desees. No lo sincronices con nada.</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_MOD_LAUNCHER_ACTION">

--- a/addons/mil_ato/stringtable.xml
+++ b/addons/mil_ato/stringtable.xml
@@ -5,211 +5,271 @@
 <Key ID="STR_ALIVE_ATO">
     <English>Military Air Component Commander</English>
     <Chinesesimp>军事空军部队指挥官</Chinesesimp>
+    <Spanish>Comandante del componente aéreo militar</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_COMMENT">
     <English>Joint Forces Air Component Commander</English>
     <Chinesesimp>联合部队空中部队指挥官</Chinesesimp>
+    <Spanish>Comandante del componente aéreo de fuerzas conjuntas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用调试</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_DEBUG_COMMENT">
     <English>Verbose logging to the RPT file, plus map markers at the HQ, field HQ and hangar positions this module picks. Those markers are global - every player sees them, not just admins - and are never removed, so leave this off for live missions.</English>
+    <Spanish>Registro detallado en el archivo RPT, además de marcadores en el mapa en las posiciones del HQ, el HQ de campaña y el hangar que elija este módulo. Esos marcadores son globales (los ve todo el mundo, no solo los administradores) y no se eliminan nunca, así que déjalo desactivado en misiones reales.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_PERSISTENT">
     <English>Persistent:</English>
     <Chinesesimp>持久的</Chinesesimp>
+    <Spanish>Persistente:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_PERSISTENT_COMMENT">
     <English>Saves this module's aircraft roster - which aircraft exist and which airspace each belongs to - to the ALiVE database between sessions. Turning it on for any one MACC saves the roster for all of them. The HQ, runway overrides and any tasking in progress are never saved and are worked out fresh on every load.</English>
+    <Spanish>Guarda en la base de datos de ALiVE la lista de aeronaves de este módulo (qué aeronaves existen y a qué espacio aéreo pertenece cada una) entre sesiones. Activarlo en un solo MACC guarda la lista de todos. El HQ, las anulaciones de pista y cualquier asignación en curso no se guardan nunca y se recalculan en cada carga.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_BROADCASTONRADIO">
     <English>Radio Messages:</English>
     <Chinesesimp>无线电信息</Chinesesimp>
+    <Spanish>Mensajes de radio:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_BROADCASTONRADIO_COMMENT">
     <English>HQ radio traffic, heard only by players on this module's own side: mission acknowledged or denied, aircraft lost, and base compromised. No silences all of it except the one-off 'forward airbase established' call at mission start, which always plays.</English>
+    <Spanish>Tráfico de radio del HQ, oído solo por los jugadores del bando de este módulo: misión aceptada o denegada, aeronave perdida y base comprometida. «No» lo silencia todo salvo la llamada única de «base aérea avanzada establecida» al inicio de la misión, que siempre suena.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_DRONE_TYPES">
     <English>Drone Types:</English>
+    <Spanish>Tipos de dron:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_DRONE_TYPES_COMMENT">
     <English>Tick the drones this commander may place. Ctrl-click to select more than one. Leave everything unticked to use whatever drones the faction itself lists, which is the usual choice. Worth setting when a faction has none of its own, which is common even where the mod provides them. The list covers every drone the loaded content offers.</English>
+    <Spanish>Marca los drones que este comandante puede colocar. Ctrl+clic para seleccionar más de uno. Deja todo sin marcar para usar los drones que indique la propia facción, que es lo habitual. Conviene ajustarlo cuando una facción no tiene ninguno propio, algo frecuente incluso cuando el mod los proporciona. La lista incluye todos los drones que ofrece el contenido cargado.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_PLACE_DRONES">
     <English>Place Drones:</English>
+    <Spanish>Colocar drones:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_PLACE_DRONES_COMMENT">
     <English>Places one of the faction's drones at the base at mission start, on a helipad if there is one. Separate from Place Air Assets, so an air component can consist of drones alone. Unarmed reconnaissance drones count - they are the ones most worth having. Does nothing if Use Drones is set to No.</English>
+    <Spanish>Coloca uno de los drones de la facción en la base al inicio de la misión, en un helipuerto si lo hay. Es independiente de «Colocar medios aéreos», así que un componente aéreo puede estar formado solo por drones. Los drones de reconocimiento desarmados cuentan: son los más útiles. No hace nada si «Usar drones» está en No.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_USE_UAVS">
     <English>Use Drones:</English>
+    <Spanish>Usar drones:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_USE_UAVS_COMMENT">
     <English>Whether this commander may fly unmanned aircraft. They are adopted from the airspace like any other aircraft and need no aircrew, so a reconnaissance drone can be tasked while every pilot is busy. Set to No and drones in this airspace are left alone entirely, for anyone else to use.</English>
+    <Spanish>Si este comandante puede operar aeronaves no tripuladas. Se adoptan del espacio aéreo como cualquier otra aeronave y no necesitan tripulación, así que se puede asignar un dron de reconocimiento aunque todos los pilotos estén ocupados. Con No, los drones de este espacio aéreo se dejan intactos para que los use cualquier otro.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_SORTIE_DURATION">
     <English>Sortie Duration:</English>
+    <Spanish>Duración de la salida:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_SORTIE_DURATION_COMMENT">
     <English>Minutes a sortie is allowed to run before the aircraft is recalled, in whole minutes. This also sets how long an aircraft waits for its pilot and how long it loiters on task. Leave blank to use whatever the requesting commander asks for, which is usually 10.</English>
+    <Spanish>Minutos que puede durar una salida antes de que se llame de vuelta a la aeronave, en minutos enteros. También define cuánto espera una aeronave a su piloto y cuánto permanece en órbita sobre el objetivo. Déjalo en blanco para usar lo que pida el comandante solicitante, que suele ser 10.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_MIN_ASSETS">
     <English>Minimum Aircraft For Offensive Missions:</English>
+    <Spanish>Aeronaves mínimas para misiones ofensivas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_MIN_ASSETS_COMMENT">
     <English>Once this many aircraft or fewer remain, the commander stops flying offensive missions and keeps only Combat Air Patrol and Defensive Counter-Air until numbers recover. Leave blank for the default, which is 4 aircraft when the roster was restored from a save and 2 otherwise.</English>
+    <Spanish>Cuando queden estas aeronaves o menos, el comandante deja de volar misiones ofensivas y mantiene solo patrulla aérea de combate y contraofensiva aérea defensiva hasta que se recuperen los efectivos. Déjalo en blanco para el valor por defecto: 4 aeronaves si la lista se restauró de un guardado y 2 en caso contrario.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_MAX_CONCURRENT_SORTIES">
     <English>Maximum Concurrent Offensive Sorties:</English>
+    <Spanish>Máximo de salidas ofensivas simultáneas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_MAX_CONCURRENT_SORTIES_COMMENT">
     <English>How many offensive missions (Strike, Reconnaissance, CAS, OCA, SEAD) this commander may have running at once. Each offensive mission keeps its target present in the world until the mission ends, so this limit also bounds how many of those targets exist at any time. Requests beyond the limit are turned down and the requesting commander simply asks again later. Combat Air Patrol and Defensive Counter-Air are never limited. Leave blank for no limit.</English>
+    <Spanish>Cuántas misiones ofensivas (ataque, reconocimiento, CAS, OCA, SEAD) puede tener este comandante en curso a la vez. Cada misión ofensiva mantiene su objetivo presente en el mundo hasta que termina, así que este límite también acota cuántos de esos objetivos existen en cada momento. Las peticiones que superen el límite se rechazan y el comandante solicitante simplemente vuelve a pedirlo más tarde. La patrulla aérea de combate y la contraofensiva aérea defensiva no se limitan nunca. Déjalo en blanco para no poner límite.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_PILOTBUILDING">
     <English>Pilot Ready Room:</English>
     <Chinesesimp>飞行员准备室</Chinesesimp>
+    <Spanish>Sala de pilotos:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_PILOTBUILDING_COMMENT">
     <English>Classname of a building within 50 m of this module where replacement aircrew appear, for example Land_Cargo_House_V3_F. Leave blank to pick a nearby building automatically. A classname that matches nothing within 50 m puts the crew out in the open at the module's own position, which is worse than leaving it blank.</English>
+    <Spanish>Classname de un edificio situado a menos de 50 m de este módulo donde aparecerá la tripulación de reemplazo, por ejemplo Land_Cargo_House_V3_F. Déjalo en blanco para elegir automáticamente un edificio cercano. Un classname que no coincida con nada en 50 m deja a la tripulación a la intemperie en la posición del módulo, lo cual es peor que dejarlo en blanco.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RUNWAYSTARTPOS">
     <English>Runway start position:</English>
     <Chinesesimp>跑道起始位置:</Chinesesimp>
+    <Spanish>Posición inicial de la pista:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RUNWAYSTARTPOS_COMMENT">
     <English>Advanced override. One end of the runway centreline, format [x,y,z]. Stops other ALiVE systems placing compositions on the runway - it does not affect where aircraft take off or land. Leave blank: ALiVE detects real runways and taxiways on its own.</English>
+    <Spanish>Anulación avanzada. Un extremo del eje de pista, en formato [x,y,z]. Impide que otros sistemas de ALiVE coloquen composiciones sobre la pista; no afecta a dónde despegan o aterrizan las aeronaves. Déjalo en blanco: ALiVE detecta por sí solo las pistas y calles de rodaje reales.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RUNWAYENDPOS">
     <English>Runway end position:</English>
     <Chinesesimp>跑道终点位置:</Chinesesimp>
+    <Spanish>Posición final de la pista:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RUNWAYENDPOS_COMMENT">
     <English>Advanced override. The other end of the runway centreline, format [x,y,z]. Pairs with Runway start position - see that tooltip. Only drawn on the map when Debug is on.</English>
+    <Spanish>Anulación avanzada. El otro extremo del eje de pista, en formato [x,y,z]. Va emparejado con «Posición inicial de la pista»; consulta esa descripción. Solo se dibuja en el mapa con la depuración activada.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RUNWAYWIDTH">
     <English>Runway width:</English>
     <Chinesesimp>跑道宽度:</Chinesesimp>
+    <Spanish>Anchura de la pista:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RUNWAYWIDTH_COMMENT">
     <English>Advanced override. Width in metres of the no-placement zone around the centreline above. Leave blank if start and end position are blank. If those are set and this is not, a 24 m zone is used - the same as a vanilla runway.</English>
+    <Spanish>Anulación avanzada. Anchura en metros de la zona sin colocación alrededor del eje anterior. Déjalo en blanco si las posiciones inicial y final están en blanco. Si esas sí están definidas y esta no, se usa una zona de 24 m, la misma que una pista original del juego.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_FACTION">
     <English>Faction:</English>
     <Chinesesimp>阵营</Chinesesimp>
+    <Spanish>Facción:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_FACTION_COMMENT">
     <English>Seeds this module's aircraft list and permanently fixes its side, e.g. OPF_F. Factions from synced AI Commanders are added automatically, but only from Commanders whose side is friendly to this one; the rest are dropped without warning. An unrecognised classname does not error, it falls back to EAST. A synced Faction Compiler overrides this.</English>
+    <Spanish>Inicializa la lista de aeronaves de este módulo y fija de forma permanente su bando, p. ej. OPF_F. Las facciones de los Comandantes IA sincronizados se añaden automáticamente, pero solo las de Comandantes cuyo bando sea aliado de este; el resto se descartan sin aviso. Un classname no reconocido no da error, sino que recurre a EAST. Un Compilador de facciones sincronizado tiene prioridad sobre esto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_TYPES">
     <English>Available ATOs:</English>
     <Chinesesimp>可用的ATO</Chinesesimp>
+    <Spanish>ATO disponibles:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_TYPES_COMMENT">
     <English>Tick the air missions this commander may fly. Ctrl-click to select more than one. Suppression of Enemy Air Defences only detects anti-air sites - turn on Generate SEAD Tasks to have anything done about them. When few aircraft remain, the list is narrowed to Combat Air Patrol and Defensive Counter-Air on its own until numbers recover.</English>
+    <Spanish>Marca las misiones aéreas que puede volar este comandante. Ctrl+clic para seleccionar más de una. La supresión de defensas antiaéreas enemigas solo detecta emplazamientos antiaéreos; activa «Generar tareas SEAD» para que se haga algo con ellos. Cuando quedan pocas aeronaves, la lista se reduce solo a patrulla aérea de combate y contraofensiva aérea defensiva hasta que se recuperen los efectivos.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_AIRSPACE">
     <English>Airspace Markers:</English>
     <Chinesesimp>空域标记</Chinesesimp>
+    <Spanish>Marcadores de espacio aéreo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_AIRSPACE_COMMENT">
     <English>Marker names bounding this module's airspace, comma-separated, no spaces or quotes, e.g. marker1,marker2. Aircraft are never synced to this module: any armed aircraft of a managed faction already sitting inside one of these markers is adopted. Leave blank for the whole map. If none of the names match a real marker the module silently fails to start, so check the spelling.</English>
+    <Spanish>Nombres de los marcadores que delimitan el espacio aéreo de este módulo, separados por comas, sin espacios ni comillas, p. ej. marker1,marker2. Las aeronaves nunca se sincronizan con este módulo: se adopta cualquier aeronave armada de una facción gestionada que ya se encuentre dentro de uno de estos marcadores. Déjalo en blanco para todo el mapa. Si ninguno de los nombres corresponde a un marcador real, el módulo no arranca y no avisa, así que revisa la ortografía.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_USAGE">
     <English>Place a MACC module to provide Combat Air Patrol and Defensive Counter-Air over your airspace. Sync it to an AI Commander module to enable Recce, Strike, Close Air Support and OCA requests. A Military AI Commander module must be present somewhere in the mission or MACC will not start.</English>
+    <Spanish>Coloca un módulo MACC para proporcionar patrulla aérea de combate y contraofensiva aérea defensiva sobre tu espacio aéreo. Sincronízalo con un módulo de Comandante IA para habilitar peticiones de reconocimiento, ataque, apoyo aéreo cercano y OCA. Debe haber un módulo de Comandante IA militar en algún punto de la misión o MACC no arrancará.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_CREATE_HQ">
     <English>Build HQ If Needed:</English>
+    <Spanish>Construir HQ si hace falta:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_CREATE_HQ_COMMENT">
     <English>MACC always takes a military or headquarters building within 750 m of the module as its command post. This only decides what happens when there is none: Yes spawns a garrisoned field HQ composition, No falls back to a building at the nearest airbase with no garrison. A carrier-based MACC always uses the fallback. Either way air tasking stops while the enemy holds the ground around the HQ, and stops for good if it is destroyed.</English>
+    <Spanish>MACC siempre toma como puesto de mando un edificio militar o de cuartel general situado a menos de 750 m del módulo. Esto solo decide qué pasa cuando no hay ninguno: «Sí» genera una composición de HQ de campaña con guarnición; «No» recurre a un edificio de la base aérea más cercana sin guarnición. Un MACC embarcado siempre usa la alternativa. En cualquier caso, la asignación aérea se detiene mientras el enemigo domine el terreno alrededor del HQ, y se detiene definitivamente si este es destruido.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_PLACE_AIR">
     <English>Place Air Assets:</English>
     <Chinesesimp>放置飞行载具</Chinesesimp>
+    <Spanish>Colocar medios aéreos:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_PLACE_AIR_COMMENT">
     <English>If fewer than two armed aircraft start inside this module's airspace, extra ones are placed at the nearest airbase or helipad. Startup only - replacing later losses is what Resupply does. Has no effect on a carrier. Beware: with this off and no armed aircraft at all in the airspace, MACC never starts and nothing is tasked for the whole mission.</English>
+    <Spanish>Si al inicio hay menos de dos aeronaves armadas dentro del espacio aéreo de este módulo, se colocan más en la base aérea o helipuerto más cercano. Solo al arrancar; reponer pérdidas posteriores es cosa del Reabastecimiento. No tiene efecto en un portaaviones. Atención: con esto desactivado y sin ninguna aeronave armada en el espacio aéreo, MACC no arranca nunca y no se asigna nada en toda la misión.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_GENERATE_TASKS">
     <English>Generate Player Tasks:</English>
     <Chinesesimp>生成玩家任务</Chinesesimp>
+    <Spanish>Generar tareas de jugador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_GENERATE_TASKS_COMMENT">
     <English>Hands air missions to players as tasks, using the C2ISTAR module: search and rescue for downed aircrew, a backup interception call when several hostiles appear, and any mission with no free AI aircraft - that last only when a player is already flying the right type. AI tasking is unaffected either way; with No these are simply dropped, not held for later.</English>
+    <Spanish>Entrega misiones aéreas a los jugadores como tareas, usando el módulo C2ISTAR: búsqueda y rescate de tripulaciones derribadas, una llamada de interceptación de respaldo cuando aparecen varios hostiles, y cualquier misión sin aeronaves de IA libres (esto último solo si un jugador ya está volando el tipo adecuado). La asignación a la IA no se ve afectada en ningún caso; con «No» estas simplemente se descartan, no se guardan para después.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_GENERATE_SEADTASKS">
     <English>Generate SEAD Tasks:</English>
+    <Spanish>Generar tareas SEAD:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_GENERATE_SEADTASKS_COMMENT">
     <English>MACC does not send AI aircraft against detected anti-air sites. This only creates a player Air Tasking Order for them, and needs the C2ISTAR module. Leave this off and detected anti-air is recorded but never engaged.</English>
+    <Spanish>MACC no envía aeronaves de IA contra los emplazamientos antiaéreos detectados. Esto solo crea una orden de misión aérea para jugadores, y requiere el módulo C2ISTAR. Si lo dejas desactivado, la defensa antiaérea detectada se registra pero nunca se ataca.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RESUPPLY">
     <English>Resupply:</English>
     <Chinesesimp>重新补给</Chinesesimp>
+    <Spanish>Reabastecimiento:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RESUPPLY_COMMENT">
     <English>Replaces lost aircraft. If a Logistics Commander for the same faction is anywhere in the mission it flies the replacement in; otherwise MACC creates one itself at the original parking spot. Either way the new aircraft sits out a few minutes of maintenance before it can be tasked. With No, losses are permanent and the roster only ever shrinks.</English>
+    <Spanish>Repone las aeronaves perdidas. Si hay un Comandante de logística de la misma facción en cualquier punto de la misión, este trae el reemplazo por aire; si no, MACC lo crea él mismo en la plaza de estacionamiento original. En ambos casos la nueva aeronave pasa unos minutos en mantenimiento antes de poder ser asignada. Con «No», las pérdidas son permanentes y la lista solo se reduce.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_NOT_ESTABLISHED">
     <English>All callsigns, this is %1, %2 forward airbase has not been established. No air assets available for tasking. Out.</English>
     <Chinesesimp>所有呼号,这是%1,%2前方空军基地尚未建立。没有可用于任务的飞行载具。完毕。</Chinesesimp>
+    <Spanish>A todos los indicativos, aquí %1, la base aérea avanzada %2 no ha sido establecida. No hay medios aéreos disponibles para asignación. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_ESTABLISHED">
     <English>All callsigns, this is %1, %2 forward airbase established at grid %3, Air Tasking Orders to follow. Out.</English>
     <Chinesesimp>所有呼号,这是%1,%2前方空军基地,在网格%3建立,空中任务命令如下。完毕。</Chinesesimp>
+    <Spanish>A todos los indicativos, aquí %1, base aérea avanzada %2 establecida en la cuadrícula %3, a la espera de órdenes de misión aérea. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_UNDER_ATTACK">
     <English>All callsigns, this is %1, %2 forward airbase at grid %3 is under attack by enemy forces, request immediate support. Out.</English>
     <Chinesesimp>所有呼号,这里是%1,位于网格%3的%2前方空军基地正受到敌军的攻击,请求立即支援。完毕。</Chinesesimp>
+    <Spanish>A todos los indicativos, aquí %1, la base aérea avanzada %2 en la cuadrícula %3 está siendo atacada por fuerzas enemigas, solicitamos apoyo inmediato. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_OVERRUN">
     <English>All callsigns, this is %1, %2 forward airbase at grid %3 is compromised. Relocating to alternate. Air combat operations unavailable until further notice. Out.</English>
     <Chinesesimp>所有呼号,这是%1,位于网格%3的%2前方空军基地已被攻破。重新定位到备用位置。空战行动在另行通知前不可用。完毕。</Chinesesimp>
+    <Spanish>A todos los indicativos, aquí %1, la base aérea avanzada %2 en la cuadrícula %3 está comprometida. Nos reubicamos a la alternativa. Operaciones aéreas de combate no disponibles hasta nuevo aviso. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_REQUEST_ACKNOWLEDGED">
     <English>All callsigns, this is %1, %2 has requested %3 at grid %4. Air Tasking Order to follow. Out.</English>
     <Chinesesimp>所有呼号，这是%1, %2 已在网格 %4 请求 %3。执行空中任务命令。完毕。</Chinesesimp>
+    <Spanish>A todos los indicativos, aquí %1, %2 ha solicitado %3 en la cuadrícula %4. A la espera de la orden de misión aérea. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_UNAVAILABLE">
     <English>All callsigns, this is %1, aircraft unavailable, air combat operations suspended. Requesting replen. Out.</English>
     <Chinesesimp>所有呼号，这里是 %1 ,飞机无法使用,空战行动暂停。请求重新规划。完毕。</Chinesesimp>
+    <Spanish>A todos los indicativos, aquí %1, no hay aeronaves disponibles, operaciones aéreas de combate suspendidas. Solicitando reposición. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_REQUEST_DENIED">
     <English>All callsigns, this is %1, request for %2 at grid %3 denied. Aircraft not available. Out.</English>
     <Chinesesimp>所有呼号,这是%1,对网格%3上的%2的请求被拒绝。飞机不可用。完毕。</Chinesesimp>
+    <Spanish>A todos los indicativos, aquí %1, petición de %2 en la cuadrícula %3 denegada. No hay aeronaves disponibles. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_START">
     <English>All callsigns, this is %1, scrambling %2 on ATO %3 at grid %4. Out.</English>
     <Chinesesimp>所有呼号,这是 %1 ,正在对网格 %4 处的ATO %3 上的 %2 进行抢夺。完毕。</Chinesesimp>
+    <Spanish>A todos los indicativos, aquí %1, despegue inmediato de %2 en la ATO %3, cuadrícula %4. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_AIRCRAFT_LOST">
     <English>All callsigns, this is %1, we've lost radar contact with a %2 on %3. Out.</English>
     <Chinesesimp>所有呼号，这里是%1,我们与 %3 上的 %2 失去雷达联系。完毕。</Chinesesimp>
+    <Spanish>A todos los indicativos, aquí %1, hemos perdido el contacto por radar con un %2 en %3. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_ON_STATION">
     <English>All callsigns, this is %1, %2 on station at grid %3. Commencing %4 now. Out.</English>
     <Chinesesimp>所有呼号,我是%1,%2,位于网格%3上的电台。现在开始%4。完毕。</Chinesesimp>
+    <Spanish>A todos los indicativos, aquí %1, %2 en posición en la cuadrícula %3. Iniciando %4 ahora. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RETURN">
     <English>on %1. Air tasking complete, I am RTB. Out.</English>
     <Chinesesimp>%1。空中任务完成,这里是RTB。完毕</Chinesesimp>
+    <Spanish>en %1. Misión aérea completada, regreso a base. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RETURN_FUEL">
     <English>Bingo fuel, I am RTB. Out.</English>
     <Chinesesimp>油量已达最低限度,这里RTB。完毕。</Chinesesimp>
+    <Spanish>Combustible mínimo, regreso a base. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RETURN_AMMO">
     <English>Winchester, I am RTB. Out.</English>
     <Chinesesimp>温彻斯特,这里是RTB,完毕。</Chinesesimp>
+    <Spanish>Sin munición, regreso a base. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_RETURN_DAMAGE">
     <English>We've been hit, critical damage sustained, I am RTB. Out.</English>
     <Chinesesimp>我们被击中了,受到严重伤害,我是RTB。完毕。</Chinesesimp>
+    <Spanish>Nos han alcanzado, daños críticos, regreso a base. Corto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ATO_MISSION_COMPLETE">
     <English>All callsigns, this is %1, %2 is back at base, %3 mission complete. Out.</English>
     <Chinesesimp>所有呼号,这是 %1 , %2 已返回基地, %3 任务完成。完毕。</Chinesesimp>
+    <Spanish>A todos los indicativos, aquí %1, %2 ha regresado a la base, misión %3 completada. Corto.</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/mil_c2istar/stringtable.xml
+++ b/addons/mil_c2istar/stringtable.xml
@@ -125,9 +125,11 @@
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_C2ISTAR_AUTO_PLAYER_TASKS">
     <English>Automatic Player Tasks:</English>
+    <Spanish>Tareas automáticas de jugador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_C2ISTAR_AUTO_PLAYER_TASKS_COMMENT">
     <English>Whether players are given tasks they did not ask for. Set to No and nothing arrives unprompted from anywhere in ALiVE: no rescues, air taskings, counter battery, convoy protection or commander orders. Orders a player requests from the tablet still work. Each module keeps its own setting for silencing just that source; this one covers them all, including anything added later. Can also be turned on and off during a mission from the commander menu.</English>
+    <Spanish>Si los jugadores reciben tareas que no han pedido. Con «No» no llega nada sin solicitar desde ninguna parte de ALiVE: ni rescates, ni asignaciones aéreas, ni contrabatería, ni protección de convoyes, ni órdenes del comandante. Las órdenes que un jugador pida desde la tableta siguen funcionando. Cada módulo mantiene su propio ajuste para silenciar solo esa fuente; este los cubre todos, incluidos los que se añadan en el futuro. También se puede activar y desactivar durante la misión desde el menú del comandante.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_C2ISTAR_AUTOGEN_BLUFOR">
     <English>Auto Task BLU:</English>
@@ -460,21 +462,27 @@
 </Key>
 <Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_ALLOW_PLAYER_OBJECTIVES">
     <English>Allow Player Objectives:</English>
+    <Spanish>Permitir objetivos de jugador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_ALLOW_PLAYER_OBJECTIVES_COMMENT">
     <English>Allow players to designate, cancel and reprioritise commander objectives from the Operations tablet view</English>
+    <Spanish>Permite a los jugadores designar, cancelar y repriorizar objetivos del comandante desde la vista de Operaciones de la tableta</Spanish>
 </Key>
 <Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_OBJECTIVE_COOLDOWN">
     <English>Player Objective Cooldown:</English>
+    <Spanish>Espera entre objetivos de jugador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_OBJECTIVE_COOLDOWN_COMMENT">
     <English>Seconds a player must wait between designating objectives</English>
+    <Spanish>Segundos que un jugador debe esperar entre designaciones de objetivos</Spanish>
 </Key>
 <Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_MAX_PLAYER_OBJECTIVES">
     <English>Max Player Objectives:</English>
+    <Spanish>Máx. objetivos de jugador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_C2ISTAR_SCOM_OPS_MAX_PLAYER_OBJECTIVES_COMMENT">
     <English>Maximum simultaneous player-designated objectives per side</English>
+    <Spanish>Número máximo de objetivos designados por jugadores simultáneos por bando</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_C2ISTAR_SCOM_INTEL_LIMIT">

--- a/addons/mil_convoy/stringtable.xml
+++ b/addons/mil_convoy/stringtable.xml
@@ -5,37 +5,46 @@
 <Key ID="STR_ALIVE_CONVOY">
     <English>MIlitary Convoy's - DEPRECIATED! REMOVE FROM YOUR MISSIONS</English>
     <Chinesesimp>军事车队-弃用！从任务中删除</Chinesesimp>
+    <Spanish>Convoyes militares - ¡OBSOLETO! ELIMÍNALO DE TUS MISIONES</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CONVOY_COMMENT">
     <English>Military Convoy Module - DEPRECIATED! REMOVE FROM YOUR MISSIONS</English>
     <Chinesesimp>军事车队模块-已弃用！从任务中删除</Chinesesimp>
+    <Spanish>Módulo de convoyes militares - ¡OBSOLETO! ELIMÍNALO DE TUS MISIONES</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CONVOY_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用调试：</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CONVOY_DEBUG_COMMENT">
     <English>Enables CONVOY Module Debug</English>
     <Chinesesimp>启用CONVOY模块调试</Chinesesimp>
+    <Spanish>Activa la depuración del módulo CONVOY</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CONVOY_INTENSITY">
     <English>Convoy Intensity</English>
     <Chinesesimp>车队强度</Chinesesimp>
+    <Spanish>Intensidad de convoyes</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CONVOY_INTENSITY_DESC">
     <English>Intensity setting of convoys - Low\Med\High</English>
     <Chinesesimp>车队强度设置-低\中\高</Chinesesimp>
+    <Spanish>Ajuste de intensidad de los convoyes - Baja\Media\Alta</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CONVOY_FACTIONS">
     <English>Convoy Faction</English>
     <Chinesesimp>车队派别</Chinesesimp>
+    <Spanish>Facción del convoy</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CONVOY_FACTIONS_COMMENT">
     <English>Faction of Convoy's! Will be overridden if synced to an OPCOM!</English>
     <Chinesesimp>车队的势力!如果同步到OPCOM,将被覆盖!</Chinesesimp>
+    <Spanish>¡Facción de los convoyes! ¡Se ignorará si está sincronizado con un OPCOM!</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CONV_ERROR1">
     <English>Only one Convoy module can be used</English>
     <Chinesesimp>只能使用一个车队模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de convoyes</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/mil_intelligence/stringtable.xml
+++ b/addons/mil_intelligence/stringtable.xml
@@ -5,77 +5,96 @@
 <Key ID="STR_ALIVE_MI">
     <English>Military Intelligence - DEPRECIATED! REMOVE FROM YOUR MISSIONS</English>
     <Chinesesimp>军事情报 - 已弃用! 从任务中移除</Chinesesimp>
+    <Spanish>Inteligencia militar - ¡OBSOLETO! ELIMÍNALO DE TUS MISIONES</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_COMMENT">
     <English>Strategic Military Intelligence - DEPRECIATED! REMOVE FROM YOUR MISSIONS</English>
     <Chinesesimp>战略军事情报 - 已弃用！从任务中移除</Chinesesimp>
+    <Spanish>Inteligencia militar estratégica - ¡OBSOLETO! ELIMÍNALO DE TUS MISIONES</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用调试:</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_DEBUG_COMMENT">
     <English>Enables MI Module Debug</English>
     <Chinesesimp>启用MI模块调试</Chinesesimp>
+    <Spanish>Activa la depuración del módulo MI</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_INTEL_CHANCE">
     <English>Intel Coverage:</English>
     <Chinesesimp>情报覆盖范围:</Chinesesimp>
+    <Spanish>Cobertura de inteligencia:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_INTEL_CHANCE_COMMENT">
     <English>Amount of intel reports generated</English>
     <Chinesesimp>生成的情报报告数量</Chinesesimp>
+    <Spanish>Cantidad de informes de inteligencia generados</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_INTEL_CHANCE_LOW">
     <English>Low coverage of intel</English>
     <Chinesesimp>低情报覆盖率</Chinesesimp>
+    <Spanish>Cobertura de inteligencia baja</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_INTEL_CHANCE_MEDIUM">
     <English>Medium coverage of intel</English>
     <Chinesesimp>中情报覆盖率</Chinesesimp>
+    <Spanish>Cobertura de inteligencia media</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_INTEL_CHANCE_HIGH">
     <English>High coverage of intel</English>
     <Chinesesimp>高情报覆盖率</Chinesesimp>
+    <Spanish>Cobertura de inteligencia alta</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_INTEL_CHANCE_TOTAL">
     <English>Total coverage of intel</English>
     <Chinesesimp>情报总覆盖范围</Chinesesimp>
+    <Spanish>Cobertura de inteligencia total</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_FRIENDLY_INTEL">
     <English>Friendly Coverage:</English>
     <Chinesesimp>友方覆盖范围:</Chinesesimp>
+    <Spanish>Cobertura aliada:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_FRIENDLY_INTEL_COMMENT">
     <English>Display nearby friendly units</English>
     <Chinesesimp>显示附近的友军单位</Chinesesimp>
+    <Spanish>Muestra las unidades aliadas cercanas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_FRIENDLY_INTEL_RADIUS">
     <English>Friendly Radius:</English>
     <Chinesesimp>友方半径:</Chinesesimp>
+    <Spanish>Radio aliado:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_FRIENDLY_INTEL_RADIUS_COMMENT">
     <English>Display friendly units within this radius around players</English>
     <Chinesesimp>显示此玩家周围半径内的友军单位</Chinesesimp>
+    <Spanish>Muestra las unidades aliadas dentro de este radio alrededor de los jugadores</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MI_USAGE">
     <English>place 1 Mil_Int module only per mission. Select the level of detail and frequency of intel received in the options. It is also possible to show Friendly Intel to track units friendly to players.</English>
     <Chinesesimp>每个任务只放置1个Mil_Int模块. 在选项中选择接收情报的详细级别和频率. 也可以显示友军情报来追踪友军单位.</Chinesesimp>
+    <Spanish>Coloca solo un módulo Mil_Int por misión. Selecciona en las opciones el nivel de detalle y la frecuencia de la inteligencia recibida. También es posible mostrar inteligencia aliada para seguir a las unidades amigas de los jugadores.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SD">
     <English>Military Sector Display - DEPRECIATED! REMOVE FROM YOUR MISSIONS</English>
     <Chinesesimp>军事部门显示 - 已弃用！ 从任务中移除</Chinesesimp>
+    <Spanish>Visualización de sectores militares - ¡OBSOLETO! ELIMÍNALO DE TUS MISIONES</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SD_RUN_EVERY">
     <English>Update time</English>
     <Chinesesimp>更新时间</Chinesesimp>
+    <Spanish>Intervalo de actualización</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SD_RUN_EVERY_COMMENT">
     <English>Update sector markings every number of minutes entered</English>
     <Chinesesimp>每隔数分钟更新区域标记</Chinesesimp>
+    <Spanish>Actualiza las marcas de sector cada tantos minutos como se indiquen</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PSD">
     <English>Player Sector Display - DEPRECIATED! REMOVE FROM YOUR MISSIONS</English>
     <Chinesesimp>玩家区域显示 - 已弃用! 从任务中移除</Chinesesimp>
+    <Spanish>Visualización de sectores de jugador - ¡OBSOLETO! ELIMÍNALO DE TUS MISIONES</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/mil_placement_custom/stringtable.xml
+++ b/addons/mil_placement_custom/stringtable.xml
@@ -5,38 +5,47 @@
 <Key ID="STR_ALIVE_CMP">
     <English>Military Placement (Cust. Obj.)</English>
     <Chinesesimp>军事布局</Chinesesimp>
+    <Spanish>Colocación militar (obj. personalizado)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_COMMENT">
     <English>Custom Military Objective</English>
     <Chinesesimp>自定义军事目标</Chinesesimp>
+    <Spanish>Objetivo militar personalizado</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用测试</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_DEBUG_COMMENT">
     <English>Enables CMP Module Debug</English>
     <Chinesesimp>启用CMP模块调试</Chinesesimp>
+    <Spanish>Activa la depuración del módulo CMP</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_FACTION">
     <English>Force Faction:</English>
     <Chinesesimp>武力势力</Chinesesimp>
+    <Spanish>Facción de la fuerza:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_FACTION_COMMENT">
     <English>Faction of the units to be placed (BLU_F, OPF_F, IND_F, BLU_G_F)</English>
     <Chinesesimp>待放置单元的系数(BLU_F、OPF_F、IND_F、BLU_G_F)</Chinesesimp>
+    <Spanish>Facción de las unidades que se van a colocar (BLU_F, OPF_F, IND_F, BLU_G_F)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_PRIORITY">
     <English>Objective priority:</English>
     <Chinesesimp>目标优先级</Chinesesimp>
+    <Spanish>Prioridad del objetivo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_PRIORITY_COMMENT">
     <English>Priority of the custom objective. Used by OPCOM and others for target evaluation</English>
     <Chinesesimp>自定义目标的优先级,用于OPCOM和其他目标评估</Chinesesimp>
+    <Spanish>Prioridad del objetivo personalizado. La usan OPCOM y otros para evaluar objetivos</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_SIZE">
     <English>Objective size:</English>
     <Chinesesimp>目标大小</Chinesesimp>
+    <Spanish>Tamaño del objetivo:</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_CMP_SIZE_COMMENT">
@@ -51,34 +60,42 @@
 <Key ID="STR_ALIVE_CMP_CUSTOM_INFANTRY_COUNT">
     <English>Infantry Count:</English>
     <Chinesesimp>步兵计数</Chinesesimp>
+    <Spanish>Cantidad de infantería:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_CUSTOM_INFANTRY_COUNT_COMMENT">
     <English>Set count of Infantry groups to be spawned, set to 0 for none</English>
     <Chinesesimp>设置要生成的步兵组计数,如果没有则设置为0</Chinesesimp>
+    <Spanish>Define cuántos grupos de infantería se generan; 0 para ninguno</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_CUSTOM_MOTORISED_COUNT">
     <English>Motorised Count:</English>
     <Chinesesimp>摩托化小组计数</Chinesesimp>
+    <Spanish>Cantidad de motorizados:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_CUSTOM_MOTORISED_COUNT_COMMENT">
     <English>Set count of Motorised groups to be spawned, set to 0 for none</English>
     <Chinesesimp>设置要生成的摩托化小组的计数,如果没有,则设置为0</Chinesesimp>
+    <Spanish>Define cuántos grupos motorizados se generan; 0 para ninguno</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_CUSTOM_MECHANISED_COUNT">
     <English>Mechanised Count:</English>
     <Chinesesimp>机械化小组计数</Chinesesimp>
+    <Spanish>Cantidad de mecanizados:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_CUSTOM_MECHANISED_COUNT_COMMENT">
     <English>Set count of Mechanised groups to be spawned, set to 0 for none</English>
     <Chinesesimp>设置要生成的机械化小组的计数,如果没有,则设置为0</Chinesesimp>
+    <Spanish>Define cuántos grupos mecanizados se generan; 0 para ninguno</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_CUSTOM_ARMOUR_COUNT">
     <English>Armour Count:</English>
     <Chinesesimp>装甲小组计数</Chinesesimp>
+    <Spanish>Cantidad de blindados:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_CUSTOM_ARMOUR_COUNT_COMMENT">
     <English>Set count of Armour groups to be spawned, set to 0 for none</English>
     <Chinesesimp>设置要生成的装甲小组计数,如果没有则设置为0</Chinesesimp>
+    <Spanish>Define cuántos grupos blindados se generan; 0 para ninguno</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_CMP_CUSTOM_ARTILLERY_COUNT">
@@ -163,10 +180,12 @@
 <Key ID="STR_ALIVE_CMP_CUSTOM_SPECOPS_COUNT">
     <English>SpecOps Count:</English>
     <Chinesesimp>特战小组计数</Chinesesimp>
+    <Spanish>Cantidad de fuerzas especiales:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_CUSTOM_SPECOPS_COUNT_COMMENT">
     <English>Set count of SpecOps groups to be spawned, set to 0 for none</English>
     <Chinesesimp>设置要生成的特战小组计数,如果没有则设置为0</Chinesesimp>
+    <Spanish>Define cuántos grupos de fuerzas especiales se generan; 0 para ninguno</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_CMP_HDR_ANTIAIR">
@@ -261,42 +280,52 @@
 <Key ID="STR_ALIVE_CMP_COMPOSITION">
     <English>Spawn Composition:</English>
     <Chinesesimp>平民放置</Chinesesimp>
+    <Spanish>Composición a generar:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_COMPOSITION_COMMENT">
     <English>Multi-select listbox of compositions valid for the module's faction (Military for WEST/EAST, Guerrilla for RESISTANCE). At spawn time the validator tries the ticked compositions in shuffled order at three search tiers (50m / 150m / 300m) and uses the first that fits the surrounding terrain, so a tight site can still get a spawn from an alternative pick in the pool. The Override field accepts free-text class names for mod compositions the listbox doesn't surface. Empty selection = no composition spawn. Multi-select: Ctrl+click toggles individual rows, Shift+click selects a range, plain click replaces with just that one row.</English>
     <Chinesesimp>输入组合的类型(总部,要塞,直升机机场等)或者组合类名</Chinesesimp>
+    <Spanish>Lista de selección múltiple con las composiciones válidas para la facción del módulo (militares para WEST/EAST, guerrilla para RESISTANCE). Al generar, el validador prueba las composiciones marcadas en orden aleatorio con tres niveles de búsqueda (50 m / 150 m / 300 m) y usa la primera que encaje en el terreno circundante, de modo que un emplazamiento estrecho todavía puede recibir una alternativa del conjunto. El campo de anulación acepta texto libre con classnames de composiciones de mods que la lista no muestre. Sin selección = no se genera composición. Selección múltiple: Ctrl+clic activa o desactiva filas concretas, Mayús+clic selecciona un rango y un clic normal deja seleccionada solo esa fila.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_COMPOSITION_BIS_A">
     <English>BIS - Camp Audacity</English>
     <Chinesesimp>BIS-Audacity营地</Chinesesimp>
+    <Spanish>BIS - Campamento Audacity</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_COMPOSITION_BIS_B">
     <English>BIS - Camp Bravery</English>
     <Chinesesimp>BIS-Bravery营地</Chinesesimp>
+    <Spanish>BIS - Campamento Bravery</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_COMPOSITION_BIS_C">
     <English>BIS - Camp Courage</English>
     <Chinesesimp>BIS-Courage营地</Chinesesimp>
+    <Spanish>BIS - Campamento Courage</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_COMPOSITION_BIS_D">
     <English>BIS - Camp Defiance</English>
     <Chinesesimp>BIS-Defiance营地</Chinesesimp>
+    <Spanish>BIS - Campamento Defiance</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_COMPOSITION_BIS_E">
     <English>BIS - Camp Endurance</English>
     <Chinesesimp>BIS-Endurance营地</Chinesesimp>
+    <Spanish>BIS - Campamento Endurance</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_COMPOSITION_BIS_F">
     <English>BIS - Camp Fortitude</English>
     <Chinesesimp>BIS-Fortitude营地</Chinesesimp>
+    <Spanish>BIS - Campamento Fortitude</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_CREATE_HQ">
     <English>Create as HQ:</English>
     <Chinesesimp>创建为总部</Chinesesimp>
+    <Spanish>Crear como HQ:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_CREATE_HQ_COMMENT">
     <English>Selects HQ objective close to the module or if unavailable spawns an HQ composition at the module position</English>
     <Chinesesimp>选择模块附近的总部目标,或者如果不可用,则在模块位置生成总部合成</Chinesesimp>
+    <Spanish>Selecciona un objetivo de HQ cercano al módulo o, si no hay ninguno disponible, genera una composición de HQ en la posición del módulo</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_CMP_CREATE_FIELD_HQ">
@@ -330,17 +359,21 @@
 <Key ID="STR_ALIVE_CMP_READINESS_LEVEL">
     <English>Readiness:</English>
     <Chinesesimp>准备就绪:</Chinesesimp>
+    <Spanish>Nivel de alerta:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_READINESS_LEVEL_COMMENT">
     <English>The amount of troops that will be on duty and patrolling</English>
     <Chinesesimp>即将执勤和巡逻的部队数量</Chinesesimp>
+    <Spanish>Cantidad de tropas que estarán de servicio y patrullando</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_ALLOW_PLAYER_TASK">
     <English>Allow player tasking:</English>
     <Chinesesimp>允许玩家任务:</Chinesesimp>
+    <Spanish>Permitir tareas de jugador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CMP_ALLOW_PLAYER_TASK_COMMENT">
     <English>MilAssault/MilDefend C2ISTAR tasks</English>
     <Chinesesimp>C2ISTAR军事进攻/军事防御任务</Chinesesimp>
+    <Spanish>Tareas C2ISTAR MilAssault/MilDefend</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/mil_placement_spe/stringtable.xml
+++ b/addons/mil_placement_spe/stringtable.xml
@@ -5,22 +5,27 @@
 <Key ID="STR_ALIVE_SPEMP">
     <English>Military Placement (Garrison Obj.)</English>
     <Chinesesimp>军事布局</Chinesesimp>
+    <Spanish>Colocación militar (obj. de guarnición)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_COMMENT">
     <English>Custom Military Objective</English>
     <Chinesesimp>自定义军事目标</Chinesesimp>
+    <Spanish>Objetivo militar personalizado</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用测试</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_DEBUG_COMMENT">
     <English>Enables SPEMP Module Debug</English>
     <Chinesesimp>启用CMP模块调试</Chinesesimp>
+    <Spanish>Activa la depuración del módulo SPEMP</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_FACTION">
     <English>Force Faction:</English>
     <Chinesesimp>武力势力</Chinesesimp>
+    <Spanish>Facción de la fuerza:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_FACTION_COMMENT">
     <English>Faction of the units to be placed. To use a faction of your own, sync a Custom Faction Compiler module rather than choosing from this list.</English>
@@ -34,50 +39,62 @@
 <Key ID="STR_ALIVE_SPEMP_PRIORITY">
     <English>Objective priority:</English>
     <Chinesesimp>目标优先级</Chinesesimp>
+    <Spanish>Prioridad del objetivo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_PRIORITY_COMMENT">
     <English>Priority of the custom objective. Used by OPCOM and others for target evaluation</English>
     <Chinesesimp>自定义目标的优先级,用于OPCOM和其他目标评估</Chinesesimp>
+    <Spanish>Prioridad del objetivo personalizado. La usan OPCOM y otros para evaluar objetivos</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_SIZE">
     <English>Objective size:</English>
     <Chinesesimp>目标大小</Chinesesimp>
+    <Spanish>Tamaño del objetivo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_SIZE_COMMENT">
     <English>Size of the custom objective. Used by OPCOM and others for target evaluation</English>
     <Chinesesimp>自定义目标的大小。用于OPCOM和其他目标评估</Chinesesimp>
+    <Spanish>Tamaño del objetivo personalizado. Lo usan OPCOM y otros para evaluar objetivos</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_CUSTOM_INFANTRY_CLASS">
     <English>Infantry Group Classname:</English>
     <Chinesesimp>小组类名</Chinesesimp>
+    <Spanish>Classname del grupo de infantería:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_CUSTOM_INFANTRY_BEHAVIOUR">
     <English>Infantry Group AI Behaviour:</English>
     <Chinesesimp>小组AI行为</Chinesesimp>
+    <Spanish>Comportamiento de IA del grupo de infantería:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_CUSTOM_INFANTRY_BEHAVIOUR_COMMENT">
     <English>A group's behaviour determines how it is units move from one point to another, behave when idle, and how they engage an enemy.</English>
     <Chinesesimp>一个团队的行为决定了它的单位如何从一个点移动到另一个点，空闲时的行为，以及他们如何与敌人交战</Chinesesimp>
+    <Spanish>El comportamiento de un grupo determina cómo se desplazan sus unidades de un punto a otro, cómo actúan cuando están inactivas y cómo entran en combate.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_CUSTOM_INFANTRY_CLASS_COMMENT">
     <English>Set classname of Infantry group to be spawned, set to empty for random. If vehicle classname is set, this will be ignored.</English>
     <Chinesesimp>设置要生成的步兵组的类名，随机设置为空。如果设置了车辆类名，这个将被忽略。</Chinesesimp>
+    <Spanish>Define el classname del grupo de infantería que se va a generar; déjalo vacío para uno aleatorio. Si se define un classname de vehículo, este se ignora.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_CUSTOM_VEHICLE_CLASS">
     <English>Vehicle Classname:</English>
     <Chinesesimp>载具类名</Chinesesimp>
+    <Spanish>Classname del vehículo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_CUSTOM_VEHICLE_CLASS_COMMENT">
     <English>Set classname of Vehicle to be spawned. If empty, Infantry group will be spawned.</English>
     <Chinesesimp>设置要生成的载具的类名。如果是空的，则会生成步兵组。</Chinesesimp>
+    <Spanish>Define el classname del vehículo que se va a generar. Si está vacío, se generará un grupo de infantería.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_CUSTOM_VEHICLE_EMPTY">
     <English>Spawn Vehicle Uncrewed:</English>
     <Chinesesimp>生成无人载具</Chinesesimp>
+    <Spanish>Generar vehículo sin tripulación:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_CUSTOM_VEHICLE_EMPTY_COMMENT">
     <English>If set to no, vehicle will be spawned with AI crew.</English>
     <Chinesesimp>如果设置为否，载具将拥有AI成员</Chinesesimp>
+    <Spanish>Si se establece en no, el vehículo se generará con tripulación de IA.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_USAGE">
     <English>Place the Spearhead Custom Military Objective module in the editor and set the size, priority and force you want. Choose the faction from the list. To use a faction of your own, sync a Custom Faction Compiler module to this one and its faction is used instead.</English>
@@ -91,9 +108,11 @@
 <Key ID="STR_ALIVE_SPEMP_ALLOW_PLAYER_TASK">
     <English>Allow player tasking:</English>
     <Chinesesimp>允许玩家任务:</Chinesesimp>
+    <Spanish>Permitir tareas de jugador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SPEMP_ALLOW_PLAYER_TASK_COMMENT">
     <English>MilAssault/MilDefend C2ISTAR tasks</English>
     <Chinesesimp>C2ISTAR军事进攻/军事防御任务</Chinesesimp>
+    <Spanish>Tareas C2ISTAR MilAssault/MilDefend</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sup_artillery/stringtable.xml
+++ b/addons/sup_artillery/stringtable.xml
@@ -5,10 +5,12 @@
 <Key ID="STR_ALIVE_ARTILLERY">
     <English>Player Combat Support (Artillery)</English>
     <Chinesesimp>玩家战斗支援(火炮)</Chinesesimp>
+    <Spanish>Apoyo de combate para jugadores (artillería)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_COMMENT">
     <English>Artillery Module for ALiVE Combat Support</English>
     <Chinesesimp>用于ALiVE作战支持的火炮模块</Chinesesimp>
+    <Spanish>Módulo de artillería para el apoyo de combate de ALiVE</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_ARTILLERY_USAGE">
@@ -23,10 +25,12 @@
 <Key ID="STR_ALIVE_ARTILLERY_CALLSIGN">
     <English>Callsign</English>
     <Chinesesimp>呼号</Chinesesimp>
+    <Spanish>Indicativo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_CALLSIGN_DESC">
     <English>Enter the Callsign, ensure that it is unique</English>
     <Chinesesimp>输入呼号，确保它是唯一的</Chinesesimp>
+    <Spanish>Introduce el indicativo; asegúrate de que sea único</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_ARTILLERY_TYPE">
@@ -71,38 +75,47 @@
 <Key ID="STR_ALIVE_ARTILLERY_HE">
     <English>Number of HE Rounds</English>
     <Chinesesimp>高爆弹数量</Chinesesimp>
+    <Spanish>Número de proyectiles HE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_HE_DESC">
     <English>Set the number of rounds of HE available for the asset - Used by all Arty\Mortar Assets</English>
     <Chinesesimp>设置物资可用的高爆弹数量 - 由所有火炮\迫击炮使用</Chinesesimp>
+    <Spanish>Define cuántos proyectiles HE tiene disponibles el medio - Lo usan todos los medios de artillería\mortero</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_ILLUM">
     <English>Number of ILLUM Rounds</English>
     <Chinesesimp>照明弹数量</Chinesesimp>
+    <Spanish>Número de proyectiles de iluminación</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_ILLUM_DESC">
     <English>Set the number of rounds of ILLUM available for the asset - Used by all Arty\Mortar Assets</English>
     <Chinesesimp>设置物资可用的照明弹数量 - 由所有火炮\迫击炮使用</Chinesesimp>
+    <Spanish>Define cuántos proyectiles de iluminación tiene disponibles el medio - Lo usan todos los medios de artillería\mortero</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_SMOKE">
     <English>Number of SMOKE Rounds</English>
     <Chinesesimp>烟雾弹数量</Chinesesimp>
+    <Spanish>Número de proyectiles de humo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_SMOKE_DESC">
     <English>Set the number of rounds of SMOKE available for the asset - Used by all Arty\Mortar Assets</English>
     <Chinesesimp>设置物资可用的烟雾弹数量 - 由所有火炮\迫击炮使用</Chinesesimp>
+    <Spanish>Define cuántos proyectiles de humo tiene disponibles el medio - Lo usan todos los medios de artillería\mortero</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_WP">
     <English>Number of WP Rounds</English>
     <Chinesesimp>白磷弹数量</Chinesesimp>
+    <Spanish>Número de proyectiles de fósforo blanco</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_ARTILLERY_WP_DESC">
     <English>Set the number of White Phosphorus rounds available for the asset. Only a gun that carries WP will offer it - most artillery has none, and vanilla artillery has none at all.</English>
+    <Spanish>Define cuántos proyectiles de fósforo blanco tiene disponibles el medio. Solo lo ofrecerá una pieza que lleve fósforo blanco: la mayoría de la artillería no tiene, y la artillería original del juego no tiene ninguno.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_GUIDED">
     <English>Number of GUIDED Rounds</English>
     <Chinesesimp>制导导弹数量</Chinesesimp>
+    <Spanish>Número de proyectiles guiados</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_ARTILLERY_GUIDED_DESC">
@@ -117,46 +130,57 @@
 <Key ID="STR_ALIVE_ARTILLERY_CLUSTER">
     <English>Number of CLUSTER Rounds</English>
     <Chinesesimp>子母弹数量</Chinesesimp>
+    <Spanish>Número de proyectiles de racimo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_CLUSTER_DESC">
     <English>Set the number of rounds of CLUSTERS available for the asset - Only used by MBT</English>
     <Chinesesimp>设置物资可用的子母弹数量 - 仅主战坦克使用</Chinesesimp>
+    <Spanish>Define cuántos proyectiles de racimo tiene disponibles el medio - Solo lo usa el MBT</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_LG">
     <English>Number of Laser Guided Rounds</English>
     <Chinesesimp>激光制导导弹数量</Chinesesimp>
+    <Spanish>Número de proyectiles guiados por láser</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_LG_DESC">
     <English>Set the number of rounds of LG available for the asset - Only used by MBT</English>
     <Chinesesimp>设置物资可用的激光制导导弹数量 - 仅主战坦克使用</Chinesesimp>
+    <Spanish>Define cuántos proyectiles guiados por láser tiene disponibles el medio - Solo lo usa el MBT</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_MINE">
     <English>Number of MINE Rounds</English>
     <Chinesesimp>布雷弹数量</Chinesesimp>
+    <Spanish>Número de proyectiles de minas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_MINE_DESC">
     <English>Set the number of rounds of MINE available for the asset - Only used by MBT</English>
     <Chinesesimp>设置物资可用的布雷弹数量 - 仅主战坦克使用</Chinesesimp>
+    <Spanish>Define cuántos proyectiles de minas tiene disponibles el medio - Solo lo usa el MBT</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_ATMINE">
     <English>Number of AT MINE Rounds</English>
     <Chinesesimp>反坦克布雷弹数量</Chinesesimp>
+    <Spanish>Número de proyectiles de minas AT</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_ATMINE_DESC">
     <English>Set the number of rounds of AT MINES available for the asset - Only used by MBT</English>
     <Chinesesimp>设置物资可用的反坦克布雷弹数量 - 仅主战坦克使用</Chinesesimp>
+    <Spanish>Define cuántos proyectiles de minas AT tiene disponibles el medio - Solo lo usa el MBT</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_ROCKETS">
     <English>Number of ROCKET Rounds</English>
     <Chinesesimp>火箭弹数量</Chinesesimp>
+    <Spanish>Número de cohetes</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_ROCKETS_DESC">
     <English>Set the number of rounds of 230mm Titan Missile available for the asset - Only used by MLRS</English>
     <Chinesesimp>设置物资可用的230毫米泰坦导弹数量 - 仅多管火箭发射系统使用</Chinesesimp>
+    <Spanish>Define cuántos misiles Titan de 230 mm tiene disponibles el medio - Solo lo usa el MLRS</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ARTILLERY_CODE">
     <English>Code</English>
     <Chinesesimp>代码</Chinesesimp>
+    <Spanish>Código</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_ARTILLERY_CODE_DESC">

--- a/addons/sup_cas/stringtable.xml
+++ b/addons/sup_cas/stringtable.xml
@@ -5,10 +5,12 @@
 <Key ID="STR_ALIVE_CAS">
     <English>Player Combat Support (CAS)</English>
     <Chinesesimp>玩家战斗支援 (CAS)</Chinesesimp>
+    <Spanish>Apoyo de combate para jugadores (CAS)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CAS_COMMENT">
     <English>CAS Module for ALiVE Combat Support</English>
     <Chinesesimp>CAS模块用于实时战斗支援</Chinesesimp>
+    <Spanish>Módulo CAS para el apoyo de combate de ALiVE</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_CAS_USAGE">
@@ -23,14 +25,17 @@
 <Key ID="STR_ALIVE_CAS_CALLSIGN">
     <English>Callsign</English>
     <Chinesesimp>呼号</Chinesesimp>
+    <Spanish>Indicativo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CAS_CALLSIGN_DESC">
     <English>Enter the Callsign, ensure that it is unique</English>
     <Chinesesimp>输入呼号，确保它是唯一的</Chinesesimp>
+    <Spanish>Introduce el indicativo; asegúrate de que sea único</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CAS_TYPE">
     <English>CAS Vehicle Type</English>
     <Chinesesimp>CAS 载具类型</Chinesesimp>
+    <Spanish>Tipo de vehículo CAS</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_CAS_TYPE_DESC">
@@ -85,6 +90,7 @@
 <Key ID="STR_ALIVE_CAS_CODE">
     <English>Code</English>
     <Chinesesimp>代码</Chinesesimp>
+    <Spanish>Código</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_CAS_CODE_DESC">

--- a/addons/sup_combatsupport/stringtable.xml
+++ b/addons/sup_combatsupport/stringtable.xml
@@ -5,10 +5,12 @@
 <Key ID="STR_ALIVE_COMBATSUPPORT">
     <English>Player Combat Support</English>
     <Chinesesimp>玩家战斗支持</Chinesesimp>
+    <Spanish>Apoyo de combate para jugadores</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CS_COMMENT">
     <English>ALiVE Combat Support System (CAS/Artillery/Transport)</English>
     <Chinesesimp>现役作战支持系统（空对地/火炮/运输）</Chinesesimp>
+    <Spanish>Sistema de apoyo de combate de ALiVE (CAS/artillería/transporte)</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_CS_ALLOW">
@@ -53,6 +55,7 @@
 <Key ID="STR_ALIVE_CAS_LIMIT">
     <English>CAS Respawn Limit:</English>
     <Chinesesimp>空中支援限额</Chinesesimp>
+    <Spanish>Límite de reaparición de CAS:</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_TRANS_LIMIT_COMMENT">
@@ -107,14 +110,17 @@
 <Key ID="STR_ALIVE_CS_AUDIO">
     <English>Radio Messages (Audio):</English>
     <Chinesesimp>无线电信息（音频）</Chinesesimp>
+    <Spanish>Mensajes de radio (audio):</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CS_AUDIO_COMMENT">
     <English>Uses audible radio messages for support requests</English>
     <Chinesesimp>使用音频无线电信息请求支持</Chinesesimp>
+    <Spanish>Usa mensajes de radio audibles para las peticiones de apoyo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TRANS_LIMIT">
     <English>Transport Respawn Limit:</English>
     <Chinesesimp>运输支援限额</Chinesesimp>
+    <Spanish>Límite de reaparición de transporte:</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_CS_RESPAWN_COMMENT">
@@ -129,6 +135,7 @@
 <Key ID="STR_ALIVE_CS_RESPAWN">
     <English>Respawn Time:</English>
     <Chinesesimp>支援间隔时间</Chinesesimp>
+    <Spanish>Tiempo de reaparición:</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_CS_ALLOW_COMMENT">
@@ -143,6 +150,7 @@
 <Key ID="STR_ALIVE_CS_ERROR1">
     <English>Only one Combat Support module can be used</English>
     <Chinesesimp>只能使用一个作战支持模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de apoyo de combate</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_CS_USAGE">

--- a/addons/sup_command/stringtable.xml
+++ b/addons/sup_command/stringtable.xml
@@ -5,21 +5,26 @@
 <Key ID="STR_ALIVE_SCOM">
     <English>Player Command/Control (C2ISTAR)</English>
     <Chinesesimp>玩家命令/控制(C2ISTAR)</Chinesesimp>
+    <Spanish>Mando y control para jugadores (C2ISTAR)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SCOM_MENU">
     <English>Player C2ISTAR</English>
     <Chinesesimp>玩家C2ISTAR</Chinesesimp>
+    <Spanish>C2ISTAR de jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SCOM_COMMENT">
     <English>Group Management</English>
     <Chinesesimp>小组管理</Chinesesimp>
+    <Spanish>Gestión de grupos</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SCOM_INTEL_COMMENT">
     <English>Battlefield Intelligence</English>
     <Chinesesimp>战场情报</Chinesesimp>
+    <Spanish>Inteligencia del campo de batalla</Spanish>
 </Key>
 <Key ID="STR_ALIVE_SCOM_OPS_COMMENT">
     <English>Command/Control</English>
     <Chinesesimp>命令/控制</Chinesesimp>
+    <Spanish>Mando y control</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sup_group_manager/stringtable.xml
+++ b/addons/sup_group_manager/stringtable.xml
@@ -5,13 +5,16 @@
 <Key ID="STR_ALIVE_GM">
     <English>Player Command/Control (C2ISTAR)</English>
     <Chinesesimp>玩家命令/控制(C2ISTAR)</Chinesesimp>
+    <Spanish>Mando y control para jugadores (C2ISTAR)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_GM_MENU">
     <English>Player C2ISTAR</English>
     <Chinesesimp>玩家(C2ISTAR)</Chinesesimp>
+    <Spanish>C2ISTAR de jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_GM_COMMENT">
     <English>Group Management</English>
     <Chinesesimp>团队管理</Chinesesimp>
+    <Spanish>Gestión de grupos</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sup_multispawn/stringtable.xml
+++ b/addons/sup_multispawn/stringtable.xml
@@ -5,10 +5,12 @@
 <Key ID="STR_ALIVE_multispawn">
     <English>Player Multispawn</English>
     <Chinesesimp>玩家大量生成</Chinesesimp>
+    <Spanish>Multirreaparición de jugadores</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_COMMENT">
     <English>ALiVE Multispawn enables some handy Respawn functionalities! Please see our WiKi for more information!</English>
     <Chinesesimp>ALiVE Multispawn支持一些方便的重生功能!请访问我们的维基获取更多信息!</Chinesesimp>
+    <Spanish>¡La multirreaparición de ALiVE habilita varias funciones de reaparición muy útiles! ¡Consulta nuestra wiki para más información!</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_USAGE">
     <English>
@@ -53,65 +55,81 @@ ALiVE_SUP_MULTISPAWN_DESTINATION_%FACTION%&lt;br /&gt;
 &lt;br /&gt;
 你可以将你选择的自定义车辆同步到模块中!记住，只使用同一阵营的车辆!
     </Chinesesimp>
+    <Spanish>| Descripción&lt;br /&gt; | &lt;br /&gt; | Reaparecer en la escuadra: reaparición estilo BF (por grupo).&lt;br /&gt; | Inserción: simula una inserción aérea constante (por facción).&lt;br /&gt; | Reaparecer en vehículo: hace aparecer a los jugadores en el vehículo de HQ sincronizado (por facción).&lt;br /&gt; | Reaparecer en edificio: hace aparecer a los jugadores en un edificio a elegir (por facción).&lt;br /&gt; | &lt;br /&gt; | Nombres de marcador&lt;br /&gt; | &lt;br /&gt; | Inserción:&lt;br /&gt; | ALiVE_SUP_MULTISPAWN_INSERTION_%FACTION%&lt;br /&gt; | ALiVE_SUP_MULTISPAWN_DESTINATION_%FACTION%&lt;br /&gt; | &lt;br /&gt; | Por facción: ALiVE_SUP_MULTISPAWN_RESPAWN_%FACTION%&lt;br /&gt; | Por grupo (setGroupID): ALiVE_SUP_MULTISPAWN_RESPAWNGROUP_%GROUPID%&lt;br /&gt; | Reaparecer en vehículo (nombre del vehículo): ALiVE_SUP_MULTISPAWN_RESPAWNVEHICLE_%FACTION%&lt;br /&gt; | Reaparecer en edificio: ALiVE_SUP_MULTISPAWN_RESPAWNBUILDING_%FACTION%&lt;br /&gt; | &lt;br /&gt; | ¡Puedes sincronizar con el módulo los vehículos personalizados que quieras! ¡Ten en cuenta que solo se usan vehículos de la misma facción! |</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_DEBUG">
     <English>Enable debug:</English>
     <Chinesesimp>启用调试:</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_DEBUG_COMMENT">
     <English>Enables debug</English>
     <Chinesesimp>启用调试:</Chinesesimp>
+    <Spanish>Activa la depuración</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_TYPE">
     <English>Respawn Type:</English>
     <Chinesesimp>重生类型:</Chinesesimp>
+    <Spanish>Tipo de reaparición:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_TYPE_COMMENT">
     <English>Select where players will be respawned</English>
     <Chinesesimp>选择玩家重生的位置</Chinesesimp>
+    <Spanish>Selecciona dónde reaparecerán los jugadores</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MULTISPAWN_TIMEOUT">
     <English>Respawn Timeout:</English>
     <Chinesesimp>重生超时:</Chinesesimp>
+    <Spanish>Espera de reaparición:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MULTISPAWN_TIMEOUT_COMMENT">
     <English>Add a wait time to respawn</English>
     <Chinesesimp>增加重生的等待时间</Chinesesimp>
+    <Spanish>Añade un tiempo de espera antes de reaparecer</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MULTISPAWN_VEHICLETYPES">
     <English>Vehicletypes:</English>
     <Chinesesimp>车辆类型:</Chinesesimp>
+    <Spanish>Tipos de vehículo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_MULTISPAWN_VEHICLETYPES_COMMENT">
     <English>Respawn vehicle classes for some dynamic respawn types (like "Insertion",...)!</English>
     <Chinesesimp>一些动态重生类型的重生车辆类别 (像 "插入",...)!</Chinesesimp>
+    <Spanish>¡Clases de vehículo de reaparición para algunos tipos dinámicos de reaparición (como «Inserción»...)!</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_DISABLED">
     <English>Disable multispawn:</English>
     <Chinesesimp>禁用多生成:</Chinesesimp>
+    <Spanish>Desactivar multirreaparición:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_DISABLED_COMMENT">
     <English>XXXX</English>
     <Chinesesimp>XXXX</Chinesesimp>
+    <Spanish>XXXX</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_ERROR1">
     <English>Only one multispawn module can be used</English>
     <Chinesesimp>只能使用一个多生成模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de multirreaparición</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_SPAWNINGNEARENEMIESALLOWED">
     <English>Respawn Enemy Check:</English>
     <Chinesesimp>检查敌军重生</Chinesesimp>
+    <Spanish>Comprobación de enemigos al reaparecer:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_SPAWNINGNEARENEMIESALLOWED_COMMENT">
     <English>Allowed to spawn on squadmates even if enemies are near!</English>
     <Chinesesimp>允许在队友身上生成 即使敌军在附近!</Chinesesimp>
+    <Spanish>¡Permite reaparecer junto a compañeros de escuadra aunque haya enemigos cerca!</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_RESPAWNWITHGEAR">
     <English>Respawn with Gear:</English>
     <Chinesesimp>保存装备重生：</Chinesesimp>
+    <Spanish>Reaparecer con el equipo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_multispawn_RESPAWNWITHGEAR_COMMENT">
     <English>Respawn with the same gear that the player carried when he was killed</English>
     <Chinesesimp>使用与玩家被杀时相同的装备重生</Chinesesimp>
+    <Spanish>Reaparece con el mismo equipo que llevaba el jugador al morir</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sup_transport/stringtable.xml
+++ b/addons/sup_transport/stringtable.xml
@@ -5,10 +5,12 @@
 <Key ID="STR_ALIVE_TRANSPORT">
     <English>Player Combat Support (Transport)</English>
     <Chinesesimp>玩家战斗支援(运输)</Chinesesimp>
+    <Spanish>Apoyo de combate para jugadores (transporte)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TRANSPORT_COMMENT">
     <English>Transport Module for ALiVE Combat Support</English>
     <Chinesesimp>用于ALiVE战斗支援的运输模块</Chinesesimp>
+    <Spanish>Módulo de transporte para el apoyo de combate de ALiVE</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_TRANSPORT_USAGE">
@@ -23,14 +25,17 @@
 <Key ID="STR_ALIVE_TRANSPORT_CALLSIGN">
     <English>Callsign</English>
     <Chinesesimp>呼号</Chinesesimp>
+    <Spanish>Indicativo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TRANSPORT_CALLSIGN_DESC">
     <English>Enter the Callsign, ensure that it is unique</English>
     <Chinesesimp>输入呼号,确保它是唯一的</Chinesesimp>
+    <Spanish>Introduce el indicativo; asegúrate de que sea único</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TRANSPORT_TYPE">
     <English>Transport Vehicle Type</English>
     <Chinesesimp>运输车辆类型</Chinesesimp>
+    <Spanish>Tipo de vehículo de transporte</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_TRANSPORT_TYPE_DESC">
@@ -85,6 +90,7 @@
 <Key ID="STR_ALIVE_TRANSPORT_CODE">
     <English>Code</English>
     <Chinesesimp>代码</Chinesesimp>
+    <Spanish>Código</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_TRANSPORT_CODE_DESC">
@@ -99,6 +105,7 @@
 <Key ID="STR_ALIVE_TRANSPORT_SLINGLOADING">
     <English>Slingloading</English>
     <Chinesesimp>绳索吊装</Chinesesimp>
+    <Spanish>Carga suspendida</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_TRANSPORT_SLINGLOADING_DESC">

--- a/addons/sys_adminactions/stringtable.xml
+++ b/addons/sys_adminactions/stringtable.xml
@@ -7,125 +7,156 @@
     <German>Admin Aktionen</German>
     <Italian>Azioni Admin</Italian>
     <Chinesesimp>管理行为</Chinesesimp>
+    <Spanish>Acciones de administrador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_COMMENT">
     <English>Server admin functions</English>
 	<Chinesesimp>服务器管理功能</Chinesesimp>
+    <Spanish>Funciones de administrador del servidor</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_OPTIONS">
     <English>Module Settings</English>
 	<Chinesesimp>模块设置</Chinesesimp>
+    <Spanish>Ajustes del módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_OPTIONS_COMMENT">
     <English>Adjust ALiVE module settings, i.e. debug, as necessary</English>
 	<Chinesesimp>当必要时,调整ALIVE模快设置,即调试排错(debug)</Chinesesimp>
+    <Spanish>Ajusta los parámetros de los módulos de ALiVE, como la depuración, según sea necesario</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_GHOST">
     <English>Allow Ghosting:</English>
 	<Chinesesimp>允许备份还原(GHOST):</Chinesesimp>
+    <Spanish>Permitir modo fantasma:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_GHOST_ENABLE">
     <English>Enable Ghosting</English>
 	<Chinesesimp>启用备份还原(GHOST)</Chinesesimp>
+    <Spanish>Activar modo fantasma</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_GHOST_DISABLE">
     <English>Disable Ghosting</English>
 	<Chinesesimp>禁用备份还原(GHOST)</Chinesesimp>
+    <Spanish>Desactivar modo fantasma</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_GHOST_COMMENT">
     <English>Allow server admins to be ignored by AI</English>
 	<Chinesesimp>允许服务器管理员被AI忽略</Chinesesimp>
+    <Spanish>Permite que la IA ignore a los administradores del servidor</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_TELEPORT">
     <English>Allow Teleport:</English>
 	<Chinesesimp>允许传送：</Chinesesimp>
+    <Spanish>Permitir teletransporte:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_TELEPORT_ENABLE">
     <English>Enable Teleporting</English>
 	<Chinesesimp>启用传送：</Chinesesimp>
+    <Spanish>Activar teletransporte</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_TELEPORTUNITS">
     <English>Teleport Units</English>
 	<Chinesesimp>传送单位</Chinesesimp>
+    <Spanish>Teletransportar unidades</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_TELEPORTUNITS_COMMENT">
     <English>Teleports the given units to the desired position</English>
 	<Chinesesimp>传送给定的单位到所需的位置</Chinesesimp>
+    <Spanish>Teletransporta las unidades indicadas a la posición deseada</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_TELEPORT_DISABLE">
     <English>Disable Teleporting</English>
 	<Chinesesimp>禁用传送</Chinesesimp>
+    <Spanish>Desactivar teletransporte</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_TELEPORT_COMMENT">
     <English>Allow server admins to teleport anywhere on the map</English>
 	<Chinesesimp>允许服务器管理员传送到地图上任意位置</Chinesesimp>
+    <Spanish>Permite a los administradores del servidor teletransportarse a cualquier punto del mapa</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_MARK_UNITS">
     <English>Mark Units:</English>
 	<Chinesesimp>标记单位</Chinesesimp>
+    <Spanish>Marcar unidades:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_MARK_UNITS_ENABLE">
     <English>Activate Marking Units</English>
 	<Chinesesimp>激活标记单位</Chinesesimp>
+    <Spanish>Activar el marcado de unidades</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_MARK_UNITS_COMMENT">
     <English>Allow server admins to mark units positions for 15 seconds</English>
 	<Chinesesimp>允许服务器管理员标记单位位置15秒</Chinesesimp>
+    <Spanish>Permite a los administradores del servidor marcar las posiciones de las unidades durante 15 segundos</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_PROFILES_DEBUG">
     <English>Debug Profile System:</English>
 	<Chinesesimp>调试(debug)配置系统：</Chinesesimp>
+    <Spanish>Depurar sistema de perfiles:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_PROFILES_DEBUG_COMMENT">
     <English>Toggle debug mode on the profile system</English>
 	<Chinesesimp>切换配置系统调试模式</Chinesesimp>
+    <Spanish>Activa o desactiva el modo de depuración del sistema de perfiles</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_AGENT_DEBUG">
     <English>Debug Agent System:</English>
 	<Chinesesimp>调试代理系统：</Chinesesimp>
+    <Spanish>Depurar sistema de agentes:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_AGENT_DEBUG_COMMENT">
     <English>Toggle debug mode on the agent system</English>
 	<Chinesesimp>切换代理系统调试模式</Chinesesimp>
+    <Spanish>Activa o desactiva el modo de depuración del sistema de agentes</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_CREATE_PROFILES">
     <English>Profile non profiled units:</English>
 	<Chinesesimp>编辑非配置单位：</Chinesesimp>
+    <Spanish>Perfilar unidades sin perfil:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_CREATE_PROFILES_ENABLE">
     <English>Profile Non-Profiled Units</English>
 	<Chinesesimp>编辑非配置单位</Chinesesimp>
+    <Spanish>Perfilar unidades sin perfil</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_CREATE_PROFILES_COMMENT">
     <English>Create profiles from non profiles units and vehicles.</English>
 	<Chinesesimp>从非配置单位和载具创建配置文件。</Chinesesimp>
+    <Spanish>Crea perfiles a partir de unidades y vehículos sin perfil.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_CONSOLE">
     <English>Allow Debug:</English>
 	<Chinesesimp>允许调试排错(debug)</Chinesesimp>
+    <Spanish>Permitir depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_CONSOLE_ENABLE">
     <English>Debug Console</English>
 	<Chinesesimp>调试控制台</Chinesesimp>
+    <Spanish>Consola de depuración</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_CONSOLE_COMMENT">
     <English>Open the debug console</English>
 	<Chinesesimp>打开调试控制台</Chinesesimp>
+    <Spanish>Abre la consola de depuración</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_ERROR1">
     <English>Only one Admin Actions module can be used</English>
 	<Chinesesimp>仅使用一个管理员操作模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de acciones de administrador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_USAGE">
     <English>Place an admin actions module to give the server admin or single player admin functions like teleport, ghost and run scripts.</English>
 	<Chinesesimp>放置一个管理动作模块,以提供服务器管理或单人玩家管理功能,如传送,备份还原(GHOST)和运行脚本。</Chinesesimp>
+    <Spanish>Coloca un módulo de acciones de administrador para dar al administrador del servidor, o al jugador en un jugador, funciones como teletransporte, modo fantasma y ejecución de scripts.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_OPCOM_TOGGLEINSTALLATIONS">
     <English>Toggle OPCOM Installations</English>
 	<Chinesesimp>切换作战指挥设施</Chinesesimp>
+    <Spanish>Mostrar u ocultar instalaciones de OPCOM</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ADMINACTIONS_OPCOM_TOGGLEINSTALLATIONS_COMMENT">
     <English>Displays markers at installations</English>
 	<Chinesesimp>在设施处显示标记</Chinesesimp>
+    <Spanish>Muestra marcadores en las instalaciones</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_crewinfo/stringtable.xml
+++ b/addons/sys_crewinfo/stringtable.xml
@@ -5,25 +5,31 @@
 <Key ID="STR_ALIVE_CREWINFO">
     <English>Crew Info</English>
     <Chinesesimp>乘员信息</Chinesesimp>
+    <Spanish>Info de tripulación</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CREWINFO_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用调试:</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CREWINFO_DEBUG_COMMENT">
     <English>Enables Crew Info Module Debug</English>
     <Chinesesimp>启用乘员信息模块调试</Chinesesimp>
+    <Spanish>Activa la depuración del módulo de info de tripulación</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CREWINFO_UI">
     <English>Crew Info (Position):</English>
     <Chinesesimp>乘员信息(位置):</Chinesesimp>
+    <Spanish>Info de tripulación (posición):</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CREWINFO_UI_COMMENT">
     <English>Crew Info Interface Location - select none to turn off</English>
     <Chinesesimp>乘员信息界面位置-选择none关闭</Chinesesimp>
+    <Spanish>Ubicación de la interfaz de info de tripulación; selecciona «ninguna» para desactivarla</Spanish>
 </Key>
 <Key ID="STR_ALIVE_CREWINFO_ERROR1">
     <English>Only one crew info module can be used</English>
     <Chinesesimp>只能使用一个乘员信息模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de info de tripulación</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_data/stringtable.xml
+++ b/addons/sys_data/stringtable.xml
@@ -5,128 +5,159 @@
             <Key ID="STR_ALIVE_Data">
                 <English>ALiVE Data</English>
                 <Chinesesimp>Alive数据</Chinesesimp>
+                <Spanish>ALiVE Data</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_COMMENT">
                 <English>Data module for perf monitoring, stats and persistence</English>
                 <Chinesesimp>用于性能监视、统计和持久性的数据模块</Chinesesimp>
+                <Spanish>Módulo de datos para monitorización de rendimiento, estadísticas y persistencia</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_DEBUG">
                 <English>Enable Debug:</English>
                 <Chinesesimp>启用调试DEBUG:</Chinesesimp>
+                <Spanish>Activar depuración:</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_DEBUG_COMMENT">
                 <English>Enables Data Module Debug</English>
                 <Chinesesimp>启用数据模块调试</Chinesesimp>
+                <Spanish>Activa la depuración del módulo de datos</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_ENABLE">
                 <English>Enable Database</English>
                 <Chinesesimp>启用数据库</Chinesesimp>
+                <Spanish>Activar base de datos</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_ENABLE_COMMENT">
                 <English>Enables Database module</English>
                 <Chinesesimp>启用数据库</Chinesesimp>
+                <Spanish>Activa el módulo de base de datos</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_DISABLE">
                 <English>Disable Database</English>
                 <Chinesesimp>禁用数据库</Chinesesimp>
+                <Spanish>Desactivar base de datos</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_DISABLE_COMMENT">
                 <English>Disables Database module</English>
                 <Chinesesimp>禁用数据库</Chinesesimp>
+                <Spanish>Desactiva el módulo de base de datos</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_Source">
                 <English>Database Source</English>
                 <Chinesesimp>数据库源</Chinesesimp>
+                <Spanish>Origen de la base de datos</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_Source_COMMENT">
                 <English>Choose an available Database Source</English>
                 <Chinesesimp>选择一个可用的数据库源</Chinesesimp>
+                <Spanish>Elige un origen de base de datos disponible</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_DATABASENAME">
                 <English>Database Name</English>
                 <Chinesesimp>数据库名称</Chinesesimp>
+                <Spanish>Nombre de la base de datos</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_DATABASENAME_COMMENT">
                 <English>Enter the name of the database</English>
                 <Chinesesimp>输入数据库的名称</Chinesesimp>
+                <Spanish>Introduce el nombre de la base de datos</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_ERROR1">
                 <English>Only one Data module can be used</English>
                 <Chinesesimp>只能使用一个数据模块</Chinesesimp>
+                <Spanish>Solo se puede usar un módulo de datos</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_SAVEDATETIME">
                 <English>Save Mission Time:</English>
                 <Chinesesimp>保存任务时间:</Chinesesimp>
+                <Spanish>Guardar hora de la misión:</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_SAVEDATETIME_COMMENT">
                 <English>Enable/disable saving date and time of the mission</English>
                 <Chinesesimp>启用/禁用保存任务的日期和时间 </Chinesesimp>
+                <Spanish>Activa o desactiva el guardado de la fecha y la hora de la misión</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_SAVECOMPOSITIONS">
                 <English>Save Roadblocks/Outposts:</English>
                 <Chinesesimp>保存路障/前哨:</Chinesesimp>
+                <Spanish>Guardar controles y puestos avanzados:</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_SAVECOMPOSITIONS_COMMENT">
                 <English>Enable/disable saving any compositions that are spawned for camps, checkpoints etc</English>
                 <Chinesesimp>启用/禁用保存为营地、检查点等生成的任何合成</Chinesesimp>
+                <Spanish>Activa o desactiva el guardado de las composiciones generadas para campamentos, controles, etc.</Spanish>
             </Key>    
             <Key ID="STR_ALIVE_Data_killFeed">
                 <English>Enable Chat Kill Feed:</English>
                 <Chinesesimp>启用击杀消息:</Chinesesimp>
+                <Spanish>Activar registro de bajas en el chat:</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_killFeed_COMMENT">
                 <English>Enable kill feed in players group or side chat.</English>
                 <Chinesesimp>在玩家群组或阵营频道中启用击杀消息。</Chinesesimp>
+                <Spanish>Activa el registro de bajas en el chat de grupo o de bando de los jugadores.</Spanish>
             </Key>                    
             <Key ID="STR_ALIVE_Data_disableStats">
                 <English>Disable Stats:</English>
                 <Chinesesimp>禁用统计:</Chinesesimp>
+                <Spanish>Desactivar estadísticas:</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_disableStats_COMMENT">
                 <English>Disable the recording of player/operation stats to the War Room</English>
                 <Chinesesimp>禁止记录作战室的玩家/操作数据</Chinesesimp>
+                <Spanish>Desactiva el registro de estadísticas de jugador y de operación en la War Room</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_disableAAR">
                 <English>Disable AAR:</English>
                 <Chinesesimp>禁用AAR:</Chinesesimp>
+                <Spanish>Desactivar AAR:</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_disableAAR_COMMENT">
                 <English>Disable player tracking for AAR on War Room</English>
                 <Chinesesimp>在作战室中禁用AAR的玩家追踪功能</Chinesesimp>
+                <Spanish>Desactiva el seguimiento de jugadores para el AAR de la War Room</Spanish>
             </Key>            
             <Key ID="STR_ALIVE_Data_disablePerf">
                 <English>Disable PerfMon:</English>
                 <Chinesesimp>禁用性能数据</Chinesesimp>
+                <Spanish>Desactivar PerfMon:</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_disablePerf_COMMENT">
                 <English>Disable the recording of server performance data to War Room </English>
                 <Chinesesimp>禁止向作战室记录服务器性能数据</Chinesesimp>
+                <Spanish>Desactiva el registro de datos de rendimiento del servidor en la War Room</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_disablePerfMon">
                 <English>Disable OS PerfMon:</English>
                 <Chinesesimp>禁用OS性能数据</Chinesesimp>
+                <Spanish>Desactivar PerfMon del SO:</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_disablePerfMon_COMMENT">
                 <English>Disable OS Performance Statistics such as %CPU, Threads, Memory Usage etc</English>
                 <Chinesesimp>禁用操作系统性能统计,如%CPU,线程,内存使用率等</Chinesesimp>
+                <Spanish>Desactiva las estadísticas de rendimiento del sistema operativo, como %CPU, hilos, uso de memoria, etc.</Spanish>
             </Key>    
             <Key ID="STR_ALIVE_Data_customPerfMonCode">
                 <English>Custom Perf Monitors:</English>
                 <Chinesesimp>自定义性能监控:</Chinesesimp>
+                <Spanish>Monitores de rendimiento personalizados:</Spanish>
             </Key>
             <Key ID="STR_ALIVE_Data_customPerfMonCode_COMMENT">
                 <English>Customize objects counted and intervals. Ensure interval values are in ascending order. 'triggers' will count allMissionObjects "EmptyDetector", 'entities' will count entities "All", 'objects' will count allMissionObjects "All", 'activeScripts' will count all active scripts. Any thing else will be count YOURPARAM i.e. count allDead.</English>
                 <Chinesesimp>自定义对象计数和间隔。确保间隔值按升序排列。'triggers'将计算所有的missionobjects "EmptyDetector", 'entities'将计算实体"All", 'objects'将计算所有的missionobjects "All", 'activeScripts'将计算所有的活动脚本。其他的将被计算为YOURPARAM,也就是计算allDead。</Chinesesimp>
+                <Spanish>Personaliza los objetos contabilizados y los intervalos. Asegúrate de que los valores de intervalo estén en orden ascendente. 'triggers' contará allMissionObjects "EmptyDetector", 'entities' contará entities "All", 'objects' contará allMissionObjects "All" y 'activeScripts' contará todos los scripts activos. Cualquier otra cosa se contará como count TUPARÁMETRO, p. ej. count allDead.</Spanish>
             </Key>
             <!-- AI-translated; native-speaker review welcome -->
             <Key ID="STR_ALIVE_Data_saveAllowlist">
                 <English>Save Server Allowlist:</English>
                 <Chinesesimp>服务器保存白名单:</Chinesesimp>
+                <Spanish>Lista de permitidos para guardar el servidor:</Spanish>
             </Key>
             <!-- AI-translated; native-speaker review welcome -->
             <Key ID="STR_ALIVE_Data_saveAllowlist_COMMENT">
                 <English>Comma separated list of Steam UIDs allowed to use the Save Server button without being logged in as admin. Leave empty to restrict saving to admins.</English>
                 <Chinesesimp>允许在未以管理员身份登录的情况下使用"保存服务器"按钮的Steam UID列表(逗号分隔)。留空则仅限管理员保存。</Chinesesimp>
+                <Spanish>Lista separada por comas de UID de Steam autorizados a usar el botón de guardar el servidor sin estar identificados como administradores. Déjala vacía para restringir el guardado a los administradores.</Spanish>
             </Key>
             <!-- AI-translated; native-speaker review welcome -->
             <Key ID="STR_ALIVE_DATA_MENU">

--- a/addons/sys_gc/stringtable.xml
+++ b/addons/sys_gc/stringtable.xml
@@ -5,41 +5,51 @@
 <Key ID="STR_ALIVE_GC">
     <English>Garbage Collector</English>
     <Chinesesimp>垃圾回收(GC)</Chinesesimp>
+    <Spanish>Recolector de basura</Spanish>
 </Key>
 <Key ID="STR_ALIVE_GC_COMMENT">
     <English>Cleans up dead objects and improves performance</English>
     <Chinesesimp>清除死亡对象并提高性能</Chinesesimp>
+    <Spanish>Limpia los objetos muertos y mejora el rendimiento</Spanish>
 </Key>
 <Key ID="STR_ALIVE_GC_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用调试DEBUG:</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_GC_DEBUG_COMMENT">
     <English>Enables GC Module Debug</English>
     <Chinesesimp>开启GC模块调试</Chinesesimp>
+    <Spanish>Activa la depuración del módulo GC</Spanish>
 </Key>
 <Key ID="STR_ALIVE_GC_INDIVIDUALTYPES">
     <English>Garbage Collector Clutter Types</English>
     <Chinesesimp>垃圾收集器杂波类型</Chinesesimp>
+    <Spanish>Tipos de objeto del recolector de basura</Spanish>
 </Key>
 <Key ID="STR_ALIVE_GC_INDIVIDUALTYPES_COMMENT">
     <English>Include certain non-unit or non-vehicle objects in collection eg: ["Box_NATO_Wps_F","Box_NATO_AmmoOrd_F"]</English>
     <Chinesesimp>在集合中包含某些非单位或非车辆对象,例如:["Box_NATO_Wps_F","Box_NATO_AmmoOrd_F"]</Chinesesimp>
+    <Spanish>Incluye en la recolección ciertos objetos que no son unidades ni vehículos, p. ej.: ["Box_NATO_Wps_F","Box_NATO_AmmoOrd_F"]</Spanish>
 </Key>
 <Key ID="STR_ALIVE_GC_INTERVAL">
     <English>Garbage Collector Interval:</English>
     <Chinesesimp>垃圾回收间隔:</Chinesesimp>
+    <Spanish>Intervalo del recolector de basura:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_GC_INTERVAL_COMMENT">
     <English>Interval in which to clean killed objects! Use 0 to turn off GC completely!</English>
     <Chinesesimp>清理已杀死对象的时间间隔!使用0完全关闭GC!</Chinesesimp>
+    <Spanish>¡Intervalo con el que se limpian los objetos destruidos! ¡Usa 0 para desactivar por completo el GC!</Spanish>
 </Key>
 <Key ID="STR_ALIVE_GC_THRESHHOLD">
     <English>Garbage Collector Limiter:</English>
     <Chinesesimp>垃圾收集器限制器:</Chinesesimp>
+    <Spanish>Limitador del recolector de basura:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_GC_THRESHHOLD_COMMENT">
     <English>Will remove all dead objects and groups if this limit is met (count allDead)</English>
     <Chinesesimp>如果满足此限制，将删除所有死亡的对象和组(计数allDead)</Chinesesimp>
+    <Spanish>Eliminará todos los objetos y grupos muertos si se alcanza este límite (count allDead)</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_indexer/stringtable.xml
+++ b/addons/sys_indexer/stringtable.xml
@@ -5,54 +5,67 @@
 <Key ID="STR_ALIVE_INDEXER">
     <English>Map Indexer</English>
     <Chinesesimp>地图索引器</Chinesesimp>
+    <Spanish>Indexador de mapas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_COMMENT">
     <English>Index the current map</English>
     <Chinesesimp>为当前映射建立索引</Chinesesimp>
+    <Spanish>Indexa el mapa actual</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_STATICDATA">
     <English>Object Categorization:</English>
     <Chinesesimp>对象分类:</Chinesesimp>
+    <Spanish>Categorización de objetos:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_STATICDATA_COMMENT">
     <English>If enabled, each unique object on the map will need to be categorised</English>
     <Chinesesimp>如果启用，地图上的每个唯一对象都需要分类</Chinesesimp>
+    <Spanish>Si se activa, habrá que categorizar cada objeto único del mapa</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_MAPPATH">
     <English>Map PBO file path:</English>
     <Chinesesimp>地图PBO文件路径:</Chinesesimp>
+    <Spanish>Ruta del archivo PBO del mapa:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_MAPPATH_COMMENT">
     <English>Enter the path and filename of the map pbo relative to Arma 3 root directory.</English>
     <Chinesesimp>输入映射pbo相对于Arma 3根目录的路径和文件名。</Chinesesimp>
+    <Spanish>Introduce la ruta y el nombre del PBO del mapa relativos al directorio raíz de Arma 3.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_MAPBOUND">
     <English>Custom MapBound:</English>
     <Chinesesimp>自定义MapBound:</Chinesesimp>
+    <Spanish>Límite de mapa personalizado:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_MAPBOUND_COMMENT">
     <English>Map bound value must cover the entire map and be rounded up to nearest 1000. By default uses worldSize/mapSize</English>
     <Chinesesimp>地图绑定值必须覆盖整个地图,并四舍五入到最接近1000。默认使用worldSize/mapSize</Chinesesimp>
+    <Spanish>El valor del límite de mapa debe cubrir todo el mapa y redondearse al alza al millar más próximo. Por defecto usa worldSize/mapSize</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_ERROR1">
     <English>Only one Map Indexer module can be used</English>
     <Chinesesimp>只能使用一个地图索引器模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de indexador de mapas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_OS">
     <English>Operating System:</English>
     <Chinesesimp>操作系统:</Chinesesimp>
+    <Spanish>Sistema operativo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_OS_COMMENT">
     <English>If map indexer crashes, try changing the operating system selection here.</English>
     <Chinesesimp>如果映射索引器崩溃，请尝试在这里更改操作系统选择。</Chinesesimp>
+    <Spanish>Si el indexador de mapas falla, prueba a cambiar aquí la selección de sistema operativo.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_ENVIRONMENT">
     <English>Composition Environment:</English>
     <Chinesesimp>阵地布局环境:</Chinesesimp>
+    <Spanish>Entorno de composiciones:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_INDEXER_ENVIRONMENT_COMMENT">
     <English>Environment used to select ALiVE compositions on this map. Written to the exported static data, so it no longer needs to be added by hand after indexing.</English>
     <Chinesesimp>用于在此地图上选择ALiVE阵地布局的环境。会写入导出的静态数据，索引后无需再手动添加。</Chinesesimp>
+    <Spanish>Entorno usado para elegir las composiciones de ALiVE en este mapa. Se escribe en los datos estáticos exportados, así que ya no hay que añadirlo a mano después de indexar.</Spanish>
 </Key>
 
 </Container></Package></Project>

--- a/addons/sys_marker/stringtable.xml
+++ b/addons/sys_marker/stringtable.xml
@@ -5,41 +5,51 @@
 <Key ID="STR_ALIVE_marker">
     <English>Advanced Markers</English>
     <Chinesesimp>高级标记</Chinesesimp>
+    <Spanish>Marcadores avanzados</Spanish>
 </Key>
 <Key ID="STR_ALIVE_marker_COMMENT">
     <English>Autostarting ALiVE Module template (uses additional module to configure parameters)</English>
     <Chinesesimp>自动启动激活模块模板(使用额外的模块来配置参数)</Chinesesimp>
+    <Spanish>Plantilla de módulo ALiVE de arranque automático (usa un módulo adicional para configurar los parámetros)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_markerPARAMS">
     <English>Template Parameters</English>
     <Chinesesimp>模板参数</Chinesesimp>
+    <Spanish>Parámetros de la plantilla</Spanish>
 </Key>
 <Key ID="STR_ALIVE_marker_ERROR1">
     <English>Only one module template allowed</English>
     <Chinesesimp>只允许一个模块模板</Chinesesimp>
+    <Spanish>Solo se permite una plantilla de módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_markerPARAMS_COMMENT">
     <English>Over-ride default parameters for the Module Template</English>
     <Chinesesimp>覆盖模块模板的默认参数</Chinesesimp>
+    <Spanish>Anula los parámetros por defecto de la plantilla de módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_markerPARAMS_USAGE">
     <English>Place the module and configure the over-rides</English>
     <Chinesesimp>放置模块并配置覆盖</Chinesesimp>
+    <Spanish>Coloca el módulo y configura las anulaciones</Spanish>
 </Key>
 <Key ID="STR_ALIVE_marker_DEBUG">
     <English>Debug:</English>
     <Chinesesimp>调试DEBUG:</Chinesesimp>
+    <Spanish>Depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_marker_DEBUG_COMMENT">
     <English>Enable Debug</English>
     <Chinesesimp>启用调试</Chinesesimp>
+    <Spanish>Activar depuración</Spanish>
 </Key>
 <Key ID="STR_ALIVE_marker_DIALOG_TITLE">
     <English>ADVANCED MARKER</English>
     <Chinesesimp>高级标记</Chinesesimp>
+    <Spanish>MARCADOR AVANZADO</Spanish>
 </Key>
 <Key ID="STR_ALIVE_marker_DIALOG_spotrep">
     <English>spotrep</English>
     <Chinesesimp>spotrep</Chinesesimp>
+    <Spanish>spotrep</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_newsfeed/stringtable.xml
+++ b/addons/sys_newsfeed/stringtable.xml
@@ -5,38 +5,47 @@
 <Key ID="STR_ALIVE_NEWSFEED">
     <English>Newsfeed</English>
     <Chinesesimp>新闻源</Chinesesimp>
+    <Spanish>Noticias</Spanish>
 </Key>
 <Key ID="STR_ALIVE_NEWSFEED_COMMENT">
     <English>ALiVE Newsfeed direct to in Game</English>
     <Chinesesimp>将ALiVE新闻源接入到游戏中</Chinesesimp>
+    <Spanish>Noticias de ALiVE directamente en el juego</Spanish>
 </Key>
 <Key ID="STR_ALIVE_NEWSFEED_ALLOW">
     <English>Enable Newsfeed:</English>
     <Chinesesimp>启用新闻源：</Chinesesimp>
+    <Spanish>Activar noticias:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_NEWSFEED_ALLOW_COMMENT">
     <English>Allow the option to get the latest ALiVE News in Game</English>
     <Chinesesimp>允许选择在游戏中获取最新的ALiVE新闻</Chinesesimp>
+    <Spanish>Permite la opción de recibir las últimas noticias de ALiVE en el juego</Spanish>
 </Key>
 <Key ID="STR_ALIVE_NEWSFEED_ENABLE">
     <English>Enable Newsfeed</English>
     <Chinesesimp>启用新闻源</Chinesesimp>
+    <Spanish>Activar noticias</Spanish>
 </Key>
 <Key ID="STR_ALIVE_NEWSFEED_ENABLE_COMMENT">
     <English>Enable the dispaly of the ALiVE Newsfeed in game</English>
     <Chinesesimp>在游戏中启用ALiVE新闻源的显示</Chinesesimp>
+    <Spanish>Activa la visualización de las noticias de ALiVE en el juego</Spanish>
 </Key>
 <Key ID="STR_ALIVE_NEWSFEED_DISABLE">
     <English>Disable Newsfeed</English>
     <Chinesesimp>禁用新闻源</Chinesesimp>
+    <Spanish>Desactivar noticias</Spanish>
 </Key>
 <Key ID="STR_ALIVE_NEWSFEED_DISABLE_COMMENT">
     <English>Disable the dispaly of the ALiVE Newsfeed in game</English>
     <Chinesesimp>在游戏中禁用ALiVE新闻源的显示</Chinesesimp>
+    <Spanish>Desactiva la visualización de las noticias de ALiVE en el juego</Spanish>
 </Key>
 <Key ID="STR_ALIVE_NEWSFEED_ERROR1">
     <English>Only one newsfeed module can be used</English>
     <Chinesesimp>只能使用一个新闻源模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de noticias</Spanish>
 </Key>
 
 </Container></Package></Project>

--- a/addons/sys_orbatcreator/stringtable.xml
+++ b/addons/sys_orbatcreator/stringtable.xml
@@ -5,73 +5,91 @@
 <Key ID="STR_ALIVE_ORBATCREATOR">
     <English>ALiVE ORBAT Creator</English>
     <Chinesesimp>ALiVE战斗序列(ORBAT)创造者</Chinesesimp>
+    <Spanish>Creador de ORBAT de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_COMMENT">
     <English>Open the ORBAT Creator</English>
     <Chinesesimp>开启战斗序列(ORBAT)创造者</Chinesesimp>
+    <Spanish>Abre el creador de ORBAT</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用调试:</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_DEBUG_COMMENT">
     <English>Enables Module Debug</English>
     <Chinesesimp>启用模块调试</Chinesesimp>
+    <Spanish>Activa la depuración del módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_BACKGROUND">
     <English>Enable Background:</English>
     <Chinesesimp>启用背景：</Chinesesimp>
+    <Spanish>Activar fondo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_BACKGROUND_COMMENT">
     <English>Creates a grey background for editing purposes. Alternatively, the editor will use the current map and position of the module.</English>
     <Chinesesimp>为编辑目的创建灰色背景.或者,编辑器将使用模块的当前地图和位置.</Chinesesimp>
+    <Spanish>Crea un fondo gris para facilitar la edición. Si no, el editor usará el mapa y la posición actuales del módulo.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_PREFIX">
     <English>Addon Prefix:</English>
     <Chinesesimp>附加前缀:</Chinesesimp>
+    <Spanish>Prefijo del addon:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_PREFIX_COMMENT">
     <English>Enter an addon prefix here if applicable i.e. CUP</English>
     <Chinesesimp>在此处输入一个附加前缀,如适用,例如CUP</Chinesesimp>
+    <Spanish>Introduce aquí un prefijo de addon si procede, p. ej. CUP</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_COPY">
     <English>Copy Parent Classes:</English>
     <Chinesesimp>复制父本:</Chinesesimp>
+    <Spanish>Copiar clases padre:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_COPY_COMMENT">
     <English>Advanced usage - if you wish to copy the parent class of existing units, rather than existing class, select Yes. No by default.</English>
     <Chinesesimp>高级用法-如果要复制现有单位的父本,而不是现有类,请选择是.默认情况下为否.</Chinesesimp>
+    <Spanish>Uso avanzado: si quieres copiar la clase padre de las unidades existentes en lugar de la clase actual, selecciona Sí. No por defecto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_ARSENAL_TYPE">
     <English>Arsenal Type:</English>
     <Chinesesimp>军械库类型:</Chinesesimp>
+    <Spanish>Tipo de arsenal:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_ARSENAL_TYPE_COMMENT">
     <English>Select which arsenal is used to edit ORBAT unit loadouts.</English>
     <Chinesesimp>选择用于编辑ORBAT单位装备的军械库.</Chinesesimp>
+    <Spanish>Selecciona qué arsenal se usa para editar el equipo de las unidades del ORBAT.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_ARSENAL_TYPE_BIS">
     <English>Virtual Arsenal</English>
     <Chinesesimp>Virtual军械库</Chinesesimp>
+    <Spanish>Arsenal virtual</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_ARSENAL_TYPE_ACE">
     <English>ACE Arsenal</English>
     <Chinesesimp>ACE军械库</Chinesesimp>
+    <Spanish>Arsenal de ACE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_ARSENAL_SAVE">
     <English>Save Changes</English>
     <Chinesesimp>保存更改</Chinesesimp>
+    <Spanish>Guardar cambios</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_ARSENAL_TYPE_ACE_UNAVAILABLE">
     <English>ACE mod is not currently loaded</English>
     <Chinesesimp>ACE模组当前未加载</Chinesesimp>
+    <Spanish>El mod ACE no está cargado actualmente</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_ARSENAL_TYPE_RUNTIME_UNAVAILABLE">
     <English>ACE Arsenal is unavailable. Falling back to Virtual Arsenal.</English>
     <Chinesesimp>ACE军械库不可用.将改用Virtual军械库.</Chinesesimp>
+    <Spanish>El arsenal de ACE no está disponible. Se usará el arsenal virtual.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_ORBATCREATOR_ARSENAL_TYPE_RUNTIME_FAILED">
     <English>ACE Arsenal could not be opened.</English>
     <Chinesesimp>无法打开ACE军械库.</Chinesesimp>
+    <Spanish>No se ha podido abrir el arsenal de ACE.</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_patrolrep/stringtable.xml
+++ b/addons/sys_patrolrep/stringtable.xml
@@ -5,41 +5,51 @@
 <Key ID="STR_ALIVE_patrolrep">
     <English>patrolrep Module</English>
     <Chinesesimp>巡逻模块</Chinesesimp>
+    <Spanish>Módulo PATROLREP</Spanish>
 </Key>
 <Key ID="STR_ALIVE_patrolrep_COMMENT">
     <English>Send a PATROLREP to be stored in game and on War Room</English>
     <Chinesesimp>派遣一个巡逻人员藏在游戏和作战室里</Chinesesimp>
+    <Spanish>Envía un PATROLREP para almacenarlo en el juego y en la War Room</Spanish>
 </Key>
 <Key ID="STR_ALIVE_patrolrepPARAMS">
     <English>Template Parameters</English>
     <Chinesesimp>模板参数</Chinesesimp>
+    <Spanish>Parámetros de la plantilla</Spanish>
 </Key>
 <Key ID="STR_ALIVE_patrolrep_ERROR1">
     <English>Only one module template allowed</English>
     <Chinesesimp>只允许一个模块模板</Chinesesimp>
+    <Spanish>Solo se permite una plantilla de módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_patrolrepPARAMS_COMMENT">
     <English>Over-ride default parameters for the Module Template</English>
     <Chinesesimp>超越模块模板的默认参数</Chinesesimp>
+    <Spanish>Anula los parámetros por defecto de la plantilla de módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_patrolrepPARAMS_USAGE">
     <English>Place the module and configure the over-rides</English>
     <Chinesesimp>放置模块并设定超越值</Chinesesimp>
+    <Spanish>Coloca el módulo y configura las anulaciones</Spanish>
 </Key>
 <Key ID="STR_ALIVE_patrolrep_DEBUG">
     <English>Debug:</English>
     <Chinesesimp>调试:</Chinesesimp>
+    <Spanish>Depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_patrolrep_DEBUG_COMMENT">
     <English>Enable Debug</English>
     <Chinesesimp>启用调试</Chinesesimp>
+    <Spanish>Activar depuración</Spanish>
 </Key>
 <Key ID="STR_ALIVE_patrolrep_DIALOG_TITLE">
     <English>ADVANCED patrolrep</English>
     <Chinesesimp>高级巡逻人员</Chinesesimp>
+    <Spanish>PATROLREP AVANZADO</Spanish>
 </Key>
 <Key ID="STR_ALIVE_patrolrep_DIALOG_patrolrep">
     <English>patrolrep</English>
     <Chinesesimp>巡逻人员</Chinesesimp>
+    <Spanish>patrolrep</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_player/stringtable.xml
+++ b/addons/sys_player/stringtable.xml
@@ -7,153 +7,191 @@
     <German>Player Persistence</German>
     <Italian>Player Persistence</Italian>
 	<Chinesesimp>玩家持续性</Chinesesimp>
+    <Spanish>Persistencia de jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_COMMENT">
     <English>Player Persistence Module</English>
 	<Chinesesimp>玩家持续性模组</Chinesesimp>
+    <Spanish>Módulo de persistencia de jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_ENABLE">
     <English>Persist Player State</English>
 	<Chinesesimp>保持玩家状态</Chinesesimp>
+    <Spanish>Conservar el estado del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_ENABLE_COMMENT">
     <English>Persist Player State between server disconnects and/or server restarts</English>
 	<Chinesesimp>在服务器断开连接和/或服务器重新启动之间保持玩家状态</Chinesesimp>
+    <Spanish>Conserva el estado del jugador entre desconexiones y reinicios del servidor</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowReset">
     <English>Allow Player State Reset:</English>
 	<Chinesesimp>允许玩家状态重置：</Chinesesimp>
+    <Spanish>Permitir reinicio del estado del jugador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowReset_ENABLE">
     <English>Enable Player Reset</English>
 	<Chinesesimp>启用玩家重置</Chinesesimp>
+    <Spanish>Activar reinicio del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowReset_DISABLE">
     <English>Disable Player Reset</English>
 	<Chinesesimp>禁用玩家重置</Chinesesimp>
+    <Spanish>Desactivar reinicio del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowReset_COMMENT">
     <English>Allow players to reset themselves to their current session starting state or manual save point</English>
 	<Chinesesimp>允许玩家将自己重置为当前会话开始状态或手动保存点</Chinesesimp>
+    <Spanish>Permite a los jugadores volver al estado con el que empezaron la sesión actual o al último punto de guardado manual</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowReset_ACTION">
     <English>Reset to Previous Session State</English>
 	<Chinesesimp>重置为上一个会话状态</Chinesesimp>
+    <Spanish>Volver al estado de la sesión anterior</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowManualSave">
     <English>Allow Player Manual Save:</English>
 	<Chinesesimp>允许玩家手动保存：</Chinesesimp>
+    <Spanish>Permitir guardado manual del jugador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowReset_ACTION_COMMENT">
     <English>Reset yourself to the last current session starting state or manual save point</English>
 	<Chinesesimp>将自己重置为上一个当前会话开始状态或手动保存点</Chinesesimp>
+    <Spanish>Vuelve al estado con el que empezaste la sesión actual o al último punto de guardado manual</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowManualSave_ENABLE">
     <English>Enable Player Manual Save</English>
 	<Chinesesimp>启用玩家手动保存</Chinesesimp>
+    <Spanish>Activar guardado manual del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowManualSave_DISABLE">
     <English>Disable Player Manual Save</English>
 	<Chinesesimp>禁用玩家手动保存</Chinesesimp>
+    <Spanish>Desactivar guardado manual del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowManualSave_COMMENT">
     <English>Allow players to manually save their current state</English>
 	<Chinesesimp>允许玩家手动保存当前状态</Chinesesimp>
+    <Spanish>Permite a los jugadores guardar manualmente su estado actual</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowManualSave_ACTION">
     <English>Save Player Data</English>
 	<Chinesesimp>保存玩家数据</Chinesesimp>
+    <Spanish>Guardar datos del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowManualSave_ACTION_COMMENT">
     <English>Save your player data between disconnect and reconnect. If DB is enabled, will store player state between server restarts.</English>
 	<Chinesesimp>在断开连接和重新连接之间保存您的播放器数据。 如果启用 DB,将在服务器重新启动之间存储玩家状态。</Chinesesimp>
+    <Spanish>Guarda tus datos de jugador entre la desconexión y la reconexión. Si la base de datos está activada, conservará el estado del jugador entre reinicios del servidor.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowDiffClass">
     <English>Allow Different Class Rejoin:</English>
 	<Chinesesimp>允许不同的兵种重新加入：</Chinesesimp>
+    <Spanish>Permitir reincorporarse con otra clase:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowDiffClass_ENABLE">
     <English>Enable Different Class Rejoin</English>
 	<Chinesesimp>启用不同的兵种重新加入</Chinesesimp>
+    <Spanish>Activar reincorporación con otra clase</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowDiffClass_DISABLE">
     <English>Disable Different Class Rejoin</English>
 	<Chinesesimp>停用不同的兵种重新加入</Chinesesimp>
+    <Spanish>Desactivar reincorporación con otra clase</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_allowDiffClass_COMMENT">
     <English>Allow players to rejoin the mission as a different class</English>
 	<Chinesesimp>允许玩家以不同的兵种重新加入任务</Chinesesimp>
+    <Spanish>Permite a los jugadores volver a la misión con una clase distinta</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_storeToDB">
     <English>Save to Database:</English>
 	<Chinesesimp>保存到数据库：</Chinesesimp>
+    <Spanish>Guardar en base de datos:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_storeToDB_ENABLE">
     <English>Enable external database</English>
 	<Chinesesimp>启用外部数据库</Chinesesimp>
+    <Spanish>Activar base de datos externa</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_storeToDB_DISABLE">
     <English>Disable External Database</English>
 	<Chinesesimp>禁用外部数据库</Chinesesimp>
+    <Spanish>Desactivar base de datos externa</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_storeToDB_COMMENT">
     <English>Enable/disable saving player data</English>
 	<Chinesesimp>启用/禁用保存玩家数据</Chinesesimp>
+    <Spanish>Activa o desactiva el guardado de los datos del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_SAVELOADOUT">
     <English>Store Loadout:</English>
 	<Chinesesimp>储存装备：</Chinesesimp>
+    <Spanish>Guardar equipo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_SAVELOADOUT_COMMENT">
     <English>Enable/disable saving player load-out data</English>
 	<Chinesesimp>启用/停用保存玩家装备数据</Chinesesimp>
+    <Spanish>Activa o desactiva el guardado del equipo del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_SAVEAMMO">
     <English>Store Ammo Count:</English>
 	<Chinesesimp>储存弹药数量</Chinesesimp>
+    <Spanish>Guardar munición:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_SAVEAMMO_COMMENT">
     <English>Enable/disable saving player ammo count</English>
 	<Chinesesimp>启用/停用储存玩家弹药数量</Chinesesimp>
+    <Spanish>Activa o desactiva el guardado del recuento de munición del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_SAVEHEALTH">
     <English>Store Health:</English>
 	<Chinesesimp>储存健康：</Chinesesimp>
+    <Spanish>Guardar salud:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_SAVEHEALTH_COMMENT">
     <English>Enable/disable saving player health data</English>
 	<Chinesesimp>启用/停用储存玩家健康数据</Chinesesimp>
+    <Spanish>Activa o desactiva el guardado de los datos de salud del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_SAVEPOSITION">
     <English>Store Position:</English>
 	<Chinesesimp>储存位置：</Chinesesimp>
+    <Spanish>Guardar posición:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_SAVEPOSITION_COMMENT">
     <English>Enable/disable saving player position data</English>
 	<Chinesesimp>启用/停用保存玩家位置数据</Chinesesimp>
+    <Spanish>Activa o desactiva el guardado de la posición del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_SAVESCORES">
     <English>Store Scores:</English>
 	<Chinesesimp>储存积分：</Chinesesimp>
+    <Spanish>Guardar puntuación:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_SAVESCORES_COMMENT">
     <English>Enable/disable saving player score for the current mission</English>
 	<Chinesesimp>启用/停用保存玩家当前任务的积分</Chinesesimp>
+    <Spanish>Activa o desactiva el guardado de la puntuación del jugador en la misión actual</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_autoSaveTime">
     <English>Auto Save Interval:</English>
 	<Chinesesimp>自动保存间隔</Chinesesimp>
+    <Spanish>Intervalo de guardado automático:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_autoSaveTime_SET">
     <English>Set Auto Save Interval</English>
 	<Chinesesimp>设定自动保存间隔</Chinesesimp>
+    <Spanish>Definir el intervalo de guardado automático</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_autoSaveTime_COMMENT">
     <English>Set the interval between auto saves of player data (in seconds) to external database. This may impact server performance. 0 means save only at mission exit or player disconnection.</English>
 	<Chinesesimp>设定为玩家数据自动保存到外部数据库的间隔(以秒计)。这可能会影响服务器性能。0意为仅在任务退出或玩家断开连接时保存。</Chinesesimp>
+    <Spanish>Define el intervalo (en segundos) entre guardados automáticos de los datos del jugador en la base de datos externa. Puede afectar al rendimiento del servidor. 0 significa guardar solo al salir de la misión o al desconectarse el jugador.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_ERROR1">
     <English>Only one Player Persistence module can be used</English>
 	<Chinesesimp>只有一个玩家持续性模组可以被使用</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de persistencia de jugador</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_playeroptions/stringtable.xml
+++ b/addons/sys_playeroptions/stringtable.xml
@@ -5,45 +5,56 @@
 <Key ID="STR_ALIVE_playeroptions">
     <English>ALiVE Player Options</English>
     <Chinesesimp>ALiVE玩家选项</Chinesesimp>
+    <Spanish>Opciones de jugador de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYEROPTIONS_SHORT">
     <English>Player Options</English>
     <Chinesesimp>玩家选项</Chinesesimp>
+    <Spanish>Opciones de jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_playeroptions_COMMENT">
     <English>Set in game player options such as view distance, respawn, player persistence, crew info, player tags and more</English>
     <Chinesesimp>设置游戏玩家选项,如视野距离,重生,玩家持久性,乘员信息,玩家标签等</Chinesesimp>
+    <Spanish>Configura opciones de jugador en el juego, como la distancia de visión, la reaparición, la persistencia de jugador, la info de tripulación, las etiquetas de jugador y más</Spanish>
 </Key>
 <Key ID="STR_ALIVE_playeroptionsPARAMS">
     <English>Template Parameters</English>
     <Chinesesimp>模板参数</Chinesesimp>
+    <Spanish>Parámetros de la plantilla</Spanish>
 </Key>
 <Key ID="STR_ALIVE_playeroptions_ERROR1">
     <English>Only one module template allowed</English>
     <Chinesesimp>只允许一个模块模板</Chinesesimp>
+    <Spanish>Solo se permite una plantilla de módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_playeroptionsPARAMS_COMMENT">
     <English>Over-ride default parameters for the Module Template</English>
     <Chinesesimp>覆盖模块模板的默认参数</Chinesesimp>
+    <Spanish>Anula los parámetros por defecto de la plantilla de módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_playeroptions_DEBUG">
     <English>Debug:</English>
     <Chinesesimp>调试:</Chinesesimp>
+    <Spanish>Depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_playeroptions_DEBUG_COMMENT">
     <English>Enable Debug</English>
     <Chinesesimp>启用调试DEBUG:</Chinesesimp>
+    <Spanish>Activar depuración</Spanish>
 </Key>
 <Key ID="STR_ALIVE_playeroptions_USAGE">
     <English>Simply place the ALiVE Player Options module and set the appropriate parameters. You do not need to sync, position or orientate this module.</English>
     <Chinesesimp>简单地放置ALIVE玩家选项模块,并设置适当的参数。你不需要同步,或定位这个模块。</Chinesesimp>
+    <Spanish>Simplemente coloca el módulo Opciones de jugador de ALiVE y ajusta los parámetros correspondientes. No necesitas sincronizarlo, colocarlo ni orientarlo de ninguna forma concreta.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_RESTORE_MARKERS">
     <English>Restore ALiVE Markers</English>
     <Chinesesimp>恢复ALIVE标记</Chinesesimp>
+    <Spanish>Restaurar marcadores de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_player_RESTORE_MARKERS_COMMENT">
     <English>Reinitialise the ALiVE SYS Marker Store locally</English>
     <Chinesesimp>在本地重新初始化ALIVE SYS标记存储</Chinesesimp>
+    <Spanish>Reinicializa localmente el almacén de marcadores de ALiVE</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_playertags/stringtable.xml
+++ b/addons/sys_playertags/stringtable.xml
@@ -5,153 +5,191 @@
 <Key ID="STR_ALIVE_PLAYERTAGS">
     <English>Player Tags</English>
     <Chinesesimp>玩家标签</Chinesesimp>
+    <Spanish>Etiquetas de jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_COMMENT">
     <English>Player tag functions</English>
     <Chinesesimp>玩家标签功能</Chinesesimp>
+    <Spanish>Funciones de etiquetas de jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_DISPLAY_COMMENT">   
     <English>Allow player to see player's names</English>
     <Chinesesimp>允许玩家看到玩家的名字</Chinesesimp>
+    <Spanish>Permite al jugador ver los nombres de los demás jugadores</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_DISPLAY_ENABLE">
     <English>Enable Player Tags</English>
     <Chinesesimp>启用玩家标签</Chinesesimp>
+    <Spanish>Activar etiquetas de jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_DISPLAY_DISABLE">  
     <English>Disable Player Tags</English>
     <Chinesesimp>禁用玩家标签</Chinesesimp>
+    <Spanish>Desactivar etiquetas de jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_ERROR1">
     <English>Only one Player Tags module can be used</English>
     <Chinesesimp>只能使用一个玩家标签模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de etiquetas de jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用调试DEBUG:</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_DEBUG_COMMENT">
     <English>Enables Player Tags Module Debug</English>
     <Chinesesimp>启用调试DEBUG</Chinesesimp>
+    <Spanish>Activa la depuración del módulo de etiquetas de jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_STYLE">
     <English>Player Tags:</English>
     <Chinesesimp>玩家标签:</Chinesesimp>
+    <Spanish>Etiquetas de jugador:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_STYLE_COMMENT">
     <English>Switches style and method of player detection</English>
     <Chinesesimp>切换玩家检测的风格和方法</Chinesesimp>
+    <Spanish>Cambia el estilo y el método de detección de jugadores</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_ONVIEW">
     <English>Player Tags On View Only:</English>
     <Chinesesimp>只在直视时显示玩家标签:</Chinesesimp>
+    <Spanish>Etiquetas solo al mirar:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_ONVIEW_COMMENT">
     <English>Only show tags if player is looked at directly</English>
     <Chinesesimp>只在直视时显示玩家标签</Chinesesimp>
+    <Spanish>Muestra las etiquetas solo si se mira directamente al jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_GROUP">
     <English>Player Tags Display Group:</English>
     <Chinesesimp>玩家标签显示组:</Chinesesimp>
+    <Spanish>Mostrar grupo en las etiquetas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_GROUP_COMMENT">
     <English>Enables Player Group Indicator</English>
     <Chinesesimp>启用玩家群体指示器</Chinesesimp>
+    <Spanish>Activa el indicador de grupo del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_RANK">
     <English>Player Tags Display Rank:</English>
     <Chinesesimp>玩家标签显示排名:</Chinesesimp>
+    <Spanish>Mostrar rango en las etiquetas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_RANK_COMMENT">
     <English>Enables Player Rank Indicator</English>
     <Chinesesimp>启用玩家排名指示器</Chinesesimp>
+    <Spanish>Activa el indicador de rango del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_INVEHICLE">
     <English>Player Tags In Vehicle:</English>
     <Chinesesimp>车辆上的玩家标签:</Chinesesimp>
+    <Spanish>Etiquetas dentro de vehículos:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_INVEHICLE_COMMENT">
     <English>Enables Player Tags whilst in Vehicles (disable if using crewinfo module)</English>
     <Chinesesimp>在车辆中启用玩家标签(如果使用crewinfo模块则禁用)</Chinesesimp>
+    <Spanish>Activa las etiquetas de jugador dentro de los vehículos (desactívalo si usas el módulo de info de tripulación)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_FRIENDLYUNITSONLY">
     <English>Restrict To Friendly Units:</English>
     <Chinesesimp>仅限友军单位:</Chinesesimp>
+    <Spanish>Restringir a unidades aliadas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_FRIENDLYUNITSONLY_COMMENT">
     <English>Only show player tags for units that are friendly to the player</English>
     <Chinesesimp>只显示对玩家友好的单位的玩家标签</Chinesesimp>
+    <Spanish>Muestra las etiquetas solo en unidades aliadas del jugador</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_TARGETS">
     <English>Player Tag Targets:</English>
     <Chinesesimp>玩家标签目标:</Chinesesimp>
+    <Spanish>Objetivos de las etiquetas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_TARGETS_COMMENT">
     <English>Sets Tag Target Types</English>
     <Chinesesimp>设置标签目标类型</Chinesesimp>
+    <Spanish>Define los tipos de objetivo de las etiquetas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_DISTANCE">
     <English>Player Tag Distance:</English>
     <Chinesesimp>玩家标签距离:</Chinesesimp>
+    <Spanish>Distancia de las etiquetas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_DISTANCE_COMMENT">
     <English>Sets Name Tag Distance</English>
     <Chinesesimp>设置姓名标签距离</Chinesesimp>
+    <Spanish>Define la distancia de las etiquetas de nombre</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_SCALE">
     <English>Player Tag Scale:</English>
     <Chinesesimp>玩家标签大小:</Chinesesimp>
+    <Spanish>Escala de las etiquetas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_SCALE_COMMENT">
     <English>Sets Name Tag Scale</English>
     <Chinesesimp>设置玩家标签大小</Chinesesimp>
+    <Spanish>Define la escala de las etiquetas de nombre</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_HEIGHT">
     <English>Player Tag Height:</English>
     <Chinesesimp>玩家标签高度:</Chinesesimp>
+    <Spanish>Altura de las etiquetas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_HEIGHT_COMMENT">
     <English>Sets Name Tag Height</English>
     <Chinesesimp>设置玩家标签高度</Chinesesimp>
+    <Spanish>Define la altura de las etiquetas de nombre</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_TOLERANCE">
     <English>Player Tag Tolerance:</English>
     <Chinesesimp>玩家标签宽度:</Chinesesimp>
+    <Spanish>Tolerancia de las etiquetas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_TOLERANCE_COMMENT">
     <English>Sets Name Tag Tolerance</English>
     <Chinesesimp>设置姓名标签宽度</Chinesesimp>
+    <Spanish>Define la tolerancia de las etiquetas de nombre</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_NAMECOLOUR">
     <English>Player Tag Name Colour:</English>
     <Chinesesimp>玩家标签姓名颜色:</Chinesesimp>
+    <Spanish>Color del nombre en las etiquetas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_NAMECOLOUR_COMMENT">
     <English>Sets Name Colour</English>
     <Chinesesimp>设置名字颜色</Chinesesimp>
+    <Spanish>Define el color del nombre</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_GROUPCOLOUR">
     <English>Player Tag Group Colour:</English>
     <Chinesesimp>球员标签组颜色:</Chinesesimp>
+    <Spanish>Color del grupo en las etiquetas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_GROUPCOLOUR_COMMENT">
     <English>Sets Group Colour</English>
     <Chinesesimp>设置组色</Chinesesimp>
+    <Spanish>Define el color del grupo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_THISGROUPLEADERNAMECOLOUR">
     <English>Player Tag GL Colour:</English>
     <Chinesesimp>玩家标签组长颜色:</Chinesesimp>
+    <Spanish>Color del jefe de grupo en las etiquetas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_THISGROUPLEADERNAMECOLOUR_COMMENT">
     <English>Sets Your Group Leader's Colour</English>
     <Chinesesimp>设置你的组长的颜色</Chinesesimp>
+    <Spanish>Define el color del jefe de tu grupo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_THISGROUPCOLOUR">
     <English>Player Tag Group Colour:</English>
     <Chinesesimp>玩家标签组颜色:</Chinesesimp>
+    <Spanish>Color de tu grupo en las etiquetas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PLAYERTAGS_THISGROUPCOLOUR_COMMENT">
     <English>Sets Your Group's Colour</English>
     <Chinesesimp>设置群组的颜色</Chinesesimp>
+    <Spanish>Define el color de tu grupo</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_profile/stringtable.xml
+++ b/addons/sys_profile/stringtable.xml
@@ -5,10 +5,12 @@
 <Key ID="STR_ALIVE_PROFILE_SYSTEM">
     <English>ALiVE Virtual AI System</English>
     <Chinesesimp>ALiVE虚拟人工智能系统</Chinesesimp>
+    <Spanish>Sistema de IA virtual de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_COMMENT">
     <English>Virtual AI System (Profiles)</English>
     <Chinesesimp>虚拟人工智能系统（配置文件）</Chinesesimp>
+    <Spanish>Sistema de IA virtual (perfiles)</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_DEBUG">
@@ -33,178 +35,222 @@
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PERSISTENT">
     <English>Persistent:</English>
     <Chinesesimp>持久性:</Chinesesimp>
+    <Spanish>Persistente:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PERSISTENT_COMMENT">
     <English>Enables external Database persistence for Virtual AI</English>
     <Chinesesimp>为虚拟AI启用外部数据库持久化</Chinesesimp>
+    <Spanish>Activa la persistencia en base de datos externa para la IA virtual</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PLOT_SECTORS">
     <English>Sector Colouring:</English>
     <Chinesesimp>扇区着色：</Chinesesimp>
+    <Spanish>Coloreado de sectores:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PLOT_SECTORS_COMMENT">
     <English>Enables sector colouring according to units presence</English>
     <Chinesesimp>根据单位存在启用扇区着色</Chinesesimp>
+    <Spanish>Activa el coloreado de sectores según la presencia de unidades</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SYNC">
     <English>Synchronisation Options:</English>
     <Chinesesimp>同步选项：</Chinesesimp>
+    <Spanish>Opciones de sincronización:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SYNC_COMMENT">
     <English>Modify synced units behaviour</English>
     <Chinesesimp>修改同步单位行为</Chinesesimp>
+    <Spanish>Modifica el comportamiento de las unidades sincronizadas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SYNC_ADD">
     <English>Only virtualize synced units</English>
     <Chinesesimp>仅虚拟化同步单位</Chinesesimp>
+    <Spanish>Virtualizar solo las unidades sincronizadas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SYNC_IGNORE">
     <English>Virtualize all editor placed units except synced units</English>
     <Chinesesimp>虚拟化除同步单位外的所有编辑器放置单位</Chinesesimp>
+    <Spanish>Virtualizar todas las unidades colocadas en el editor salvo las sincronizadas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SPAWN_RADIUS">
     <English>Spawn Radius (m):</English>
     <Chinesesimp>生成半径:</Chinesesimp>
+    <Spanish>Radio de aparición (m):</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SPAWN_RADIUS_COMMENT">
     <English>Sets the distance from players to spawn AI units</English>
     <Chinesesimp>设置玩家与AI单位生成的距离</Chinesesimp>
+    <Spanish>Define a qué distancia de los jugadores aparecen las unidades de IA</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_ACTIVE_LIMITER">
     <English>Active Limiter:</English>
     <Chinesesimp>活动限制:</Chinesesimp>
+    <Spanish>Limitador de activos:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_ACTIVE_LIMITER_COMMENT">
     <English>Sets the max number of virtualized AI *groups* to spawn at any one time</English>
     <Chinesesimp>设置任何时候要生成的虚拟化AI*组*的最大数量</Chinesesimp>
+    <Spanish>Define el número máximo de *grupos* de IA virtualizada que pueden aparecer a la vez</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_ZEUSSPAWN">
     <English>Zeus Spawn Virtual Groups:</English>
     <Chinesesimp>宙斯生成虚拟组：</Chinesesimp>
+    <Spanish>Zeus genera grupos virtuales:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_ZEUSSPAWN_COMMENT">
     <English>If enabled, active zeus entities will spawn virtual groups when in range</English>
     <Chinesesimp>如果启用,活动的宙斯实体将在范围内生成虚拟组</Chinesesimp>
+    <Spanish>Si se activa, las entidades de Zeus activas harán aparecer grupos virtuales cuando estén en rango</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_AIR_COMBAT_SPAWNING">
     <English>Air Combat</English>
     <Chinesesimp>空中战斗</Chinesesimp>
+    <Spanish>Combate aéreo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_AIR_COMBAT_SPAWNING_COMMENT">
     <English>Enables specialized spawning behavior. Aircraft and AAA profiles are always spawned.</English>
     <Chinesesimp>启用专用生成行为。飞机和AAA配置文件始终会生成。</Chinesesimp>
+    <Spanish>Activa un comportamiento de aparición especializado. Los perfiles de aeronaves y de artillería antiaérea siempre aparecen.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PROFILE_ACTIVATORS">
     <English>Modes</English>
     <Chinesesimp>模式</Chinesesimp>
+    <Spanish>Modos</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PROFILE_ACTIVATORS_COMMENT">
     <English>Choose which profile spawn modes are enabled and configure the selected mode's settings. Proximity is enabled by default; Air Combat is disabled by default.</English>
     <Chinesesimp>选择启用的配置文件生成模式并配置当前模式。接近模式默认启用；空中战斗模式默认禁用。</Chinesesimp>
+    <Spanish>Elige qué modos de aparición de perfiles están activos y configura los ajustes del modo seleccionado. Proximidad está activo por defecto; Combate aéreo está desactivado por defecto.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PROXIMITY_SPAWNING">
     <English>Proximity</English>
     <Chinesesimp>接近</Chinesesimp>
+    <Spanish>Proximidad</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PROXIMITY_SPAWNING_COMMENT">
     <English>Proximity Spawn activates profiles in a radius around the player. The spawn radius can be adjusted based on the type of vehicle a player is in. This cannot be disabled.</English>
     <Chinesesimp>接近生成会在玩家周围半径内激活配置文件。生成半径可根据玩家所乘载具类型调整。此功能无法禁用。</Chinesesimp>
+    <Spanish>La aparición por proximidad activa los perfiles en un radio alrededor del jugador. El radio se puede ajustar según el tipo de vehículo en el que vaya el jugador. No se puede desactivar.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PROXIMITY_SETTINGS">
     <English>Proximity Spawn</English>
     <Chinesesimp>接近生成</Chinesesimp>
+    <Spanish>Aparición por proximidad</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_AIR_COMBAT_SETTINGS">
     <English>Air Combat Spawn</English>
     <Chinesesimp>空战生成</Chinesesimp>
+    <Spanish>Aparición por combate aéreo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_AIR_COMBAT_PLANE_RADIUS">
     <English>Plane Vehicle Radius (m):</English>
     <Chinesesimp>飞机载具半径 (米):</Chinesesimp>
+    <Spanish>Radio de vehículos para aviones (m):</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_AIR_COMBAT_PLANE_RADIUS_COMMENT">
     <English>Distance around a player-controlled plane that ground vehicles spawn. Set to 0 to disable.</English>
     <Chinesesimp>玩家控制的飞机周围生成地面载具的距离。设为0可禁用。</Chinesesimp>
+    <Spanish>Distancia alrededor de un avión controlado por un jugador a la que aparecen los vehículos terrestres. Ponlo a 0 para desactivarlo.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_AIR_COMBAT_HELI_RADIUS">
     <English>Helicopter Vehicle Radius (m):</English>
     <Chinesesimp>直升机载具半径 (米):</Chinesesimp>
+    <Spanish>Radio de vehículos para helicópteros (m):</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_AIR_COMBAT_HELI_RADIUS_COMMENT">
     <English>Distance around a player-controlled helicopter that ground vehicles spawn. Set to 0 to disable.</English>
     <Chinesesimp>玩家控制的直升机周围生成地面载具的距离。设为0可禁用。</Chinesesimp>
+    <Spanish>Distancia alrededor de un helicóptero controlado por un jugador a la que aparecen los vehículos terrestres. Ponlo a 0 para desactivarlo.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SPAWN_JET_RADIUS">
     <English>Spawn Planes Radius (m):</English>
     <Chinesesimp>平面生成半径</Chinesesimp>
+    <Spanish>Radio de aparición en avión (m):</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SPAWN_JET_RADIUS_COMMENT">
     <English>The radius around player in planes to spawn AI. Set to 0 to disable spawning while in planes</English>
     <Chinesesimp>玩家在平面上生成AI的半径。设置为0可禁用在平面中生成</Chinesesimp>
+    <Spanish>Radio alrededor del jugador en avión en el que aparece la IA. Ponlo a 0 para desactivar la aparición mientras se vuela en avión</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SPAWN_HELI_RADIUS">
     <English>Spawn Heli Radius (m):</English>
     <Chinesesimp>直升机生成半径:</Chinesesimp>
+    <Spanish>Radio de aparición en helicóptero (m):</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SPAWN_HELI_RADIUS_COMMENT">
     <English>The radius around player in helicopters to spawn AI. Set to 0 to disable spawning while in helicopters</English>
     <Chinesesimp>玩家在直升机上生成人工智能的半径。设置为0可在直升机中禁用生成</Chinesesimp>
+    <Spanish>Radio alrededor del jugador en helicóptero en el que aparece la IA. Ponlo a 0 para desactivar la aparición mientras se vuela en helicóptero</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SPAWN_UAV_RADIUS">
     <English>Spawn UAV Radius (m):</English>
     <Chinesesimp>无人机生成半径:</Chinesesimp>
+    <Spanish>Radio de aparición con UAV (m):</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SPAWN_UAV_RADIUS_COMMENT">
     <English>The radius around player controlled UAV to spawn AI. Set to 0 to disable spawning while controlling UAVs. Set to -1 to default to (Infantry) Spawn Radius + 800.</English>
     <Chinesesimp>玩家控制的无人机周围的半径生产出AI。设置为0禁用生成时控制无人机。设置为-1默认为(步兵)生成半径 + 800.</Chinesesimp>
+    <Spanish>Radio alrededor del UAV controlado por el jugador en el que aparece la IA. Ponlo a 0 para desactivar la aparición mientras se controla un UAV. Ponlo a -1 para usar por defecto el radio de aparición (de infantería) + 800.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SPEED_MODIFIER">
     <English>Virtual Unit Speed:</English>
     <Chinesesimp>虚拟单位速度:</Chinesesimp>
+    <Spanish>Velocidad de las unidades virtuales:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SPEED_MODIFIER_COMMENT">
     <English>Alters how fast virtual AI move across the map. 0.25 means 25% of a unit's normal speed</English>
     <Chinesesimp>改变虚拟AI在地图上移动的速度。25%是指单位正常速度的25%</Chinesesimp>
+    <Spanish>Modifica la rapidez con la que la IA virtual se desplaza por el mapa. 0.25 significa el 25 % de la velocidad normal de una unidad</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_ERROR1">
     <English>Only one Virtual AI System module can be used</English>
     <Chinesesimp>只能使用一个虚拟AI系统模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de sistema de IA virtual</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_DEBUG_ENABLE">
     <English>Activate Profiles Debug</English>
     <Chinesesimp>激活配置文件调试</Chinesesimp>
+    <Spanish>Activar depuración de perfiles</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_DEBUG_DISABLE">
     <English>Deactivate Profiles Debug</English>
     <Chinesesimp>关闭配置文件调试</Chinesesimp>
+    <Spanish>Desactivar depuración de perfiles</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_DEBUG1_COMMENT">
     <English>Toggle debug mode on the profile system</English>
     <Chinesesimp>切换配置文件系统上的调试模式</Chinesesimp>
+    <Spanish>Activa o desactiva el modo de depuración del sistema de perfiles</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_VIRTUAL_COMBAT_SPEED_MODIFIER">
     <English>Virtual Combat Speed:</English>
     <Chinesesimp>虚拟作战速度：</Chinesesimp>
+    <Spanish>Velocidad del combate virtual:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_VIRTUAL_COMBAT_SPEED_MODIFIER_COMMENT">
     <English>Sets the pace of virtual combat. Fastest combat resolves twice as quickly as regular.</English>
     <Chinesesimp>设置虚拟战斗的节奏.最快的战斗解决速度是普通战斗的两倍.</Chinesesimp>
+    <Spanish>Define el ritmo del combate virtual. El más rápido resuelve el combate el doble de rápido que el normal.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_VIRTUAL_COMBAT_RANGE_MODIFIER">
     <English>Virtual Combat Range:</English>
     <Chinesesimp>虚拟单位战斗距离</Chinesesimp>
+    <Spanish>Alcance del combate virtual:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_VIRTUAL_COMBAT_RANGE_MODIFIER_COMMENT">
     <English>Sets the range of virtual combat in metres.</English>
     <Chinesesimp>以米为单位设置虚拟战斗的范围</Chinesesimp>
+    <Spanish>Define el alcance del combate virtual en metros.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PATHFINDING">
     <English>Pathfinding:</English>
     <Chinesesimp>实验路径查找：</Chinesesimp>
+    <Spanish>Búsqueda de rutas:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PATHFINDING_COMMENT">
     <English>Profiles use intelligent pathing to reach their destinations, routing around terrain, water and dense areas instead of travelling in straight lines.\nEnabled by default. Set to No to fall back to straight-line movement if you prefer, or if you encounter an issue.</English>
     <Chinesesimp>实验的!\n这项功能是高度实验性的,可能会破坏任务.\n如果发现任何问题,请禁用.\n配置文件将使用智能路径到达目的地.</Chinesesimp>
+    <Spanish>Los perfiles usan rutas inteligentes para llegar a su destino, rodeando el terreno, el agua y las zonas densas en lugar de ir en línea recta.\nActivado por defecto. Ponlo en No para volver al movimiento en línea recta si lo prefieres o si encuentras algún problema.</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PATHFINDING_GRID">
@@ -219,6 +265,7 @@
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PATHFINDING_GRID_COMMENT">
     <English>Controls the resolution of the pathfinding grid.\n\nAuto (recommended) sizes the grid to this map automatically - no need to match a map size by hand. High detail / Balanced / Performance trade path accuracy against server load. (An exact grid size can still be forced from init.sqf if ever needed.)</English>
     <Chinesesimp>实验的!\n这项功能是高度实验性的,可能会破坏任务.\n如果发现任何问题,请禁用.\n配置文件将使用智能路径到达目的地.</Chinesesimp>
+    <Spanish>Controla la resolución de la cuadrícula de búsqueda de rutas.\n\nAutomática (recomendada) ajusta la cuadrícula a este mapa por sí sola, sin necesidad de igualar a mano el tamaño del mapa. Detalle alto / Equilibrado / Rendimiento equilibran la precisión de las rutas frente a la carga del servidor. (Si alguna vez hiciera falta, todavía se puede forzar un tamaño de cuadrícula exacto desde init.sqf.)</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_PATHFINDING_DRAWGRID">
@@ -303,6 +350,7 @@
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SEATRANSPORT">
     <English>Infantry Sea Transport:</English>
     <Chinesesimp>步兵海上运输：</Chinesesimp>
+    <Spanish>Transporte marítimo de infantería:</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SEATRANSPORT_COMMENT">
@@ -317,10 +365,12 @@
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SMOOTHSPAWN">
     <English>Smooth Spawn:</English>
     <Chinesesimp>丝滑生成</Chinesesimp>
+    <Spanish>Aparición progresiva:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_SMOOTHSPAWN_COMMENT">
     <English>Sleep values between spawning units to not overload engine</English>
     <Chinesesimp>生成单位之间的睡眠值不会使引擎过载</Chinesesimp>
+    <Spanish>Tiempos de espera entre la aparición de unidades para no sobrecargar el motor</Spanish>
 </Key>
 <!-- AI-translated; native-speaker review welcome -->
 <Key ID="STR_ALIVE_PROFILE_SYSTEM_VEH_SETTLE">
@@ -484,20 +534,26 @@
 </Key>
 <Key ID="STR_ALIVE_PROFILE_VIRTUALISE">
     <English>Virtualise Groups In Radius</English>
+    <Spanish>Virtualizar grupos en un radio</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_VIRTUALISE_PROMPT">
     <English>Virtualise unprofiled AI groups in this area.</English>
+    <Spanish>Virtualiza los grupos de IA sin perfil de esta zona.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_VIRTUALISE_RADIUS">
     <English>Radius (m):</English>
+    <Spanish>Radio (m):</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_VIRTUALISE_INVALID_RADIUS">
     <English>Enter a radius greater than zero.</English>
+    <Spanish>Introduce un radio mayor que cero.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_VIRTUALISE_NO_PROFILE_SYSTEM">
     <English>Virtual AI System is not running.</English>
+    <Spanish>El sistema de IA virtual no está en funcionamiento.</Spanish>
 </Key>
 <Key ID="STR_ALIVE_PROFILE_VIRTUALISE_COMPLETE">
     <English>ALiVE: Virtualised %1 group(s) and %2 vehicle(s).</English>
+    <Spanish>ALiVE: virtualizados %1 grupo(s) y %2 vehículo(s).</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_quickstart/stringtable.xml
+++ b/addons/sys_quickstart/stringtable.xml
@@ -5,29 +5,36 @@
 <Key ID="STR_ALIVE_QUICKSTART">
     <English>Quick Start Module</English>
     <Chinesesimp>快速启动模块</Chinesesimp>
+    <Spanish>Módulo de inicio rápido</Spanish>
 </Key>
 <Key ID="STR_ALIVE_QUICKSTART_COMMENT">
     <English>Autostarting ALiVE Module template (uses additional module to configure parameters)</English>
     <Chinesesimp>自动启动ALiVE模块模板(使用其他模块配置参数)</Chinesesimp>
+    <Spanish>Plantilla de módulo ALiVE de arranque automático (usa un módulo adicional para configurar los parámetros)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_QUICKSTART_DATABASE">
     <English>Database:</English>
     <Chinesesimp>数据库：</Chinesesimp>
+    <Spanish>Base de datos:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_QUICKSTART_DATABASE_COMMENT">
     <English>Enable the external database to persist your mission</English>
     <Chinesesimp>启用外部数据库来持久化您的任务</Chinesesimp>
+    <Spanish>Activa la base de datos externa para hacer persistente tu misión</Spanish>
 </Key>
 <Key ID="STR_ALIVE_QUICKSTART_ERROR1">
     <English>Only one Quick Start Module allowed</English>
     <Chinesesimp>只允许一个快速启动模块</Chinesesimp>
+    <Spanish>Solo se permite un módulo de inicio rápido</Spanish>
 </Key>
 <Key ID="STR_ALIVE_QUICKSTART_DEBUG">
     <English>Debug:</English>
     <Chinesesimp>调试:</Chinesesimp>
+    <Spanish>Depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_QUICKSTART_DEBUG_COMMENT">
     <English>Enable Debug</English>
     <Chinesesimp>启用调试</Chinesesimp>
+    <Spanish>Activar depuración</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_sitrep/stringtable.xml
+++ b/addons/sys_sitrep/stringtable.xml
@@ -5,41 +5,51 @@
 <Key ID="STR_ALIVE_sitrep">
     <English>sitrep Module</English>
     <Chinesesimp>情况报告模块</Chinesesimp>
+    <Spanish>Módulo SITREP</Spanish>
 </Key>
 <Key ID="STR_ALIVE_sitrep_COMMENT">
     <English>Send a SITREP to be stored in game and on War Room</English>
     <Chinesesimp>发送一个情况报告存储在游戏和作战室</Chinesesimp>
+    <Spanish>Envía un SITREP para almacenarlo en el juego y en la War Room</Spanish>
 </Key>
 <Key ID="STR_ALIVE_sitrepPARAMS">
     <English>Template Parameters</English>
     <Chinesesimp>模块模板</Chinesesimp>
+    <Spanish>Parámetros de la plantilla</Spanish>
 </Key>
 <Key ID="STR_ALIVE_sitrep_ERROR1">
     <English>Only one module template allowed</English>
     <Chinesesimp>只允许一个模块模板</Chinesesimp>
+    <Spanish>Solo se permite una plantilla de módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_sitrepPARAMS_COMMENT">
     <English>Over-ride default parameters for the Module Template</English>
     <Chinesesimp>覆盖模块模板的默认参数</Chinesesimp>
+    <Spanish>Anula los parámetros por defecto de la plantilla de módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_sitrepPARAMS_USAGE">
     <English>Place the module and configure the over-rides</English>
     <Chinesesimp>放置模块并设定覆盖</Chinesesimp>
+    <Spanish>Coloca el módulo y configura las anulaciones</Spanish>
 </Key>
 <Key ID="STR_ALIVE_sitrep_DEBUG">
     <English>Debug:</English>
     <Chinesesimp>调试:</Chinesesimp>
+    <Spanish>Depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_sitrep_DEBUG_COMMENT">
     <English>Enable Debug</English>
     <Chinesesimp>启用调试</Chinesesimp>
+    <Spanish>Activar depuración</Spanish>
 </Key>
 <Key ID="STR_ALIVE_sitrep_DIALOG_TITLE">
     <English>ADVANCED SITREP</English>
     <Chinesesimp>高级情况报告</Chinesesimp>
+    <Spanish>SITREP AVANZADO</Spanish>
 </Key>
 <Key ID="STR_ALIVE_sitrep_DIALOG_SITREP">
     <English>SITREP</English>
     <Chinesesimp>情况报告</Chinesesimp>
+    <Spanish>SITREP</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_spotrep/stringtable.xml
+++ b/addons/sys_spotrep/stringtable.xml
@@ -5,41 +5,51 @@
 <Key ID="STR_ALIVE_spotrep">
     <English>spotrep Module</English>
     <Chinesesimp>更新日志模块</Chinesesimp>
+    <Spanish>Módulo SPOTREP</Spanish>
 </Key>
 <Key ID="STR_ALIVE_spotrep_COMMENT">
     <English>Autostarting ALiVE Module template (uses additional module to configure parameters)</English>
     <Chinesesimp>自动启动ALiVE模块模板(使用额外的模块来配置参数)</Chinesesimp>
+    <Spanish>Plantilla de módulo ALiVE de arranque automático (usa un módulo adicional para configurar los parámetros)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_spotrepPARAMS">
     <English>Template Parameters</English>
     <Chinesesimp>模板参数</Chinesesimp>
+    <Spanish>Parámetros de la plantilla</Spanish>
 </Key>
 <Key ID="STR_ALIVE_spotrep_ERROR1">
     <English>Only one module template allowed</English>
     <Chinesesimp>Only one module template allowed</Chinesesimp>
+    <Spanish>Solo se permite una plantilla de módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_spotrepPARAMS_COMMENT">
     <English>Over-ride default parameters for the Module Template</English>
     <Chinesesimp>覆盖模块模板的默认参数</Chinesesimp>
+    <Spanish>Anula los parámetros por defecto de la plantilla de módulo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_spotrepPARAMS_USAGE">
     <English>Place the module and configure the over-rides</English>
     <Chinesesimp>放置模块并设定覆盖</Chinesesimp>
+    <Spanish>Coloca el módulo y configura las anulaciones</Spanish>
 </Key>
 <Key ID="STR_ALIVE_spotrep_DEBUG">
     <English>Debug:</English>
     <Chinesesimp>调试：</Chinesesimp>
+    <Spanish>Depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_spotrep_DEBUG_COMMENT">
     <English>Enable Debug</English>
     <Chinesesimp>启用调试</Chinesesimp>
+    <Spanish>Activar depuración</Spanish>
 </Key>
 <Key ID="STR_ALIVE_spotrep_DIALOG_TITLE">
     <English>ADVANCED spotrep</English>
     <Chinesesimp>高级日志更新</Chinesesimp>
+    <Spanish>SPOTREP AVANZADO</Spanish>
 </Key>
 <Key ID="STR_ALIVE_spotrep_DIALOG_spotrep">
     <English>spotrep</English>
     <Chinesesimp>更新日志</Chinesesimp>
+    <Spanish>spotrep</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_statistics/stringtable.xml
+++ b/addons/sys_statistics/stringtable.xml
@@ -5,26 +5,32 @@
 <Key ID="STR_ALIVE_STATISTICS">
     <English>Statistics</English>
     <Chinesesimp>统计数据</Chinesesimp>
+    <Spanish>Estadísticas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_DISABLE_STATISTICS">
     <English>Disable Statistics</English>
     <Chinesesimp>禁用统计数据</Chinesesimp>
+    <Spanish>Desactivar estadísticas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_STATISTICS_COMMENT">
     <English>Disable MP Statistics recorded to ALiVE web service</English>
     <Chinesesimp>禁用记录到ALiVE web服务的MP统计信息</Chinesesimp>
+    <Spanish>Desactiva el registro de estadísticas multijugador en el servicio web de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_STATISTICS_ENABLE">
     <English>Enable Statistics</English>
     <Chinesesimp>启用统计数据</Chinesesimp>
+    <Spanish>Activar estadísticas</Spanish>
 </Key>
 <Key ID="STR_ALIVE_STATISTICS_ENABLE_COMMENT">
     <English>Enable/Disable events/statistics recording to the ALiVE web service</English>
     <Chinesesimp>启用/禁用ALiVE web服务的事件/统计记录</Chinesesimp>
+    <Spanish>Activa o desactiva el registro de eventos y estadísticas en el servicio web de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_STATISTICS_ERROR1">
     <English>Only one statistics module can be used</English>
     <Chinesesimp>只能使用一个统计模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de estadísticas</Spanish>
 </Key>
 
 </Container></Package></Project>

--- a/addons/sys_tour/stringtable.xml
+++ b/addons/sys_tour/stringtable.xml
@@ -5,17 +5,21 @@
 <Key ID="STR_ALIVE_TOUR">
     <English>ALiVE Tour</English>
     <Chinesesimp>ALiVE Tour(观战)</Chinesesimp> 
+    <Spanish>Visita guiada de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TOUR_COMMENT">
     <English>Drop on a mission to enable a tour for players</English>
     <Chinesesimp>进入到一个任务中,以供玩家观战</Chinesesimp>
+    <Spanish>Colócalo en una misión para ofrecer una visita guiada a los jugadores</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TOUR_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用调试：</Chinesesimp> 
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TOUR_DEBUG_COMMENT">
     <English>Enables Tour Module Debug</English>
     <Chinesesimp>启用Tour模块调试</Chinesesimp>
+    <Spanish>Activa la depuración del módulo de visita guiada</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/sys_viewdistance/stringtable.xml
+++ b/addons/sys_viewdistance/stringtable.xml
@@ -5,66 +5,82 @@
 <Key ID="STR_ALIVE_VDIST">
     <English>View Settings</English>
     <Chinesesimp>视野设置</Chinesesimp>
+    <Spanish>Ajustes de visión</Spanish>
 </Key>
 <Key ID="STR_ALIVE_VDIST_COMMENT">
     <English>View Distance Settings in Game</English>
     <Chinesesimp>在游戏中修改视距设置</Chinesesimp>
+    <Spanish>Ajustes de distancia de visión en el juego</Spanish>
 </Key>
 <Key ID="STR_ALIVE_VDIST_USAGE">
     <English>View Settings module allows you to dynamically change the appropriate view and terrain grid distance in game. You can also force a fixed View Distance by setting max and min values the same!</English>
     <Chinesesimp>视图设置模块允许您在游戏中动态更改适当的视图和地形网格距离。您还可以通过将最大值和最小值设置为相同来强制设置固定的“视距”！</Chinesesimp>
+    <Spanish>El módulo de ajustes de visión te permite cambiar dinámicamente la distancia de visión y la cuadrícula de terreno durante la partida. ¡También puedes forzar una distancia de visión fija poniendo el mismo valor máximo y mínimo!</Spanish>
 </Key>
 <Key ID="STR_ALIVE_VDIST_MAX">
     <English>Max View Distance:</English>
     <Chinesesimp>最大视距：</Chinesesimp>
+    <Spanish>Distancia de visión máxima:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_VDIST_MAX_COMMENT">
     <English>Maximum view distance allowed in Game</English>
     <Chinesesimp>在游戏中允许的视距最大值</Chinesesimp>
+    <Spanish>Distancia de visión máxima permitida en el juego</Spanish>
 </Key>
 <Key ID="STR_ALIVE_VDIST_ENABLED">
     <English>Set View Settings</English>
     <Chinesesimp>修改视图设置</Chinesesimp>
+    <Spanish>Configurar ajustes de visión</Spanish>
 </Key>
 <Key ID="STR_ALIVE_VDIST_ENABLED_COMMENT">
     <English>Set you View distance in Game</English>
     <Chinesesimp>在游戏中修改视距</Chinesesimp>
+    <Spanish>Configura tu distancia de visión en el juego</Spanish>
 </Key>
 <Key ID="STR_ALIVE_VDIST_MIN">
     <English>Min View Distance:</English>
     <Chinesesimp>最小视距：</Chinesesimp>
+    <Spanish>Distancia de visión mínima:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_VDIST_MIN_COMMENT">
     <English>Minimum view distance allowed in Game</English>
     <Chinesesimp>在游戏中允许的视距最小值</Chinesesimp>
+    <Spanish>Distancia de visión mínima permitida en el juego</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TGRID">
     <English>Terrain Grid</English>
     <Chinesesimp>地形网格</Chinesesimp>
+    <Spanish>Cuadrícula de terreno</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TGRID_COMMENT">
     <English>Terrain Grid Settings in Game</English>
     <Chinesesimp>在游戏中修改地形网格</Chinesesimp>
+    <Spanish>Ajustes de la cuadrícula de terreno en el juego</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TGRID_MAX">
     <English>Max Terrain Grid:</English>
     <Chinesesimp>最大地形网格：</Chinesesimp>
+    <Spanish>Cuadrícula de terreno máxima:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TGRID_MAX_COMMENT">
     <English>Maximum Terrain Grid allowed in Game 1 Low -> 5 High</English>
     <Chinesesimp>游戏中允许的最大地形网格 1低 -> 5高</Chinesesimp>
+    <Spanish>Cuadrícula de terreno máxima permitida en el juego, 1 baja -> 5 alta</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TGRID_MIN">
     <English>Min Terrain Grid:</English>
     <Chinesesimp>最小地形网格：</Chinesesimp>
+    <Spanish>Cuadrícula de terreno mínima:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_TGRID_MIN_COMMENT">
     <English>Minimum Terrain Grid allowed in Game 1 Low -> 5 High</English>
     <Chinesesimp>游戏中允许的最小地形网格 1低 -> 5高</Chinesesimp>
+    <Spanish>Cuadrícula de terreno mínima permitida en el juego, 1 baja -> 5 alta</Spanish>
 </Key>
 <Key ID="STR_ALIVE_VDIST_ERROR1">
     <English>Only one View Distance module can be used</English>
     <Chinesesimp>只能使用一个视距模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de distancia de visión</Spanish>
 </Key>
 
 </Container></Package></Project>

--- a/addons/sys_weather/stringtable.xml
+++ b/addons/sys_weather/stringtable.xml
@@ -5,88 +5,106 @@
 <Key ID="STR_ALIVE_WEATHER">
     <English>Ambient Dynamic Weather</English>
     <Chinesesimp>动态天气环境</Chinesesimp>
+    <Spanish>Meteorología dinámica ambiental</Spanish>
 </Key>
 <Key ID="STR_ALIVE_WEATHER_COMMENT">
     <English>Dynamic Weather module</English>
     <Chinesesimp>动态天气模块</Chinesesimp>
+    <Spanish>Módulo de meteorología dinámica</Spanish>
 </Key>
 <Key ID="STR_ALIVE_WEATHER_USAGE">
     <English>Place the Dynamic Weather module and choose between different climates! Find a high detailed set of adjustment options on the module to refine your mission!</English>
     <Chinesesimp>放置动态天气模块和选择不同的气候,在模块上找到一组高度详细的调整选项来完善你的任务！</Chinesesimp>
+    <Spanish>¡Coloca el módulo de meteorología dinámica y elige entre distintos climas! ¡Encontrarás en el módulo un conjunto detallado de opciones de ajuste para afinar tu misión!</Spanish>
 </Key>
 <Key ID="STR_ALIVE_WEATHER_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用调试:</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_DEBUG_COMMENT">
     <English>Enables dynamic weather module debug mode</English>
     <Chinesesimp>启用动态天气模块调试模式</Chinesesimp>
+    <Spanish>Activa el modo de depuración del módulo de meteorología dinámica</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_DEBUG_CYCLE">
     <English>Debug Output Delay:</English>
     <Chinesesimp>调试输出延迟:</Chinesesimp>
+    <Spanish>Intervalo de salida de depuración:</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_DEBUG_CYCLE_COMMENT">
     <English>Delay in seconds between each rpt output (Enable Debug must be enabled)</English>
     <Chinesesimp>每个rpt输出之间的延迟(以秒为单位)(必须启用“启用调试”)</Chinesesimp>
+    <Spanish>Espera en segundos entre cada salida al RPT (hay que activar «Activar depuración»)</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_ERROR1">
     <English>Only one dynamic weather module can be used</English>
     <Chinesesimp>只能使用一个动态天气模块</Chinesesimp>
+    <Spanish>Solo se puede usar un módulo de meteorología dinámica</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_INITIAL">
     <English>Weather Climate:</English>
     <Chinesesimp>天气气候:</Chinesesimp>
+    <Spanish>Clima:</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_INITIAL_COMMENT">
     <English>For a complete local explanation please refer to ALiVE wiki</English>
     <Chinesesimp>有关完整的本地解释,请参考ALiVE wiki</Chinesesimp>
+    <Spanish>Para una explicación local completa, consulta la wiki de ALiVE</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_OVERRIDE">
     <English>Weather Override:</English>
     <Chinesesimp>天气覆盖:</Chinesesimp>
+    <Spanish>Anulación de la meteorología:</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_OVERRIDE_COMMENT">
     <English>Set initial weather to one of the override settings</English>
     <Chinesesimp>将初始天气设置为覆盖设置之一</Chinesesimp>
+    <Spanish>Establece la meteorología inicial en uno de los ajustes de anulación</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_CYCLE_VARIANCE">
     <English>Cycle Variance:</English>
     <Chinesesimp>周期方差:</Chinesesimp>
+    <Spanish>Variación entre ciclos:</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_CYCLE_VARIANCE_COMMENT">
     <English>Amount of variance to weather between weather cycles</English>
     <Chinesesimp>不同天气周期之间的天气变化量</Chinesesimp>
+    <Spanish>Cantidad de variación meteorológica entre ciclos</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_CYCLE_DELAY">
     <English>Cycle Delay:</English>
     <Chinesesimp>周期延迟:</Chinesesimp>
+    <Spanish>Duración del ciclo:</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_CYCLE_DELAY_COMMENT">
     <English>Time in seconds between each weather cycle (minimum 1800 set by game engine)</English>
     <Chinesesimp>每个天气周期之间的时间(以秒为单位)(游戏引擎设置的最低1800秒)</Chinesesimp>
+    <Spanish>Tiempo en segundos entre cada ciclo meteorológico (mínimo 1800 impuesto por el motor del juego)</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_REAL_LOCATION">
     <English>Real Weather Loc:</English>
     <Chinesesimp>真实地点天气(同步真实地点的天气情况?):</Chinesesimp>
+    <Spanish>Localidad meteorológica real:</Spanish>
 </Key>
 
 <Key ID="STR_ALIVE_WEATHER_REAL_LOCATION_COMMENT">
     <English>For a complete list of valid Locales please refer to ALiVE wiki</English>
     <Chinesesimp>有关有效区域设置的完整列表,请参阅ALiVE wiki</Chinesesimp>
+    <Spanish>Para la lista completa de localidades válidas, consulta la wiki de ALiVE</Spanish>
 </Key>
 
 </Container></Package></Project>

--- a/addons/sys_xstream/stringtable.xml
+++ b/addons/sys_xstream/stringtable.xml
@@ -5,137 +5,171 @@
 <Key ID="STR_ALIVE_XSTREAM">
     <English>xStream</English>
     <Chinesesimp>xStream</Chinesesimp>
+    <Spanish>xStream</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_COMMENT">
     <English>ALiVE xStream service for streaming live operations to the ALiVE War Room</English>
     <Chinesesimp>ALiVE xStream服务 用于向ALiVE作战室传输实时操作</Chinesesimp>
+    <Spanish>Servicio xStream de ALiVE para retransmitir operaciones en directo a la War Room de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_DEBUG">
     <English>Enable Debug:</English>
     <Chinesesimp>启用调试:</Chinesesimp>
+    <Spanish>Activar depuración:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_DEBUG_COMMENT">
     <English>Enables xStream Module Debug</English>
     <Chinesesimp>启用xStream模块调试</Chinesesimp>
+    <Spanish>Activa la depuración del módulo xStream</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableTwitch">
     <English>Enable Twitch:</English>
     <Chinesesimp>启用Twitch:</Chinesesimp>
+    <Spanish>Activar Twitch:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableTwitch_COMMENT">
     <English>Allow twitch streams for this operation in the ALiVE War Room</English>
     <Chinesesimp>允许在ALiVE 作战指挥室中执行此操作</Chinesesimp>
+    <Spanish>Permite retransmisiones de Twitch para esta operación en la War Room de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableTwitch_ENABLE">
     <English>Enable Twitch Steaming</English>
     <Chinesesimp>启用Twitch steaming</Chinesesimp>
+    <Spanish>Activar retransmisión por Twitch</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableTwitch_DISABLE">
     <English>Disable Twitch Steaming</English>
     <Chinesesimp>禁用Twitch Steaming</Chinesesimp>
+    <Spanish>Desactivar retransmisión por Twitch</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableLiveMap">
     <English>Enable Live Map:</English>
     <Chinesesimp>启用实时地图：</Chinesesimp>
+    <Spanish>Activar mapa en directo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableLiveMap_COMMENT">
     <English>Stream live in-game BLUFOR data to the ALiVE War Room Map</English>
     <Chinesesimp>将游戏中BLUFOR实时数据流传输到ALiVE 作战指挥室地图</Chinesesimp>
+    <Spanish>Retransmite en directo los datos BLUFOR de la partida al mapa de la War Room de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableLiveMap_ENABLE">
     <English>Enable Live Map</English>
     <Chinesesimp>启用实时地图</Chinesesimp>
+    <Spanish>Activar mapa en directo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableLiveMap_DISABLE">
     <English>Disable Live Map</English>
     <Chinesesimp>禁用实时地图</Chinesesimp>
+    <Spanish>Desactivar mapa en directo</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableCamera">
     <English>Enable xStream Camera:</English>
     <Chinesesimp>启用xStream摄像机:</Chinesesimp>
+    <Spanish>Activar cámara xStream:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableCamera_COMMENT">
     <English>Enable xStream camera system for streaming purposes</English>
     <Chinesesimp>为流媒体目的启用xStream相机系统</Chinesesimp>
+    <Spanish>Activa el sistema de cámara xStream para retransmisiones</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableCamera_ENABLE">
     <English>Enable xStream Camera</English>
     <Chinesesimp>启用xStream摄像机</Chinesesimp>
+    <Spanish>Activar cámara xStream</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_enableCamera_DISABLE">
     <English>Disable xStream Camera</English>
     <Chinesesimp>禁用xStream摄像机</Chinesesimp>
+    <Spanish>Desactivar cámara xStream</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_startCamera">
     <English>Start xStream Camera</English>
     <Chinesesimp>开始xStream摄像机</Chinesesimp>
+    <Spanish>Iniciar cámara xStream</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_stopCamera">
     <English>Stop xStream Camera</English>
     <Chinesesimp>停止xStream摄像机</Chinesesimp>
+    <Spanish>Detener cámara xStream</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_acreChannel">
     <English>ACRE Channel:</English>
     <Chinesesimp>ACRE频道:</Chinesesimp>
+    <Spanish>Canal de ACRE:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_acreChannel_COMMENT">
     <English>(Optional) Select an ACRE channel for the camera system to listen in on (recommend an HQ net)</English>
     <Chinesesimp>(可选)为摄像机系统选择一个ACRE频道进行监听(建议使用HQ频道)</Chinesesimp>
+    <Spanish>(Opcional) Selecciona un canal de ACRE en el que escuchará el sistema de cámara (se recomienda una red de HQ)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_cameraShake">
     <English>Camera Shake:</English>
     <Chinesesimp>摄像机抖动:</Chinesesimp>
+    <Spanish>Vibración de cámara:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_cameraShake_COMMENT">
     <English>Enable camera shake for the ALiVE xStream camera</English>
     <Chinesesimp>为ALiVE xStream摄像机启用摄像机抖动</Chinesesimp>
+    <Spanish>Activa la vibración de la cámara xStream de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_satellite">
     <English>Satellite Camera:</English>
     <Chinesesimp>卫星摄像机:</Chinesesimp>
+    <Spanish>Cámara satélite:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_satellite_COMMENT">
     <English>Enable satellite camera views for the ALiVE xStream camera system</English>
     <Chinesesimp>启用AliVE xStream摄像机系统的卫星摄像机视图</Chinesesimp>
+    <Spanish>Activa las vistas de cámara satélite del sistema de cámara xStream de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_aerial">
     <English>Aerial Camera:</English>
     <Chinesesimp>航空摄像机:</Chinesesimp>
+    <Spanish>Cámara aérea:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_aerial_COMMENT">
     <English>Enable satellite camera views for the ALiVE xStream camera system</English>
     <Chinesesimp></Chinesesimp>
+    <Spanish>Activa las vistas de cámara satélite del sistema de cámara xStream de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_vehicle">
     <English>Vehicle Camera:</English>
     <Chinesesimp></Chinesesimp>
+    <Spanish>Cámara de vehículo:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_vehicle_COMMENT">
     <English>Enable external vehicle camera views for the ALiVE xStream camera system</English>
     <Chinesesimp>启用ALiVE xStream摄像机系统的卫星摄像机视图</Chinesesimp>
+    <Spanish>Activa las vistas de cámara externa de vehículo del sistema de cámara xStream de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_thirdPerson">
     <English>3rd Person Camera:</English>
     <Chinesesimp>第三人称摄像头:</Chinesesimp>
+    <Spanish>Cámara en tercera persona:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_thirdPerson_COMMENT">
     <English>Enable third person camera views for the ALiVE xStream camera system</English>
     <Chinesesimp>启用ALiVE xStream摄像机系统的第三人称摄像机视图</Chinesesimp>
+    <Spanish>Activa las vistas de cámara en tercera persona del sistema de cámara xStream de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_cameraManOnly">
     <English>Cameraman View Only:</English>
     <Chinesesimp>仅限摄像师查看：</Chinesesimp>
+    <Spanish>Solo vista de cámara:</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_cameraManOnly_COMMENT">
     <English>Only allow a cameraman view for the ALiVE xStream camera</English>
     <Chinesesimp>仅允许摄影师查看ALiVE xStream摄像机</Chinesesimp>
+    <Spanish>Permite únicamente la vista de cámara para la cámara xStream de ALiVE</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_clientID">
     <English>Client IDs</English>
     <Chinesesimp>客户端ID</Chinesesimp>
+    <Spanish>ID de cliente</Spanish>
 </Key>
 <Key ID="STR_ALIVE_XSTREAM_clientID_COMMENT">
     <English>Specify a list of usernames that are allowed to act as camera clients, separated by commas (Tupolov,Wolffy,Highhead etc)</English>
     <Chinesesimp>指定允许充当摄像机客户端的用户名列表,用逗号分隔(Tupolov、Wolffy、Highhead等)</Chinesesimp>
+    <Spanish>Especifica una lista de nombres de usuario autorizados a actuar como clientes de cámara, separados por comas (Tupolov,Wolffy,Highhead, etc.)</Spanish>
 </Key>
 </Container></Package></Project>

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -5,9 +5,11 @@
 <Key ID="STR_ALIVE_UI_TOOLTIP_LOGO_ABOUT">
     <English>ALiVE is an Arma 3 Mod that enhances MP play with a more strategic enemy, enhanced combat ambience, combat support, logistics and revolutionary mission persistence and online statistics. Please Donate at http://alivemod.com/#Donate</English>
     <Chinesesimp>ALiVE是Arma3的一个Mod 增强了MP玩法 一个更具战略意义的敌人，增强了战斗氛围 战斗支持 后勤和革命任务的持久性和在线统计。请在http://alivemod.com/#Donate上捐款</Chinesesimp>
+    <Spanish>ALiVE es un mod de Arma 3 que mejora el juego multijugador con un enemigo más estratégico, una ambientación de combate mejorada, apoyo de combate, logística y una revolucionaria persistencia de misiones y estadísticas en línea. Dona en http://alivemod.com/#Donate</Spanish>
 </Key>
 <Key ID="STR_ALIVE_UI_TOOLTIP_JOHARI_ABOUT">
     <English>A massive thank you to Johari, the band that created two incredible and exclusive tracks for ALiVE - This is War and Everest. Go to www.johariofficial.com for more!</English>
     <Chinesesimp>非常感谢Johari乐队 他们为《ALiVE》创作了两首不可思议的独家曲目——《This is War》和《Everest》。登录www.johariofficial.com了解更多信息!</Chinesesimp>
+    <Spanish>Un enorme agradecimiento a Johari, la banda que creó dos temas increíbles y exclusivos para ALiVE: This is War y Everest. ¡Visita www.johariofficial.com para más!</Spanish>
 </Key>
 </Container></Package></Project>

--- a/optional/composition_cup/stringtable.xml
+++ b/optional/composition_cup/stringtable.xml
@@ -4,1773 +4,2363 @@
 <Container name="STR_DN">
 <Key ID="STR_ZECCUP_AirportsLarge">
     <English>Airports (Large)</English>
+    <Spanish>Aeropuertos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_AirportsMedium">
     <English>Airports (Medium)</English>
+    <Spanish>Aeropuertos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_AirportsSmall">
     <English>Airports (Small)</English>
+    <Spanish>Aeropuertos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CampsLarge">
     <English>Camps (Large)</English>
+    <Spanish>Campamentos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CampsMedium">
     <English>Camps (Medium)</English>
+    <Spanish>Campamentos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CampsSmall">
     <English>Camps (Small)</English>
+    <Spanish>Campamentos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CheckpointsBarricadesLarge">
     <English>Checkpoints &amp; Barricades (Large)</English>
+    <Spanish>Controles y barricadas (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CheckpointsBarricadesMedium">
     <English>Checkpoints &amp; Barricades (Medium)</English>
+    <Spanish>Controles y barricadas (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CheckpointsBarricadesSmall">
     <English>Checkpoints &amp; Barricades (Small)</English>
+    <Spanish>Controles y barricadas (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CommunicationsLarge">
     <English>Communications (Large)</English>
+    <Spanish>Comunicaciones (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CommunicationsMedium">
     <English>Communications (Medium)</English>
+    <Spanish>Comunicaciones (medianas)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CommunicationsSmall">
     <English>Communications (Small)</English>
+    <Spanish>Comunicaciones (pequeñas)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_ConstructionLarge">
     <English>Construction (Large)</English>
+    <Spanish>Construcción (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_ConstructionMedium">
     <English>Construction (Medium)</English>
+    <Spanish>Construcción (mediana)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_ConstructionSmall">
     <English>Construction (Small)</English>
+    <Spanish>Construcción (pequeña)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_ConstructionSuppliesLarge">
     <English>Construction Supplies (Large)</English>
+    <Spanish>Suministros de construcción (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_ConstructionSuppliesMedium">
     <English>Construction Supplies (Medium)</English>
+    <Spanish>Suministros de construcción (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_ConstructionSuppliesSmall">
     <English>Construction Supplies (Small)</English>
+    <Spanish>Suministros de construcción (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CrashsitesLarge">
     <English>Crash Sites (Large)</English>
+    <Spanish>Zonas de accidente (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CrashsitesMedium">
     <English>Crash Sites (Medium)</English>
+    <Spanish>Zonas de accidente (medianas)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_CrashsitesSmall">
     <English>Crash Sites (Small)</English>
+    <Spanish>Zonas de accidente (pequeñas)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_FieldHQLarge">
     <English>Field HQ (Large)</English>
+    <Spanish>HQ de campaña (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_FieldHQMedium">
     <English>Field HQ (Medium)</English>
+    <Spanish>HQ de campaña (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_FieldHQSmall">
     <English>Field HQ (Small)</English>
+    <Spanish>HQ de campaña (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_FortLarge">
     <English>Fortifications &amp; Bunkers (Large)</English>
+    <Spanish>Fortificaciones y búnkeres (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_FortMedium">
     <English>Fortifications &amp; Bunkers (Medium)</English>
+    <Spanish>Fortificaciones y búnkeres (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_FortSmall">
     <English>Fortifications &amp; Bunkers (Small)</English>
+    <Spanish>Fortificaciones y búnkeres (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_FuelLarge">
     <English>Fuel (Large)</English>
+    <Spanish>Combustible (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_FuelMedium">
     <English>Fuel (Medium)</English>
+    <Spanish>Combustible (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_FuelSmall">
     <English>Fuel (Small)</English>
+    <Spanish>Combustible (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_GeneralLarge">
     <English>General (Large)</English>
+    <Spanish>General (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_GeneralMedium">
     <English>General (Medium)</English>
+    <Spanish>General (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_GeneralSmall">
     <English>General (Small)</English>
+    <Spanish>General (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_HeliportsLarge">
     <English>Heliports (Large)</English>
+    <Spanish>Helipuertos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_HeliportsMedium">
     <English>Heliports (Medium)</English>
+    <Spanish>Helipuertos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_HeliportsSmall">
     <English>Heliports (Small)</English>
+    <Spanish>Helipuertos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_HqLarge">
     <English>HQ (Large)</English>
+    <Spanish>HQ (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_HqMedium">
     <English>HQ (Medium)</English>
+    <Spanish>HQ (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_HqSmall">
     <English>HQ (Small)</English>
+    <Spanish>HQ (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_IndustrialLarge">
     <English>Industrial (Large)</English>
+    <Spanish>Industrial (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_IndustrialMedium">
     <English>Industrial (Medium)</English>
+    <Spanish>Industrial (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_IndustrialSmall">
     <English>Industrial (Small)</English>
+    <Spanish>Industrial (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MarineLarge">
     <English>Marine (Large)</English>
+    <Spanish>Marítimo (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MarineMedium">
     <English>Marine (Medium)</English>
+    <Spanish>Marítimo (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MarineSmall">
     <English>Marine (Small)</English>
+    <Spanish>Marítimo (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MedicalLarge">
     <English>Medical (Large)</English>
+    <Spanish>Sanitario (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MedicalMedium">
     <English>Medical (Medium)</English>
+    <Spanish>Sanitario (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MedicalSmall">
     <English>Medical (Small)</English>
+    <Spanish>Sanitario (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MiningOilLarge">
     <English>Mining, Refining &amp; Oil (Large)</English>
+    <Spanish>Minería, refinado y petróleo (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MiningOilMedium">
     <English>Mining, Refining &amp; Oil (Medium)</English>
+    <Spanish>Minería, refinado y petróleo (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MiningOilSmall">
     <English>Mining, Refining &amp; Oil (Small)</English>
+    <Spanish>Minería, refinado y petróleo (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_OutpostsLarge">
     <English>Outposts (Large)</English>
+    <Spanish>Puestos avanzados (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_OutpostsMedium">
     <English>Outposts (Medium)</English>
+    <Spanish>Puestos avanzados (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_OutpostsSmall">
     <English>Outposts (Small)</English>
+    <Spanish>Puestos avanzados (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_PowerLarge">
     <English>Power (Large)</English>
+    <Spanish>Energía (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_PowerMedium">
     <English>Power (Medium)</English>
+    <Spanish>Energía (mediana)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_PowerSmall">
     <English>Power (Small)</English>
+    <Spanish>Energía (pequeña)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_RailLarge">
     <English>Rail (Large)</English>
+    <Spanish>Ferrocarril (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_RailMedium">
     <English>Rail (Medium)</English>
+    <Spanish>Ferrocarril (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_RailSmall">
     <English>Rail (Small)</English>
+    <Spanish>Ferrocarril (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_SettlementsLarge">
     <English>Settlements (Large)</English>
+    <Spanish>Asentamientos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_SettlementsMedium">
     <English>Settlements (Medium)</English>
+    <Spanish>Asentamientos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_SettlementsSmall">
     <English>Settlements (Small)</English>
+    <Spanish>Asentamientos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_SuppliesLarge">
     <English>Supplies &amp; Storage (Large)</English>
+    <Spanish>Suministros y almacenamiento (grandes)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_SuppliesMedium">
     <English>Supplies &amp; Storage (Medium)</English>
+    <Spanish>Suministros y almacenamiento (medianos)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_SuppliesSmall">
     <English>Supplies &amp; Storage (Small)</English>
+    <Spanish>Suministros y almacenamiento (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_SupportsLarge">
     <English>Support (Large)</English>
+    <Spanish>Apoyo (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_SupportsMedium">
     <English>Support (Medium)</English>
+    <Spanish>Apoyo (mediano)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_SupportsSmall">
     <English>Support (Small)</English>
+    <Spanish>Apoyo (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_ConstructionSuppliesLarge_FillerIndustrial">
     <English>Filler - Industrial</English>
+    <Spanish>Relleno - industrial</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_ConstructionSuppliesLarge_PipesSmall">
     <English>Pipes - Small</English>
+    <Spanish>Tuberías - pequeñas</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_ConstructionSuppliesLarge_PipesLarge">
     <English>Pipes - Large</English>
+    <Spanish>Tuberías - grandes</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_ConstructionSuppliesLarge_WallsEastern">
     <English>Walls Eastern</English>
+    <Spanish>Muros orientales</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_ConstructionSuppliesLarge_WallsWestern">
     <English>Walls Western</English>
+    <Spanish>Muros occidentales</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_ConstructionSuppliesLarge_FillerMisc1">
     <English>Filler - Misc #1</English>
+    <Spanish>Relleno - varios #1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_ConstructionSuppliesLarge_FillerMisc2">
     <English>Filler - Misc #2</English>
+    <Spanish>Relleno - varios #2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_GeneralLarge_Castle">
     <English>Castle</English>
+    <Spanish>Castillo</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_GeneralLarge_Mosque">
     <English>Mosque</English>
+    <Spanish>Mezquita</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_IndustrialLarge_Dam">
     <English>Dam</English>
+    <Spanish>Presa</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_IndustrialLarge_IndustrialBuilding1">
     <English>Industrial Building #1</English>
+    <Spanish>Edificio industrial #1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_IndustrialLarge_IndustrialBuilding2">
     <English>Industrial Building #2</English>
+    <Spanish>Edificio industrial #2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_Civilian_IndustrialMedium_Crane">
     <English>Dock Crane</English>
+    <Spanish>Grúa de muelle</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CampsSmall_Camp_CUP_O_TK">
     <English>Camp</English>
+    <Spanish>Campamento</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CampsSmall_Camp_CUP_B_USMC">
     <English>Camp</English>
+    <Spanish>Campamento</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesMedium_BunkerLarge_CUP_O_TK">
     <English>Bunker (Large) Checkpoint</English>
+    <Spanish>Puesto de control con búnker (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesMedium_VehicleHBarrier_CUP_O_TK">
     <English>Vehicle H-Barrier Checkpoint</English>
+    <Spanish>Puesto de control de H-Barrier para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesMedium_TowerBunker_CUP_O_TK">
     <English>Tower Bunker Checkpoint</English>
+    <Spanish>Puesto de control con búnker torre</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesMedium_BunkerLarge_CUP_B_USMC">
     <English>Bunker (Large) Checkpoint</English>
+    <Spanish>Puesto de control con búnker (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesMedium_TowerBunker_CUP_B_USMC">
     <English>Tower Bunker Checkpoint</English>
+    <Spanish>Puesto de control con búnker torre</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesSmall_BunkerSmall_CUP_O_TK">
     <English>Bunker (Small) Checkpoint</English>
+    <Spanish>Puesto de control con búnker (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesSmall_Sandbag_CUP_O_TK">
     <English>Sandbag Checkpoint</English>
+    <Spanish>Puesto de control con sacos terreros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesSmall_SandbagNet_CUP_O_TK">
     <English>Sandbag Checkpoint (Net)</English>
+    <Spanish>Puesto de control con sacos terreros (red)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesSmall_Concrete_CUP_O_TK">
     <English>Concrete Checkpoint</English>
+    <Spanish>Puesto de control de hormigón</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesSmall_Sandbag_CUP_B_USMC">
     <English>Sandbag Checkpoint</English>
+    <Spanish>Puesto de control con sacos terreros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesSmall_SandbagNet_CUP_B_USMC">
     <English>Sandbag Checkpoint (Net)</English>
+    <Spanish>Puesto de control con sacos terreros (red)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesSmall_BunkersSmall_CUP_B_USMC">
     <English>Bunkers (Small) Checkpoint</English>
+    <Spanish>Puesto de control con búnkeres (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CheckpointsBarricadesSmall_LightBunker_CUP_B_USMC">
     <English>Light Checkpoint</English>
+    <Spanish>Puesto de control ligero</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CommunicationsLarge_AirRadar_CUP_O_TK">
     <English>Anti-Air Radar</English>
+    <Spanish>Radar antiaéreo</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CommunicationsLarge_AirRadar_CUP_B_USMC">
     <English>Anti-Air Radar</English>
+    <Spanish>Radar antiaéreo</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CommunicationsLarge_ArtilleryRadar_CUP_O_TK">
     <English>Artillery Radar</English>
+    <Spanish>Radar de artillería</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CommunicationsLarge_ArtilleryRadar_CUP_B_USMC">
     <English>Artillery Radar</English>
+    <Spanish>Radar de artillería</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CommunicationsMedium_RadioTower_CUP_O_TK">
     <English>Radio Tower</English>
+    <Spanish>Torre de radio</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CommunicationsMedium_RadioTower_CUP_B_USMC">
     <English>Radio Tower</English>
+    <Spanish>Torre de radio</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CommunicationsSmall_UAVTerminal_CUP_O_TK">
     <English>UAV Terminal</English>
+    <Spanish>Terminal de UAV</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_CommunicationsSmall_UAVTerminal_CUP_B_USMC">
     <English>UAV Terminal</English>
+    <Spanish>Terminal de UAV</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionLarge_LightFactory_CUP_O_TK">
     <English>Light Factory</English>
+    <Spanish>Fábrica ligera</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionLarge_LightFactory_CUP_B_USMC">
     <English>Light Factory</English>
+    <Spanish>Fábrica ligera</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionLarge_HeavyFactory_CUP_O_TK">
     <English>Heavy Factory</English>
+    <Spanish>Fábrica pesada</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionLarge_HeavyFactory_CUP_B_USMC">
     <English>Heavy Factory</English>
+    <Spanish>Fábrica pesada</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionMedium_Yard_CUP_O_TK">
     <English>Container Yard</English>
+    <Spanish>Patio de contenedores</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionMedium_Yard_CUP_B_USMC">
     <English>Container Yard</English>
+    <Spanish>Patio de contenedores</Spanish>
 </Key>
 STR_ZECCUP_MilitaryDesert_ConstructionSuppliesLarge_FillerSupplies
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionSuppliesLarge_BaseObjects">
     <English>Base Objects</English>
+    <Spanish>Objetos de base</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionSuppliesLarge_MiscItems">
     <English>Misc Items</English>
+    <Spanish>Objetos varios</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionSuppliesLarge_ExternalItems">
     <English>External Items</English>
+    <Spanish>Objetos exteriores</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionSuppliesLarge_Walls">
     <English>Walls</English>
+    <Spanish>Muros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionSuppliesLarge_Sandbags_CUP_B_USMC">
     <English>Sandbags - West</English>
+    <Spanish>Sacos terreros - oeste</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionSuppliesLarge_Sandbags_CUP_O_TK">
     <English>Sandbags - East</English>
+    <Spanish>Sacos terreros - este</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_ConstructionSuppliesLarge_FillerSupplies">
     <English>Filler - Supplies</English>
+    <Spanish>Relleno - suministros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQLarge_HQTent_CUP_O_TK">
     <English>Field Tents</English>
+    <Spanish>Tiendas de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQLarge_FieldBarracks1_CUP_O_TK">
     <English>Field Barracks #1</English>
+    <Spanish>Barracones de campaña #1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQLarge_FieldBarracks2_CUP_O_TK">
     <English>Field Barracks #2</English>
+    <Spanish>Barracones de campaña #2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQLarge_FieldRadar_CUP_O_TK">
     <English>Field Radar</English>
+    <Spanish>Radar de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQLarge_FieldHQ_CUP_O_TK">
     <English>Field HQ</English>
+    <Spanish>HQ de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQLarge_FieldDepot_CUP_O_TK">
     <English>Field Depot</English>
+    <Spanish>Depósito de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQLarge_FieldBarracks1_CUP_B_USMC">
     <English>Field Barracks #1</English>
+    <Spanish>Barracones de campaña #1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQLarge_FieldBarracks2_CUP_B_USMC">
     <English>Field Barracks #2</English>
+    <Spanish>Barracones de campaña #2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQLarge_FieldRadar_CUP_B_USMC">
     <English>Field Radar</English>
+    <Spanish>Radar de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQLarge_FieldHQ_CUP_B_USMC">
     <English>Field HQ</English>
+    <Spanish>HQ de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQLarge_FieldDepot_CUP_B_USMC">
     <English>Field Depot</English>
+    <Spanish>Depósito de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_HQTent_CUP_B_USMC">
     <English>Fortified Tent HQ</English>
+    <Spanish>HQ en tienda fortificada</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_HQField_CUP_O_TK">
     <English>Basic HQ</English>
+    <Spanish>HQ básico</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_HQField_CUP_B_USMC">
     <English>Basic HQ</English>
+    <Spanish>HQ básico</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ1_CUP_B_USMC">
     <English>Fortified HQ #B1</English>
+    <Spanish>HQ fortificado #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ2_CUP_B_USMC">
     <English>Fortified HQ #B2</English>
+    <Spanish>HQ fortificado #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ3_CUP_B_USMC">
     <English>Fortified HQ #B3</English>
+    <Spanish>HQ fortificado #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ4_CUP_B_USMC">
     <English>Fortified HQ #B4</English>
+    <Spanish>HQ fortificado #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ5_CUP_B_USMC">
     <English>Fortified HQ #B5</English>
+    <Spanish>HQ fortificado #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ6_CUP_B_USMC">
     <English>Fortified HQ #B6</English>
+    <Spanish>HQ fortificado #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ7_CUP_B_USMC">
     <English>Fortified HQ #B7</English>
+    <Spanish>HQ fortificado #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ8_CUP_B_USMC">
     <English>Fortified HQ #B8</English>
+    <Spanish>HQ fortificado #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ1_CUP_O_TK">
     <English>Fortified HQ #O1</English>
+    <Spanish>HQ fortificado #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ2_CUP_O_TK">
     <English>Fortified HQ #O2</English>
+    <Spanish>HQ fortificado #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ3_CUP_O_TK">
     <English>Fortified HQ #O3</English>
+    <Spanish>HQ fortificado #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ4_CUP_O_TK">
     <English>Fortified HQ #O4</English>
+    <Spanish>HQ fortificado #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ5_CUP_O_TK">
     <English>Fortified HQ #O5</English>
+    <Spanish>HQ fortificado #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ6_CUP_O_TK">
     <English>Fortified HQ #O6</English>
+    <Spanish>HQ fortificado #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ7_CUP_O_TK">
     <English>Fortified HQ #O7</English>
+    <Spanish>HQ fortificado #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FieldHQMedium_FortifiedFieldHQ8_CUP_O_TK">
     <English>Fortified HQ #O8</English>
+    <Spanish>HQ fortificado #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortLarge_MortarPit_CUP_O_TK">
     <English>Mortar Pit</English>
+    <Spanish>Foso de morteros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortLarge_MortarPit_CUP_B_USMC">
     <English>Mortar Pit</English>
+    <Spanish>Foso de morteros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleBunker_CUP_O_TK">
     <English>Vehicle Bunker</English>
+    <Spanish>Búnker para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerTowerHvy_CUP_O_TK">
     <English>Bunker Tower (Heavy)</English>
+    <Spanish>Torre búnker (pesada)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerTowerLit_CUP_O_TK">
     <English>Bunker Tower (Light)</English>
+    <Spanish>Torre búnker (ligera)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLargeMed_CUP_O_TK">
     <English>Bunker Large</English>
+    <Spanish>Búnker grande</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerTowerMed_CUP_O_TK">
     <English>Bunker Tower</English>
+    <Spanish>Torre búnker</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLargeLit_CUP_O_TK">
     <English>Bunker Large (Light)</English>
+    <Spanish>Búnker grande (ligero)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleBunker_CUP_B_USMC">
     <English>Vehicle Bunker</English>
+    <Spanish>Búnker para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerTowerHvy_CUP_B_USMC">
     <English>Bunker Tower (Heavy)</English>
+    <Spanish>Torre búnker (pesada)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerTowerLit_CUP_B_USMC">
     <English>Bunker Tower (Light)</English>
+    <Spanish>Torre búnker (ligera)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLargeMed_CUP_B_USMC">
     <English>Bunker Large</English>
+    <Spanish>Búnker grande</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerTowerMed_CUP_B_USMC">
     <English>Bunker Tower</English>
+    <Spanish>Torre búnker</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLargeLit_CUP_B_USMC">
     <English>Bunker Large (Light)</English>
+    <Spanish>Búnker grande (ligero)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge1_CUP_B_USMC">
     <English>Bunker (Large) #B1</English>
+    <Spanish>Búnker (grande) #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge2_CUP_B_USMC">
     <English>Bunker (Large) #B2</English>
+    <Spanish>Búnker (grande) #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge3_CUP_B_USMC">
     <English>Bunker (Large) #B3</English>
+    <Spanish>Búnker (grande) #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge4_CUP_B_USMC">
     <English>Bunker (Large) #B4</English>
+    <Spanish>Búnker (grande) #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge5_CUP_B_USMC">
     <English>Bunker (Large) #B5</English>
+    <Spanish>Búnker (grande) #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge6_CUP_B_USMC">
     <English>Bunker (Large) #B6</English>
+    <Spanish>Búnker (grande) #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge7_CUP_B_USMC">
     <English>Bunker (Large) #B7</English>
+    <Spanish>Búnker (grande) #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge8_CUP_B_USMC">
     <English>Bunker (Large) #B8</English>
+    <Spanish>Búnker (grande) #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge9_CUP_B_USMC">
     <English>Bunker (Large) #B9</English>
+    <Spanish>Búnker (grande) #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower1_CUP_B_USMC">
     <English>Cargo Tower #B1</English>
+    <Spanish>Torre de carga #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower2_CUP_B_USMC">
     <English>Cargo Tower #B2</English>
+    <Spanish>Torre de carga #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower3_CUP_B_USMC">
     <English>Cargo Tower #B3</English>
+    <Spanish>Torre de carga #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower4_CUP_B_USMC">
     <English>Cargo Tower #B4</English>
+    <Spanish>Torre de carga #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower5_CUP_B_USMC">
     <English>Cargo Tower #B5</English>
+    <Spanish>Torre de carga #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower6_CUP_B_USMC">
     <English>Cargo Tower #B6</English>
+    <Spanish>Torre de carga #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower7_CUP_B_USMC">
     <English>Cargo Tower #B7</English>
+    <Spanish>Torre de carga #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower8_CUP_B_USMC">
     <English>Cargo Tower #B8</English>
+    <Spanish>Torre de carga #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower9_CUP_B_USMC">
     <English>Cargo Tower #B9</English>
+    <Spanish>Torre de carga #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleWatchtower_CUP_B_USMC">
     <English>Vehicle Watchtower</English>
+    <Spanish>Torre de vigilancia para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleCargoPost_CUP_B_USMC">
     <English>Vehicle Cargo Post</English>
+    <Spanish>Puesto de carga para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleLargeBunker_CUP_B_USMC">
     <English>Vehicle Bunker (Large)</English>
+    <Spanish>Búnker para vehículos (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleTower_CUP_B_USMC">
     <English>Vehicle Tower</English>
+    <Spanish>Torre para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleSmallBunker_CUP_B_USMC">
     <English>Vehicle Bunker (Small)</English>
+    <Spanish>Búnker para vehículos (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge1_CUP_O_TK">
     <English>Bunker (Large) #O1</English>
+    <Spanish>Búnker (grande) #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge2_CUP_O_TK">
     <English>Bunker (Large) #O2</English>
+    <Spanish>Búnker (grande) #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge3_CUP_O_TK">
     <English>Bunker (Large) #O3</English>
+    <Spanish>Búnker (grande) #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge4_CUP_O_TK">
     <English>Bunker (Large) #O4</English>
+    <Spanish>Búnker (grande) #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge5_CUP_O_TK">
     <English>Bunker (Large) #O5</English>
+    <Spanish>Búnker (grande) #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge6_CUP_O_TK">
     <English>Bunker (Large) #O6</English>
+    <Spanish>Búnker (grande) #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge7_CUP_O_TK">
     <English>Bunker (Large) #O7</English>
+    <Spanish>Búnker (grande) #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge8_CUP_O_TK">
     <English>Bunker (Large) #O8</English>
+    <Spanish>Búnker (grande) #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_BunkerLarge9_CUP_O_TK">
     <English>Bunker (Large) #O9</English>
+    <Spanish>Búnker (grande) #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower1_CUP_O_TK">
     <English>Cargo Tower #O1</English>
+    <Spanish>Torre de carga #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower2_CUP_O_TK">
     <English>Cargo Tower #O2</English>
+    <Spanish>Torre de carga #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower3_CUP_O_TK">
     <English>Cargo Tower #O3</English>
+    <Spanish>Torre de carga #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower4_CUP_O_TK">
     <English>Cargo Tower #O4</English>
+    <Spanish>Torre de carga #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower5_CUP_O_TK">
     <English>Cargo Tower #O5</English>
+    <Spanish>Torre de carga #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower6_CUP_O_TK">
     <English>Cargo Tower #O6</English>
+    <Spanish>Torre de carga #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower7_CUP_O_TK">
     <English>Cargo Tower #O7</English>
+    <Spanish>Torre de carga #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower8_CUP_O_TK">
     <English>Cargo Tower #O8</English>
+    <Spanish>Torre de carga #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_CargoTower9_CUP_O_TK">
     <English>Cargo Tower #O9</English>
+    <Spanish>Torre de carga #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleWatchtower_CUP_O_TK">
     <English>Vehicle Watchtower</English>
+    <Spanish>Torre de vigilancia para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleCargoPost_CUP_O_TK">
     <English>Vehicle Cargo Post</English>
+    <Spanish>Puesto de carga para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleLargeBunker_CUP_O_TK">
     <English>Vehicle Bunker (Large)</English>
+    <Spanish>Búnker para vehículos (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleTower_CUP_O_TK">
     <English>Vehicle Tower</English>
+    <Spanish>Torre para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortMedium_VehicleSmallBunker_CUP_O_TK">
     <English>Vehicle Bunker (Small)</English>
+    <Spanish>Búnker para vehículos (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall1_CUP_B_USMC">
     <English>Bunker (Small) #B1</English>
+    <Spanish>Búnker (pequeño) #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall2_CUP_B_USMC">
     <English>Bunker (Small) #B2</English>
+    <Spanish>Búnker (pequeño) #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall3_CUP_B_USMC">
     <English>Bunker (Small) #B3</English>
+    <Spanish>Búnker (pequeño) #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall4_CUP_B_USMC">
     <English>Bunker (Small) #B4</English>
+    <Spanish>Búnker (pequeño) #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall5_CUP_B_USMC">
     <English>Bunker (Small) #B5</English>
+    <Spanish>Búnker (pequeño) #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall6_CUP_B_USMC">
     <English>Bunker (Small) #B6</English>
+    <Spanish>Búnker (pequeño) #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall7_CUP_B_USMC">
     <English>Bunker (Small) #B7</English>
+    <Spanish>Búnker (pequeño) #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall8_CUP_B_USMC">
     <English>Bunker (Small) #B8</English>
+    <Spanish>Búnker (pequeño) #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall9_CUP_B_USMC">
     <English>Bunker (Small) #B9</English>
+    <Spanish>Búnker (pequeño) #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost1_CUP_B_USMC">
     <English>Cargo Post #B1</English>
+    <Spanish>Puesto de carga #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost2_CUP_B_USMC">
     <English>Cargo Post #B2</English>
+    <Spanish>Puesto de carga #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost3_CUP_B_USMC">
     <English>Cargo Post #B3</English>
+    <Spanish>Puesto de carga #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost4_CUP_B_USMC">
     <English>Cargo Post #B4</English>
+    <Spanish>Puesto de carga #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost5_CUP_B_USMC">
     <English>Cargo Post #B5</English>
+    <Spanish>Puesto de carga #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost6_CUP_B_USMC">
     <English>Cargo Post #B6</English>
+    <Spanish>Puesto de carga #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost7_CUP_B_USMC">
     <English>Cargo Post #B7</English>
+    <Spanish>Puesto de carga #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost8_CUP_B_USMC">
     <English>Cargo Post #B8</English>
+    <Spanish>Puesto de carga #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost9_CUP_B_USMC">
     <English>Cargo Post #B9</English>
+    <Spanish>Puesto de carga #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower2_CUP_B_USMC">
     <English>Watchtower #B2</English>
+    <Spanish>Torre de vigilancia #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower3_CUP_B_USMC">
     <English>Watchtower #B3</English>
+    <Spanish>Torre de vigilancia #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower4_CUP_B_USMC">
     <English>Watchtower #B4</English>
+    <Spanish>Torre de vigilancia #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower5_CUP_B_USMC">
     <English>Watchtower #B5</English>
+    <Spanish>Torre de vigilancia #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower6_CUP_B_USMC">
     <English>Watchtower #B6</English>
+    <Spanish>Torre de vigilancia #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower7_CUP_B_USMC">
     <English>Watchtower #B7</English>
+    <Spanish>Torre de vigilancia #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower8_CUP_B_USMC">
     <English>Watchtower #B8</English>
+    <Spanish>Torre de vigilancia #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower9_CUP_B_USMC">
     <English>Watchtower #B9</English>
+    <Spanish>Torre de vigilancia #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower1_CUP_B_USMC">
     <English>Bunker (Tower) #B1</English>
+    <Spanish>Búnker (torre) #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower2_CUP_B_USMC">
     <English>Bunker (Tower) #B2</English>
+    <Spanish>Búnker (torre) #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower3_CUP_B_USMC">
     <English>Bunker (Tower) #B3</English>
+    <Spanish>Búnker (torre) #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower4_CUP_B_USMC">
     <English>Bunker (Tower) #B4</English>
+    <Spanish>Búnker (torre) #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower5_CUP_B_USMC">
     <English>Bunker (Tower) #B5</English>
+    <Spanish>Búnker (torre) #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower6_CUP_B_USMC">
     <English>Bunker (Tower) #B6</English>
+    <Spanish>Búnker (torre) #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower7_CUP_B_USMC">
     <English>Bunker (Tower) #B7</English>
+    <Spanish>Búnker (torre) #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower8_CUP_B_USMC">
     <English>Bunker (Tower) #B8</English>
+    <Spanish>Búnker (torre) #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower9_CUP_B_USMC">
     <English>Bunker (Tower) #B9</English>
+    <Spanish>Búnker (torre) #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall1_CUP_O_TK">
     <English>Bunker (Small) #O1</English>
+    <Spanish>Búnker (pequeño) #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall2_CUP_O_TK">
     <English>Bunker (Small) #O2</English>
+    <Spanish>Búnker (pequeño) #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall3_CUP_O_TK">
     <English>Bunker (Small) #O3</English>
+    <Spanish>Búnker (pequeño) #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall4_CUP_O_TK">
     <English>Bunker (Small) #O4</English>
+    <Spanish>Búnker (pequeño) #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall5_CUP_O_TK">
     <English>Bunker (Small) #O5</English>
+    <Spanish>Búnker (pequeño) #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall6_CUP_O_TK">
     <English>Bunker (Small) #O6</English>
+    <Spanish>Búnker (pequeño) #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall7_CUP_O_TK">
     <English>Bunker (Small) #O7</English>
+    <Spanish>Búnker (pequeño) #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall8_CUP_O_TK">
     <English>Bunker (Small) #O8</English>
+    <Spanish>Búnker (pequeño) #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerSmall9_CUP_O_TK">
     <English>Bunker (Small) #O9</English>
+    <Spanish>Búnker (pequeño) #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost1_CUP_O_TK">
     <English>Cargo Post #O1</English>
+    <Spanish>Puesto de carga #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost2_CUP_O_TK">
     <English>Cargo Post #O2</English>
+    <Spanish>Puesto de carga #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost3_CUP_O_TK">
     <English>Cargo Post #O3</English>
+    <Spanish>Puesto de carga #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost4_CUP_O_TK">
     <English>Cargo Post #O4</English>
+    <Spanish>Puesto de carga #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost5_CUP_O_TK">
     <English>Cargo Post #O5</English>
+    <Spanish>Puesto de carga #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost6_CUP_O_TK">
     <English>Cargo Post #O6</English>
+    <Spanish>Puesto de carga #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost7_CUP_O_TK">
     <English>Cargo Post #O7</English>
+    <Spanish>Puesto de carga #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost8_CUP_O_TK">
     <English>Cargo Post #O8</English>
+    <Spanish>Puesto de carga #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_CargoPost9_CUP_O_TK">
     <English>Cargo Post #O9</English>
+    <Spanish>Puesto de carga #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower1_CUP_O_TK">
     <English>Watchtower #O1</English>
+    <Spanish>Torre de vigilancia #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower2_CUP_O_TK">
     <English>Watchtower #O2</English>
+    <Spanish>Torre de vigilancia #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower3_CUP_O_TK">
     <English>Watchtower #O3</English>
+    <Spanish>Torre de vigilancia #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower4_CUP_O_TK">
     <English>Watchtower #O4</English>
+    <Spanish>Torre de vigilancia #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower5_CUP_O_TK">
     <English>Watchtower #O5</English>
+    <Spanish>Torre de vigilancia #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower6_CUP_O_TK">
     <English>Watchtower #O6</English>
+    <Spanish>Torre de vigilancia #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower7_CUP_O_TK">
     <English>Watchtower #O7</English>
+    <Spanish>Torre de vigilancia #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower8_CUP_O_TK">
     <English>Watchtower #O8</English>
+    <Spanish>Torre de vigilancia #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Watchtower9_CUP_O_TK">
     <English>Watchtower #O9</English>
+    <Spanish>Torre de vigilancia #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower1_CUP_O_TK">
     <English>Bunker (Tower) #O1</English>
+    <Spanish>Búnker (torre) #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower2_CUP_O_TK">
     <English>Bunker (Tower) #O2</English>
+    <Spanish>Búnker (torre) #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower3_CUP_O_TK">
     <English>Bunker (Tower) #O3</English>
+    <Spanish>Búnker (torre) #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower4_CUP_O_TK">
     <English>Bunker (Tower) #O4</English>
+    <Spanish>Búnker (torre) #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower5_CUP_O_TK">
     <English>Bunker (Tower) #O5</English>
+    <Spanish>Búnker (torre) #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower6_CUP_O_TK">
     <English>Bunker (Tower) #O6</English>
+    <Spanish>Búnker (torre) #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower7_CUP_O_TK">
     <English>Bunker (Tower) #O7</English>
+    <Spanish>Búnker (torre) #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower8_CUP_O_TK">
     <English>Bunker (Tower) #O8</English>
+    <Spanish>Búnker (torre) #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_BunkerTower9_CUP_O_TK">
     <English>Bunker (Tower) #O9</English>
+    <Spanish>Búnker (torre) #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_NestSandbag_CUP_O_TK">
     <English>Nest - Sandbag</English>
+    <Spanish>Nido - saco terrero</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_NestHBarrier_CUP_O_TK">
     <English>Nest H-Barrier</English>
+    <Spanish>Nido de H-Barrier</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Sandbags_CUP_O_TK">
     <English>Sandbags</English>
+    <Spanish>Sacos terreros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_SandbagNet_CUP_O_TK">
     <English>Net #O5</English>
+    <Spanish>Red de camuflaje #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_SandbagNetHvy_CUP_O_TK">
     <English>Sandbag Net (Heavy)</English>
+    <Spanish>Sacos terreros con red (pesados)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_NestMed_CUP_O_TK">
     <English>Nest</English>
+    <Spanish>Nido</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_SandbagNetLit_CUP_O_TK">
     <English>Sandbag Net</English>
+    <Spanish>Sacos terreros con red</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_LightNet1_CUP_O_TK">
     <English>Net #O1</English>
+    <Spanish>Red de camuflaje #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_LightNet2_CUP_O_TK">
     <English>Net #O2</English>
+    <Spanish>Red de camuflaje #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_LightNet3_CUP_O_TK">
     <English>Net #O3</English>
+    <Spanish>Red de camuflaje #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_LightNet4_CUP_O_TK">
     <English>Net #O4</English>
+    <Spanish>Red de camuflaje #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_NetCamo_CUP_O_TK">
     <English>Vehicle Net</English>
+    <Spanish>Red para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_NestSandbag_CUP_B_USMC">
     <English>Nest - Sandbag</English>
+    <Spanish>Nido - saco terrero</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_NestHBarrier_CUP_B_USMC">
     <English>Nest H-Barrier</English>
+    <Spanish>Nido de H-Barrier</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_Sandbags_CUP_B_USMC">
     <English>Sandbags</English>
+    <Spanish>Sacos terreros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_SandbagNet_CUP_B_USMC">
     <English>Net #B5</English>
+    <Spanish>Red de camuflaje #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_SandbagNetHvy_CUP_B_USMC">
     <English>Sandbag Net (Heavy)</English>
+    <Spanish>Sacos terreros con red (pesados)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_NestMed_CUP_B_USMC">
     <English>Nest</English>
+    <Spanish>Nido</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_SandbagNetLit_CUP_B_USMC">
     <English>Sandbag Net</English>
+    <Spanish>Sacos terreros con red</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_LightNet1_CUP_B_USMC">
     <English>Net #B1</English>
+    <Spanish>Red de camuflaje #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_LightNet2_CUP_B_USMC">
     <English>Net #B2</English>
+    <Spanish>Red de camuflaje #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_LightNet3_CUP_B_USMC">
     <English>Net #B3</English>
+    <Spanish>Red de camuflaje #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_LightNet4_CUP_B_USMC">
     <English>Net #B4</English>
+    <Spanish>Red de camuflaje #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FortSmall_NetCamo_CUP_B_USMC">
     <English>Vehicle Net</English>
+    <Spanish>Red para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HeliportsLarge_AirFact_CUP_O_TK">
     <English>Air Factory</English>
+    <Spanish>Fábrica aeronáutica</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HeliportsLarge_AirFact_CUP_B_USMC">
     <English>Air Factory</English>
+    <Spanish>Fábrica aeronáutica</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HeliportsLarge_LandingZone_CUP_O_TK">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HeliportsLarge_LandingZone_CUP_B_USMC">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HeliportsMedium_LandingZone_CUP_O_TK">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HeliportsMedium_LandingZone_CUP_B_USMC">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HeliportsSmall_LandingZone_CUP_O_TK">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HeliportsSmall_LandingZone_CUP_B_USMC">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HQLarge_Headquarters_CUP_B_USMC">
     <English>Headquarters</English>
+    <Spanish>Cuartel general</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HQLarge_Headquarters_CUP_O_TK">
     <English>Headquarters</English>
+    <Spanish>Cuartel general</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HQMedium_HQCargo_CUP_O_TK">
     <English>HQ Cargo Post</English>
+    <Spanish>Puesto de carga de HQ</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HQMedium_HQCargo_CUP_B_USMC">
     <English>HQ Cargo Post</English>
+    <Spanish>Puesto de carga de HQ</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HQSmall_HQUnfoldedBRDM_CUP_O_TK">
     <English>Mobile HQ &amp; Tower</English>
+    <Spanish>HQ móvil y torre</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HQSmall_HQUnfoldedBMP_CUP_O_TK">
     <English>Mobile HQ</English>
+    <Spanish>HQ móvil</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HQSmall_HQUnfoldedM1130A_CUP_B_USMC">
     <English>Mobile HQ &amp; Tower</English>
+    <Spanish>HQ móvil y torre</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_HQSmall_HQUnfoldedM1130B_CUP_B_USMC">
     <English>Mobile HQ</English>
+    <Spanish>HQ móvil</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_MedicalLarge_Hospital_CUP_O_TK">
     <English>Hospital</English>
+    <Spanish>Hospital</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_MedicalLarge_Hospital_CUP_B_USMC">
     <English>Hospital</English>
+    <Spanish>Hospital</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_PowerSmall_Generator_CUP_O_TK">
     <English>Generator</English>
+    <Spanish>Generador</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_PowerSmall_Generator_CUP_B_USMC">
     <English>Generator</English>
+    <Spanish>Generador</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SuppliesMedium_AmmoDump_CUP_O_TK">
     <English>Ammo Dump</English>
+    <Spanish>Polvorín</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SuppliesMedium_AmmoDump_CUP_B_USMC">
     <English>Ammo Dump</English>
+    <Spanish>Polvorín</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SuppliesSmall_Cache_CUP_O_TK">
     <English>Cache</English>
+    <Spanish>Alijo</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SuppliesSmall_Cache_CUP_B_USMC">
     <English>Cache</English>
+    <Spanish>Alijo</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SupportsLarge_Barracks_CUP_O_TK">
     <English>Barracks</English>
+    <Spanish>Barracones</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SupportsLarge_Barracks_CUP_B_USMC">
     <English>Barracks</English>
+    <Spanish>Barracones</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SupportsMedium_ServicePoint_CUP_O_TK">
     <English>Service Point</English>
+    <Spanish>Punto de servicio</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SupportsMedium_ServicePoint_CUP_B_USMC">
     <English>Service Point</English>
+    <Spanish>Punto de servicio</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SupportsMedium_ServiceArea_CUP_O_TK">
     <English>Service Area</English>
+    <Spanish>Zona de servicio</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SupportsMedium_ServiceArea_CUP_B_USMC">
     <English>Service Area</English>
+    <Spanish>Zona de servicio</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SupportsMedium_Barracks_CUP_O_TK">
     <English>Barracks</English>
+    <Spanish>Barracones</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SupportsMedium_Barracks_CUP_B_USMC">
     <English>Barracks</English>
+    <Spanish>Barracones</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SupportsSmall_LivingQuarters_CUP_O_TK">
     <English>Living Quarters</English>
+    <Spanish>Alojamientos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_SupportsSmall_LivingQuarters_CUP_B_USMC">
     <English>Living Quarters</English>
+    <Spanish>Alojamientos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FuelMedium_OilT_CUP_O_TK">
     <English>Oil Tower</English>
+    <Spanish>Torre petrolífera</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FuelMedium_OilT_CUP_B_USMC">
     <English>Oil Tower</English>
+    <Spanish>Torre petrolífera</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FuelMedium_FuelDump_CUP_O_TK">
     <English>Fuel Dump</English>
+    <Spanish>Depósito de combustible</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryDesert_FuelMedium_FuelDump_CUP_B_USMC">
     <English>Fuel Dump</English>
+    <Spanish>Depósito de combustible</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CampsSmall_Camp_CUP_O_RU">
     <English>Camp</English>
+    <Spanish>Campamento</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CampsSmall_Camp_CUP_B_CDF">
     <English>Camp</English>
+    <Spanish>Campamento</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesMedium_VehicleBunker_CUP_O_RU">
     <English>Vehicle Bunker Checkpoint</English>
+    <Spanish>Puesto de control con búnker para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesMedium_TowerBunker_CUP_O_RU">
     <English>Tower Bunker Checkpoint</English>
+    <Spanish>Puesto de control con búnker torre</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesMedium_HeavyBunker_CUP_O_RU">
     <English>Heavy Bunker Checkpoint</English>
+    <Spanish>Puesto de control con búnker pesado</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesMedium_VehicleBunker_CUP_B_CDF">
     <English>Vehicle Bunker Checkpoint</English>
+    <Spanish>Puesto de control con búnker para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesMedium_TowerBunker_CUP_B_CDF">
     <English>Tower Bunker Checkpoint</English>
+    <Spanish>Puesto de control con búnker torre</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesMedium_ConcreteTower_CUP_B_CDF">
     <English>Concrete Tower Checkpoint</English>
+    <Spanish>Puesto de control con torre de hormigón</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesSmall_SandbagNet_CUP_O_RU">
     <English>Sandbag Checkpoint (Net)</English>
+    <Spanish>Puesto de control con sacos terreros (red)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesSmall_VehicleRampart_CUP_O_RU">
     <English>Vehicle Rampart Checkpoint</English>
+    <Spanish>Puesto de control con terraplén para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesSmall_BunkerSmall_CUP_O_RU">
     <English>Bunker (Small) Checkpoint</English>
+    <Spanish>Puesto de control con búnker (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesSmall_SandbagNet_CUP_B_CDF">
     <English>Sandbag Checkpoint (Net)</English>
+    <Spanish>Puesto de control con sacos terreros (red)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesSmall_ConcretePost_CUP_B_CDF">
     <English>Concrete Post Checkpoint</English>
+    <Spanish>Puesto de control con poste de hormigón</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CheckpointsBarricadesSmall_BunkerSmall_CUP_B_CDF">
     <English>Bunker (Small) Checkpoint</English>
+    <Spanish>Puesto de control con búnker (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CommunicationsLarge_AirRadar_CUP_O_RU">
     <English>Anti-Air Radar</English>
+    <Spanish>Radar antiaéreo</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CommunicationsLarge_AirRadar_CUP_B_CDF">
     <English>Anti-Air Radar</English>
+    <Spanish>Radar antiaéreo</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CommunicationsLarge_ArtilleryRadar_CUP_O_RU">
     <English>Artillery Radar</English>
+    <Spanish>Radar de artillería</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CommunicationsLarge_ArtilleryRadar_CUP_B_CDF">
     <English>Artillery Radar</English>
+    <Spanish>Radar de artillería</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CommunicationsMedium_RadioTower_CUP_O_RU">
     <English>Radio Tower</English>
+    <Spanish>Torre de radio</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CommunicationsMedium_RadioTower_CUP_B_CDF">
     <English>Radio Tower</English>
+    <Spanish>Torre de radio</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CommunicationsSmall_UAVTerminal_CUP_O_RU">
     <English>UAV Terminal</English>
+    <Spanish>Terminal de UAV</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_CommunicationsSmall_UAVTerminal_CUP_B_CDF">
     <English>UAV Terminal</English>
+    <Spanish>Terminal de UAV</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_ConstructionMedium_ContainerYard_CUP_O_RU">
     <English>Container Yard</English>
+    <Spanish>Patio de contenedores</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_ConstructionMedium_ContainerYard_CUP_B_CDF">
     <English>Container Yard</English>
+    <Spanish>Patio de contenedores</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_ConstructionSuppliesLarge_BaseObjects">
     <English>Base Objects</English>
+    <Spanish>Objetos de base</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_ConstructionSuppliesLarge_MiscItems">
     <English>Misc Items</English>
+    <Spanish>Objetos varios</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_ConstructionSuppliesLarge_ExternalItems">
     <English>External Items</English>
+    <Spanish>Objetos exteriores</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_ConstructionSuppliesLarge_Walls">
     <English>Walls</English>
+    <Spanish>Muros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_ConstructionSuppliesLarge_Sandbags_CUP_B_USMC">
     <English>Sandbags - West</English>
+    <Spanish>Sacos terreros - oeste</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_ConstructionSuppliesLarge_Sandbags_CUP_O_TK">
     <English>Sandbags - East</English>
+    <Spanish>Sacos terreros - este</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_ConstructionSuppliesLarge_FillerSupplies">
     <English>Filler - Supplies</English>
+    <Spanish>Relleno - suministros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQLarge_FieldBarracks1_CUP_O_RU">
     <English>Field Barracks #1</English>
+    <Spanish>Barracones de campaña #1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQLarge_FieldBarracks2_CUP_O_RU">
     <English>Field Barracks #2</English>
+    <Spanish>Barracones de campaña #2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQLarge_FieldRadar_CUP_O_RU">
     <English>Field Radar</English>
+    <Spanish>Radar de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQLarge_FieldHQ_CUP_O_RU">
     <English>Field HQ</English>
+    <Spanish>HQ de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQLarge_FieldDepot_CUP_O_RU">
     <English>Field Depot</English>
+    <Spanish>Depósito de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQLarge_FieldBarracks1_CUP_B_CDF">
     <English>Field Barracks #1</English>
+    <Spanish>Barracones de campaña #1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQLarge_FieldBarracks2_CUP_B_CDF">
     <English>Field Barracks #2</English>
+    <Spanish>Barracones de campaña #2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQLarge_FieldRadar_CUP_B_CDF">
     <English>Field Radar</English>
+    <Spanish>Radar de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQLarge_FieldHQ_CUP_B_CDF">
     <English>Field HQ</English>
+    <Spanish>HQ de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQLarge_FieldDepot_CUP_B_CDF">
     <English>Field Depot</English>
+    <Spanish>Depósito de campaña</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_HQField_CUP_O_RU">
     <English>Basic HQ</English>
+    <Spanish>HQ básico</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_HQField_CUP_B_CDF">
     <English>Basic HQ</English>
+    <Spanish>HQ básico</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_HQTent_CUP_O_RU">
     <English>Fortified Tent HQ</English>
+    <Spanish>HQ en tienda fortificada</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_HQTent_CUP_B_CDF">
     <English>Fortified Tent HQ</English>
+    <Spanish>HQ en tienda fortificada</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ1_CUP_B_CDF">
     <English>Fortified HQ #B1</English>
+    <Spanish>HQ fortificado #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ2_CUP_B_CDF">
     <English>Fortified HQ #B2</English>
+    <Spanish>HQ fortificado #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ3_CUP_B_CDF">
     <English>Fortified HQ #B3</English>
+    <Spanish>HQ fortificado #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ4_CUP_B_CDF">
     <English>Fortified HQ #B4</English>
+    <Spanish>HQ fortificado #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ5_CUP_B_CDF">
     <English>Fortified HQ #B5</English>
+    <Spanish>HQ fortificado #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ6_CUP_B_CDF">
     <English>Fortified HQ #B6</English>
+    <Spanish>HQ fortificado #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ7_CUP_B_CDF">
     <English>Fortified HQ #B7</English>
+    <Spanish>HQ fortificado #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ8_CUP_B_CDF">
     <English>Fortified HQ #B8</English>
+    <Spanish>HQ fortificado #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ1_CUP_O_RU">
     <English>Fortified HQ #O1</English>
+    <Spanish>HQ fortificado #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ2_CUP_O_RU">
     <English>Fortified HQ #O2</English>
+    <Spanish>HQ fortificado #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ3_CUP_O_RU">
     <English>Fortified HQ #O3</English>
+    <Spanish>HQ fortificado #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ4_CUP_O_RU">
     <English>Fortified HQ #O4</English>
+    <Spanish>HQ fortificado #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ5_CUP_O_RU">
     <English>Fortified HQ #O5</English>
+    <Spanish>HQ fortificado #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ6_CUP_O_RU">
     <English>Fortified HQ #O6</English>
+    <Spanish>HQ fortificado #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ7_CUP_O_RU">
     <English>Fortified HQ #O7</English>
+    <Spanish>HQ fortificado #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FieldHQMedium_FortifiedFieldHQ8_CUP_O_RU">
     <English>Fortified HQ #O8</English>
+    <Spanish>HQ fortificado #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortLarge_MortarPit_CUP_O_RU">
     <English>Mortar Pit</English>
+    <Spanish>Foso de morteros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortLarge_MortarPit_CUP_B_CDF">
     <English>Mortar Pit</English>
+    <Spanish>Foso de morteros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleBunker_CUP_O_RU">
     <English>Vehicle Bunker</English>
+    <Spanish>Búnker para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerTowerHvy_CUP_O_RU">
     <English>Bunker Tower (Heavy)</English>
+    <Spanish>Torre búnker (pesada)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerTowerLit_CUP_O_RU">
     <English>Bunker Tower (Light)</English>
+    <Spanish>Torre búnker (ligera)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLargeMed_CUP_O_RU">
     <English>Bunker Large</English>
+    <Spanish>Búnker grande</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerTowerMed_CUP_O_RU">
     <English>Bunker Tower</English>
+    <Spanish>Torre búnker</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLargeLit_CUP_O_RU">
     <English>Bunker Large (Light)</English>
+    <Spanish>Búnker grande (ligero)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleBunker_CUP_B_CDF">
     <English>Vehicle Bunker</English>
+    <Spanish>Búnker para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerTowerHvy_CUP_B_CDF">
     <English>Bunker Tower (Heavy)</English>
+    <Spanish>Torre búnker (pesada)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerTowerLit_CUP_B_CDF">
     <English>Bunker Tower (Light)</English>
+    <Spanish>Torre búnker (ligera)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLargeMed_CUP_B_CDF">
     <English>Bunker Large</English>
+    <Spanish>Búnker grande</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerTowerMed_CUP_B_CDF">
     <English>Bunker Tower</English>
+    <Spanish>Torre búnker</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLargeLit_CUP_B_CDF">
     <English>Bunker Large (Light)</English>
+    <Spanish>Búnker grande (ligero)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge1_CUP_B_CDF">
     <English>Bunker (Large) #B1</English>
+    <Spanish>Búnker (grande) #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge2_CUP_B_CDF">
     <English>Bunker (Large) #B2</English>
+    <Spanish>Búnker (grande) #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge3_CUP_B_CDF">
     <English>Bunker (Large) #B3</English>
+    <Spanish>Búnker (grande) #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge4_CUP_B_CDF">
     <English>Bunker (Large) #B4</English>
+    <Spanish>Búnker (grande) #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge5_CUP_B_CDF">
     <English>Bunker (Large) #B5</English>
+    <Spanish>Búnker (grande) #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge6_CUP_B_CDF">
     <English>Bunker (Large) #B6</English>
+    <Spanish>Búnker (grande) #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge7_CUP_B_CDF">
     <English>Bunker (Large) #B7</English>
+    <Spanish>Búnker (grande) #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge8_CUP_B_CDF">
     <English>Bunker (Large) #B8</English>
+    <Spanish>Búnker (grande) #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge9_CUP_B_CDF">
     <English>Bunker (Large) #B9</English>
+    <Spanish>Búnker (grande) #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower1_CUP_B_CDF">
     <English>Cargo Tower #B1</English>
+    <Spanish>Torre de carga #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower2_CUP_B_CDF">
     <English>Cargo Tower #B2</English>
+    <Spanish>Torre de carga #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower3_CUP_B_CDF">
     <English>Cargo Tower #B3</English>
+    <Spanish>Torre de carga #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower4_CUP_B_CDF">
     <English>Cargo Tower #B4</English>
+    <Spanish>Torre de carga #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower5_CUP_B_CDF">
     <English>Cargo Tower #B5</English>
+    <Spanish>Torre de carga #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower6_CUP_B_CDF">
     <English>Cargo Tower #B6</English>
+    <Spanish>Torre de carga #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower7_CUP_B_CDF">
     <English>Cargo Tower #B7</English>
+    <Spanish>Torre de carga #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower8_CUP_B_CDF">
     <English>Cargo Tower #B8</English>
+    <Spanish>Torre de carga #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower9_CUP_B_CDF">
     <English>Cargo Tower #B9</English>
+    <Spanish>Torre de carga #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleWatchtower_CUP_B_CDF">
     <English>Vehicle Watchtower</English>
+    <Spanish>Torre de vigilancia para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleCargoPost_CUP_B_CDF">
     <English>Vehicle Cargo Post</English>
+    <Spanish>Puesto de carga para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleLargeBunker_CUP_B_CDF">
     <English>Vehicle Bunker (Large)</English>
+    <Spanish>Búnker para vehículos (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleTower_CUP_B_CDF">
     <English>Vehicle Tower</English>
+    <Spanish>Torre para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleSmallBunker_CUP_B_CDF">
     <English>Vehicle Bunker (Small)</English>
+    <Spanish>Búnker para vehículos (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge1_CUP_O_RU">
     <English>Bunker (Large) #O1</English>
+    <Spanish>Búnker (grande) #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge2_CUP_O_RU">
     <English>Bunker (Large) #O2</English>
+    <Spanish>Búnker (grande) #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge3_CUP_O_RU">
     <English>Bunker (Large) #O3</English>
+    <Spanish>Búnker (grande) #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge4_CUP_O_RU">
     <English>Bunker (Large) #O4</English>
+    <Spanish>Búnker (grande) #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge5_CUP_O_RU">
     <English>Bunker (Large) #O5</English>
+    <Spanish>Búnker (grande) #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge6_CUP_O_RU">
     <English>Bunker (Large) #O6</English>
+    <Spanish>Búnker (grande) #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge7_CUP_O_RU">
     <English>Bunker (Large) #O7</English>
+    <Spanish>Búnker (grande) #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge8_CUP_O_RU">
     <English>Bunker (Large) #O8</English>
+    <Spanish>Búnker (grande) #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_BunkerLarge9_CUP_O_RU">
     <English>Bunker (Large) #O9</English>
+    <Spanish>Búnker (grande) #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower1_CUP_O_RU">
     <English>Cargo Tower #O1</English>
+    <Spanish>Torre de carga #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower2_CUP_O_RU">
     <English>Cargo Tower #O2</English>
+    <Spanish>Torre de carga #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower3_CUP_O_RU">
     <English>Cargo Tower #O3</English>
+    <Spanish>Torre de carga #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower4_CUP_O_RU">
     <English>Cargo Tower #O4</English>
+    <Spanish>Torre de carga #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower5_CUP_O_RU">
     <English>Cargo Tower #O5</English>
+    <Spanish>Torre de carga #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower6_CUP_O_RU">
     <English>Cargo Tower #O6</English>
+    <Spanish>Torre de carga #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower7_CUP_O_RU">
     <English>Cargo Tower #O7</English>
+    <Spanish>Torre de carga #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower8_CUP_O_RU">
     <English>Cargo Tower #O8</English>
+    <Spanish>Torre de carga #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_CargoTower9_CUP_O_RU">
     <English>Cargo Tower #O9</English>
+    <Spanish>Torre de carga #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleWatchtower_CUP_O_RU">
     <English>Vehicle Watchtower</English>
+    <Spanish>Torre de vigilancia para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleCargoPost_CUP_O_RU">
     <English>Vehicle Cargo Post</English>
+    <Spanish>Puesto de carga para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleLargeBunker_CUP_O_RU">
     <English>Vehicle Bunker (Large)</English>
+    <Spanish>Búnker para vehículos (grande)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleTower_CUP_O_RU">
     <English>Vehicle Tower</English>
+    <Spanish>Torre para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortMedium_VehicleSmallBunker_CUP_O_RU">
     <English>Vehicle Bunker (Small)</English>
+    <Spanish>Búnker para vehículos (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall1_CUP_B_CDF">
     <English>Bunker (Small) #B1</English>
+    <Spanish>Búnker (pequeño) #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall2_CUP_B_CDF">
     <English>Bunker (Small) #B2</English>
+    <Spanish>Búnker (pequeño) #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall3_CUP_B_CDF">
     <English>Bunker (Small) #B3</English>
+    <Spanish>Búnker (pequeño) #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall4_CUP_B_CDF">
     <English>Bunker (Small) #B4</English>
+    <Spanish>Búnker (pequeño) #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall5_CUP_B_CDF">
     <English>Bunker (Small) #B5</English>
+    <Spanish>Búnker (pequeño) #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall6_CUP_B_CDF">
     <English>Bunker (Small) #B6</English>
+    <Spanish>Búnker (pequeño) #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall7_CUP_B_CDF">
     <English>Bunker (Small) #B7</English>
+    <Spanish>Búnker (pequeño) #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall8_CUP_B_CDF">
     <English>Bunker (Small) #B8</English>
+    <Spanish>Búnker (pequeño) #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall9_CUP_B_CDF">
     <English>Bunker (Small) #B9</English>
+    <Spanish>Búnker (pequeño) #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost1_CUP_B_CDF">
     <English>Cargo Post #B1</English>
+    <Spanish>Puesto de carga #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost2_CUP_B_CDF">
     <English>Cargo Post #B2</English>
+    <Spanish>Puesto de carga #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost3_CUP_B_CDF">
     <English>Cargo Post #B3</English>
+    <Spanish>Puesto de carga #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost4_CUP_B_CDF">
     <English>Cargo Post #B4</English>
+    <Spanish>Puesto de carga #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost5_CUP_B_CDF">
     <English>Cargo Post #B5</English>
+    <Spanish>Puesto de carga #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost6_CUP_B_CDF">
     <English>Cargo Post #B6</English>
+    <Spanish>Puesto de carga #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost7_CUP_B_CDF">
     <English>Cargo Post #B7</English>
+    <Spanish>Puesto de carga #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost8_CUP_B_CDF">
     <English>Cargo Post #B8</English>
+    <Spanish>Puesto de carga #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost9_CUP_B_CDF">
     <English>Cargo Post #B9</English>
+    <Spanish>Puesto de carga #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower1_CUP_B_CDF">
     <English>Watchtower #B1</English>
+    <Spanish>Torre de vigilancia #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower2_CUP_B_CDF">
     <English>Watchtower #B2</English>
+    <Spanish>Torre de vigilancia #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower3_CUP_B_CDF">
     <English>Watchtower #B3</English>
+    <Spanish>Torre de vigilancia #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower4_CUP_B_CDF">
     <English>Watchtower #B4</English>
+    <Spanish>Torre de vigilancia #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower5_CUP_B_CDF">
     <English>Watchtower #B5</English>
+    <Spanish>Torre de vigilancia #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower6_CUP_B_CDF">
     <English>Watchtower #B6</English>
+    <Spanish>Torre de vigilancia #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower7_CUP_B_CDF">
     <English>Watchtower #B7</English>
+    <Spanish>Torre de vigilancia #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower8_CUP_B_CDF">
     <English>Watchtower #B8</English>
+    <Spanish>Torre de vigilancia #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower9_CUP_B_CDF">
     <English>Watchtower #B9</English>
+    <Spanish>Torre de vigilancia #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower1_CUP_B_CDF">
     <English>Bunker (Tower) #B1</English>
+    <Spanish>Búnker (torre) #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower2_CUP_B_CDF">
     <English>Bunker (Tower) #B2</English>
+    <Spanish>Búnker (torre) #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower3_CUP_B_CDF">
     <English>Bunker (Tower) #B3</English>
+    <Spanish>Búnker (torre) #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower4_CUP_B_CDF">
     <English>Bunker (Tower) #B4</English>
+    <Spanish>Búnker (torre) #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower5_CUP_B_CDF">
     <English>Bunker (Tower) #B5</English>
+    <Spanish>Búnker (torre) #B5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower6_CUP_B_CDF">
     <English>Bunker (Tower) #B6</English>
+    <Spanish>Búnker (torre) #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower7_CUP_B_CDF">
     <English>Bunker (Tower) #B7</English>
+    <Spanish>Búnker (torre) #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower8_CUP_B_CDF">
     <English>Bunker (Tower) #B8</English>
+    <Spanish>Búnker (torre) #B8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower9_CUP_B_CDF">
     <English>Bunker (Tower) #B9</English>
+    <Spanish>Búnker (torre) #B9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall1_CUP_O_RU">
     <English>Bunker (Small) #O1</English>
+    <Spanish>Búnker (pequeño) #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall2_CUP_O_RU">
     <English>Bunker (Small) #O2</English>
+    <Spanish>Búnker (pequeño) #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall3_CUP_O_RU">
     <English>Bunker (Small) #O3</English>
+    <Spanish>Búnker (pequeño) #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall4_CUP_O_RU">
     <English>Bunker (Small) #O4</English>
+    <Spanish>Búnker (pequeño) #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall5_CUP_O_RU">
     <English>Bunker (Small) #O5</English>
+    <Spanish>Búnker (pequeño) #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall6_CUP_O_RU">
     <English>Bunker (Small) #O6</English>
+    <Spanish>Búnker (pequeño) #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall7_CUP_O_RU">
     <English>Bunker (Small) #O7</English>
+    <Spanish>Búnker (pequeño) #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall8_CUP_O_RU">
     <English>Bunker (Small) #O8</English>
+    <Spanish>Búnker (pequeño) #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerSmall9_CUP_O_RU">
     <English>Bunker (Small) #O9</English>
+    <Spanish>Búnker (pequeño) #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost1_CUP_O_RU">
     <English>Cargo Post #O1</English>
+    <Spanish>Puesto de carga #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost2_CUP_O_RU">
     <English>Cargo Post #O2</English>
+    <Spanish>Puesto de carga #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost3_CUP_O_RU">
     <English>Cargo Post #O3</English>
+    <Spanish>Puesto de carga #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost4_CUP_O_RU">
     <English>Cargo Post #O4</English>
+    <Spanish>Puesto de carga #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost5_CUP_O_RU">
     <English>Cargo Post #O5</English>
+    <Spanish>Puesto de carga #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost6_CUP_O_RU">
     <English>Cargo Post #O6</English>
+    <Spanish>Puesto de carga #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost7_CUP_O_RU">
     <English>Cargo Post #O7</English>
+    <Spanish>Puesto de carga #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost8_CUP_O_RU">
     <English>Cargo Post #O8</English>
+    <Spanish>Puesto de carga #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_CargoPost9_CUP_O_RU">
     <English>Cargo Post #O9</English>
+    <Spanish>Puesto de carga #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower1_CUP_O_RU">
     <English>Watchtower #O1</English>
+    <Spanish>Torre de vigilancia #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower2_CUP_O_RU">
     <English>Watchtower #O2</English>
+    <Spanish>Torre de vigilancia #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower3_CUP_O_RU">
     <English>Watchtower #O3</English>
+    <Spanish>Torre de vigilancia #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower4_CUP_O_RU">
     <English>Watchtower #O4</English>
+    <Spanish>Torre de vigilancia #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower5_CUP_O_RU">
     <English>Watchtower #O5</English>
+    <Spanish>Torre de vigilancia #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower6_CUP_O_RU">
     <English>Watchtower #O6</English>
+    <Spanish>Torre de vigilancia #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower7_CUP_O_RU">
     <English>Watchtower #O7</English>
+    <Spanish>Torre de vigilancia #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower8_CUP_O_RU">
     <English>Watchtower #O8</English>
+    <Spanish>Torre de vigilancia #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Watchtower9_CUP_O_RU">
     <English>Watchtower #O9</English>
+    <Spanish>Torre de vigilancia #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower1_CUP_O_RU">
     <English>Bunker (Tower) #O1</English>
+    <Spanish>Búnker (torre) #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower2_CUP_O_RU">
     <English>Bunker (Tower) #O2</English>
+    <Spanish>Búnker (torre) #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower3_CUP_O_RU">
     <English>Bunker (Tower) #O3</English>
+    <Spanish>Búnker (torre) #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower4_CUP_O_RU">
     <English>Bunker (Tower) #O4</English>
+    <Spanish>Búnker (torre) #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower5_CUP_O_RU">
     <English>Bunker (Tower) #O5</English>
+    <Spanish>Búnker (torre) #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower6_CUP_O_RU">
     <English>Bunker (Tower) #O6</English>
+    <Spanish>Búnker (torre) #O6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower7_CUP_O_RU">
     <English>Bunker (Tower) #O7</English>
+    <Spanish>Búnker (torre) #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower8_CUP_O_RU">
     <English>Bunker (Tower) #O8</English>
+    <Spanish>Búnker (torre) #O8</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_BunkerTower9_CUP_O_RU">
     <English>Bunker (Tower) #O9</English>
+    <Spanish>Búnker (torre) #O9</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_NestHBarrier_CUP_O_RU">
     <English>Nest H-Barrier</English>
+    <Spanish>Nido de H-Barrier</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Sandbags_CUP_O_RU">
     <English>Sandbags</English>
+    <Spanish>Sacos terreros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_SandbagNetHvy_CUP_O_RU">
     <English>Sandbag Net (Heavy)</English>
+    <Spanish>Sacos terreros con red (pesados)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_NestMed_CUP_O_RU">
     <English>Nest</English>
+    <Spanish>Nido</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_LightNet1_CUP_O_RU">
     <English>Net #O1</English>
+    <Spanish>Red de camuflaje #O1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_LightNet2_CUP_O_RU">
     <English>Net #O2</English>
+    <Spanish>Red de camuflaje #O2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_LightNet3_CUP_O_RU">
     <English>Net #O3</English>
+    <Spanish>Red de camuflaje #O3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_LightNet4_CUP_O_RU">
     <English>Net #O4</English>
+    <Spanish>Red de camuflaje #O4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_NestSandbag_CUP_O_RU">
     <English>Net #O5</English>
+    <Spanish>Red de camuflaje #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_SandbagNetLit_CUP_O_RU">
     <English>Net #06</English>
+    <Spanish>Red de camuflaje #06</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_SandbagNet_CUP_O_RU">
     <English>Net #O7</English>
+    <Spanish>Red de camuflaje #O7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_NetCamo_CUP_O_RU">
     <English>Vehicle Net</English>
+    <Spanish>Red para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_NestSandbag_CUP_B_CDF">
     <English>Net #O5</English>
+    <Spanish>Red de camuflaje #O5</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_NestHBarrier_CUP_B_CDF">
     <English>Nest H-Barrier</English>
+    <Spanish>Nido de H-Barrier</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_Sandbags_CUP_B_CDF">
     <English>Sandbags</English>
+    <Spanish>Sacos terreros</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_SandbagNet_CUP_B_CDF">
     <English>Net #B7</English>
+    <Spanish>Red de camuflaje #B7</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_SandbagNetHvy_CUP_B_CDF">
     <English>Sandbag Net (Heavy)</English>
+    <Spanish>Sacos terreros con red (pesados)</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_NestMed_CUP_B_CDF">
     <English>Nest</English>
+    <Spanish>Nido</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_SandbagNetLit_CUP_B_CDF">
     <English>Net #B6</English>
+    <Spanish>Red de camuflaje #B6</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_LightNet1_CUP_B_CDF">
     <English>Net #B1</English>
+    <Spanish>Red de camuflaje #B1</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_LightNet2_CUP_B_CDF">
     <English>Net #B2</English>
+    <Spanish>Red de camuflaje #B2</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_LightNet3_CUP_B_CDF">
     <English>Net #B3</English>
+    <Spanish>Red de camuflaje #B3</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_LightNet4_CUP_B_CDF">
     <English>Net #B4</English>
+    <Spanish>Red de camuflaje #B4</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FortSmall_NetCamo_CUP_B_CDF">
     <English>Vehicle Net</English>
+    <Spanish>Red para vehículos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HeliportsLarge_AirFactory_CUP_O_RU">
     <English>Air Factory</English>
+    <Spanish>Fábrica aeronáutica</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HeliportsLarge_AirFactory_CUP_B_CDF">
     <English>Air Factory</English>
+    <Spanish>Fábrica aeronáutica</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HeliportsLarge_LandingZone_CUP_O_RU">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HeliportsLarge_LandingZone_CUP_B_CDF">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HeliportsMedium_LandingZone_CUP_O_RU">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HeliportsMedium_LandingZone_CUP_B_CDF">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HeliportsSmall_LandingZone_CUP_O_RU">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HeliportsSmall_LandingZone_CUP_B_CDF">
     <English>Landing Zone</English>
+    <Spanish>Zona de aterrizaje</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HQLarge_Headquarters_CUP_B_CDF">
     <English>Headquarters</English>
+    <Spanish>Cuartel general</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HQLarge_Headquarters_CUP_O_RU">
     <English>Headquarters</English>
+    <Spanish>Cuartel general</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HQMedium_HQCargo_CUP_O_RU">
     <English>HQ Cargo Post</English>
+    <Spanish>Puesto de carga de HQ</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HQMedium_HQCargo_CUP_B_CDF">
     <English>HQ Cargo Post</English>
+    <Spanish>Puesto de carga de HQ</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HQSmall_HQUnfoldedBTR_CUP_O_RU">
     <English>Mobile HQ - BTR</English>
+    <Spanish>HQ móvil - BTR</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_HQSmall_HQUnfoldedLAV_CUP_B_CDF">
     <English>Mobile HQ - LAV</English>
+    <Spanish>HQ móvil - LAV</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_MedicalLarge_Hospital_CUP_O_RU">
     <English>Hospital</English>
+    <Spanish>Hospital</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_MedicalLarge_Hospital_CUP_B_CDF">
     <English>Hospital</English>
+    <Spanish>Hospital</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_PowerSmall_Generator_CUP_O_RU">
     <English>Generator</English>
+    <Spanish>Generador</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_PowerSmall_Generator_CUP_B_CDF">
     <English>Generator</English>
+    <Spanish>Generador</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_SuppliesMedium_AmmoDump_CUP_O_RU">
     <English>Ammo Dump</English>
+    <Spanish>Polvorín</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_SuppliesMedium_AmmoDump_CUP_B_CDF">
     <English>Ammo Dump</English>
+    <Spanish>Polvorín</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_SuppliesSmall_Cache_CUP_O_RU">
     <English>Cache</English>
+    <Spanish>Alijo</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_SuppliesSmall_Cache_CUP_B_CDF">
     <English>Cache</English>
+    <Spanish>Alijo</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_SupportsLarge_Barracks_CUP_O_RU">
     <English>Barracks</English>
+    <Spanish>Barracones</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_SupportsLarge_Barracks_CUP_B_CDF">
     <English>Barracks</English>
+    <Spanish>Barracones</Spanish>
 </Key>
 	<Key ID="STR_ZECCUP_MilitaryWoodland_SupportsMedium_ServiceArea_CUP_O_RU">
     <English>Service Area</English>
+    <Spanish>Zona de servicio</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_SupportsMedium_ServiceArea_CUP_B_CDF">
     <English>Service Area</English>
+    <Spanish>Zona de servicio</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_SupportsMedium_Barracks_CUP_O_RU">
     <English>Barracks</English>
+    <Spanish>Barracones</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_SupportsMedium_Barracks_CUP_B_CDF">
     <English>Barracks</English>
+    <Spanish>Barracones</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_SupportsSmall_LivingQuarters_CUP_O_RU">
     <English>Living Quarters</English>
+    <Spanish>Alojamientos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_SupportsSmall_LivingQuarters_CUP_B_CDF">
     <English>Living Quarters</English>
+    <Spanish>Alojamientos</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FuelMedium_FuelDump_CUP_O_RU">
     <English>Fuel Dump</English>
+    <Spanish>Depósito de combustible</Spanish>
 </Key>
 <Key ID="STR_ZECCUP_MilitaryWoodland_FuelMedium_FuelDump_CUP_B_CDF">
     <English>Fuel Dump</English>
+    <Spanish>Depósito de combustible</Spanish>
 </Key>
 </Container></Package></Project>

--- a/optional/composition_spe/stringtable.xml
+++ b/optional/composition_spe/stringtable.xml
@@ -4,98 +4,130 @@
 <Container name="STR_DN">
 <Key ID="STR_ALIVE_COMP_SPE_MilitaryBocage">
     <English>Military (Bocage)</English>
+    <Spanish>Militar (bocage)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_GuerrillaBocage">
     <English>Guerrilla (Bocage)</English>
+    <Spanish>Guerrilla (bocage)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_AirportsSmall">
     <English>Airports (Small)</English>
+    <Spanish>Aeropuertos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_AirportsMedium">
     <English>Airports (Medium)</English>
+    <Spanish>Aeropuertos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_AirportsLarge">
     <English>Airports (Large)</English>
+    <Spanish>Aeropuertos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CheckpointsBarricadesSmall">
     <English>Checkpoints &amp; Barricades (Small)</English>
+    <Spanish>Controles y barricadas (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CheckpointsBarricadesMedium">
     <English>Checkpoints &amp; Barricades (Medium)</English>
+    <Spanish>Controles y barricadas (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CheckpointsBarricadesLarge">
     <English>Checkpoints &amp; Barricades (Large)</English>
+    <Spanish>Controles y barricadas (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_HqSmall">
     <English>HeadQuarters (Small)</English>
+    <Spanish>Cuartel general (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_HqMedium">
     <English>HeadQuarters (Medium)</English>
+    <Spanish>Cuartel general (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_HqLarge">
     <English>HeadQuarters (Large)</English>
+    <Spanish>Cuartel general (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_SupportsSmall">
     <English>Support (Small)</English>
+    <Spanish>Apoyo (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_SupportsMedium">
     <English>Support (Medium)</English>
+    <Spanish>Apoyo (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_SupportsLarge">
     <English>Support (Large)</English>
+    <Spanish>Apoyo (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CrashsitesSmall">
     <English>Crashsites (Small)</English>
+    <Spanish>Zonas de accidente (pequeñas)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CrashsitesMedium">
     <English>Crashsites (Medium)</English>
+    <Spanish>Zonas de accidente (medianas)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CrashsitesLarge">
     <English>Crashsites (Large)</English>
+    <Spanish>Zonas de accidente (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_FortSmall">
     <English>Fortifications (Small)</English>
+    <Spanish>Fortificaciones (pequeñas)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_FortMedium">
     <English>Fortifications (Medium)</English>
+    <Spanish>Fortificaciones (medianas)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_FortLarge">
     <English>Fortifications (Large)</English>
+    <Spanish>Fortificaciones (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CampsLarge">
     <English>Camps (Large)</English>
+    <Spanish>Campamentos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CampsMedium">
     <English>Camps (Medium)</English>
+    <Spanish>Campamentos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CampsSmall">
     <English>Camps (Small)</English>
+    <Spanish>Campamentos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CommunicationsLarge">
     <English>Communications (Large)</English>
+    <Spanish>Comunicaciones (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CommunicationsMedium">
     <English>Communications (Medium)</English>
+    <Spanish>Comunicaciones (medianas)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_CommunicationsSmall">
     <English>Communications (Small)</English>
+    <Spanish>Comunicaciones (pequeñas)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_FuelLarge">
     <English>Fuel (Large)</English>
+    <Spanish>Combustible (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_FuelMedium">
     <English>Fuel (Medium)</English>
+    <Spanish>Combustible (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_FuelSmall">
     <English>Fuel (Small)</English>
+    <Spanish>Combustible (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_FieldHQLarge">
     <English>Field HQ (Large)</English>
+    <Spanish>HQ de campaña (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_FieldHQMedium">
     <English>Field HQ (Medium)</English>
+    <Spanish>HQ de campaña (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_SPE_FieldHQSmall">
     <English>Field HQ (Small)</English>
+    <Spanish>HQ de campaña (pequeño)</Spanish>
 </Key>
 </Container></Package></Project>

--- a/optional/composition_vn/stringtable.xml
+++ b/optional/composition_vn/stringtable.xml
@@ -4,212 +4,282 @@
 <Container name="STR_DN">
 <Key ID="STR_ALIVE_COMP_VN_MilitaryJungle">
     <English>Military (Jungle)</English>
+    <Spanish>Militar (jungla)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_AirportsLarge">
     <English>Airports (Large)</English>
+    <Spanish>Aeropuertos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_AirportsMedium">
     <English>Airports (Medium)</English>
+    <Spanish>Aeropuertos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_AirportsSmall">
     <English>Airports (Small)</English>
+    <Spanish>Aeropuertos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CampsLarge">
     <English>Camps (Large)</English>
+    <Spanish>Campamentos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CampsMedium">
     <English>Camps (Medium)</English>
+    <Spanish>Campamentos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CampsSmall">
     <English>Camps (Small)</English>
+    <Spanish>Campamentos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CheckpointsBarricadesLarge">
     <English>Checkpoints &amp; Barricades (Large)</English>
+    <Spanish>Controles y barricadas (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CheckpointsBarricadesMedium">
     <English>Checkpoints &amp; Barricades (Medium)</English>
+    <Spanish>Controles y barricadas (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CheckpointsBarricadesSmall">
     <English>Checkpoints &amp; Barricades (Small)</English>
+    <Spanish>Controles y barricadas (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CommunicationsLarge">
     <English>Communications (Large)</English>
+    <Spanish>Comunicaciones (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CommunicationsMedium">
     <English>Communications (Medium)</English>
+    <Spanish>Comunicaciones (medianas)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CommunicationsSmall">
     <English>Communications (Small)</English>
+    <Spanish>Comunicaciones (pequeñas)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_ConstructionLarge">
     <English>Construction (Large)</English>
+    <Spanish>Construcción (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_ConstructionMedium">
     <English>Construction (Medium)</English>
+    <Spanish>Construcción (mediana)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_ConstructionSmall">
     <English>Construction (Small)</English>
+    <Spanish>Construcción (pequeña)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_ConstructionSuppliesLarge">
     <English>Construction Supplies (Large)</English>
+    <Spanish>Suministros de construcción (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_ConstructionSuppliesMedium">
     <English>Construction Supplies (Medium)</English>
+    <Spanish>Suministros de construcción (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_ConstructionSuppliesSmall">
     <English>Construction Supplies (Small)</English>
+    <Spanish>Suministros de construcción (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CrashsitesLarge">
     <English>Crash Sites (Large)</English>
+    <Spanish>Zonas de accidente (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CrashsitesMedium">
     <English>Crash Sites (Medium)</English>
+    <Spanish>Zonas de accidente (medianas)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_CrashsitesSmall">
     <English>Crash Sites (Small)</English>
+    <Spanish>Zonas de accidente (pequeñas)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_FieldHQLarge">
     <English>Field HQ (Large)</English>
+    <Spanish>HQ de campaña (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_FieldHQMedium">
     <English>Field HQ (Medium)</English>
+    <Spanish>HQ de campaña (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_FieldHQSmall">
     <English>Field HQ (Small)</English>
+    <Spanish>HQ de campaña (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_FortLarge">
     <English>Fortifications &amp; Bunkers (Large)</English>
+    <Spanish>Fortificaciones y búnkeres (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_FortMedium">
     <English>Fortifications &amp; Bunkers (Medium)</English>
+    <Spanish>Fortificaciones y búnkeres (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_FortSmall">
     <English>Fortifications &amp; Bunkers (Small)</English>
+    <Spanish>Fortificaciones y búnkeres (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_FuelLarge">
     <English>Fuel (Large)</English>
+    <Spanish>Combustible (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_FuelMedium">
     <English>Fuel (Medium)</English>
+    <Spanish>Combustible (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_FuelSmall">
     <English>Fuel (Small)</English>
+    <Spanish>Combustible (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_GeneralLarge">
     <English>General (Large)</English>
+    <Spanish>General (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_GeneralMedium">
     <English>General (Medium)</English>
+    <Spanish>General (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_GeneralSmall">
     <English>General (Small)</English>
+    <Spanish>General (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_HeliportsLarge">
     <English>Heliports (Large)</English>
+    <Spanish>Helipuertos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_HeliportsMedium">
     <English>Heliports (Medium)</English>
+    <Spanish>Helipuertos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_HeliportsSmall">
     <English>Heliports (Small)</English>
+    <Spanish>Helipuertos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_HqLarge">
     <English>HQ (Large)</English>
+    <Spanish>HQ (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_HqMedium">
     <English>HQ (Medium)</English>
+    <Spanish>HQ (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_HqSmall">
     <English>HQ (Small)</English>
+    <Spanish>HQ (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_IndustrialLarge">
     <English>Industrial (Large)</English>
+    <Spanish>Industrial (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_IndustrialMedium">
     <English>Industrial (Medium)</English>
+    <Spanish>Industrial (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_IndustrialSmall">
     <English>Industrial (Small)</English>
+    <Spanish>Industrial (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_MarineLarge">
     <English>Marine (Large)</English>
+    <Spanish>Marítimo (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_MarineMedium">
     <English>Marine (Medium)</English>
+    <Spanish>Marítimo (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_MarineSmall">
     <English>Marine (Small)</English>
+    <Spanish>Marítimo (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_MedicalLarge">
     <English>Medical (Large)</English>
+    <Spanish>Sanitario (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_MedicalMedium">
     <English>Medical (Medium)</English>
+    <Spanish>Sanitario (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_MedicalSmall">
     <English>Medical (Small)</English>
+    <Spanish>Sanitario (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_MiningOilLarge">
     <English>Mining, Refining &amp; Oil (Large)</English>
+    <Spanish>Minería, refinado y petróleo (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_MiningOilMedium">
     <English>Mining, Refining &amp; Oil (Medium)</English>
+    <Spanish>Minería, refinado y petróleo (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_MiningOilSmall">
     <English>Mining, Refining &amp; Oil (Small)</English>
+    <Spanish>Minería, refinado y petróleo (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_OutpostsLarge">
     <English>Outposts (Large)</English>
+    <Spanish>Puestos avanzados (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_OutpostsMedium">
     <English>Outposts (Medium)</English>
+    <Spanish>Puestos avanzados (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_OutpostsSmall">
     <English>Outposts (Small)</English>
+    <Spanish>Puestos avanzados (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_PowerLarge">
     <English>Power (Large)</English>
+    <Spanish>Energía (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_PowerMedium">
     <English>Power (Medium)</English>
+    <Spanish>Energía (mediana)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_PowerSmall">
     <English>Power (Small)</English>
+    <Spanish>Energía (pequeña)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_RailLarge">
     <English>Rail (Large)</English>
+    <Spanish>Ferrocarril (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_RailMedium">
     <English>Rail (Medium)</English>
+    <Spanish>Ferrocarril (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_RailSmall">
     <English>Rail (Small)</English>
+    <Spanish>Ferrocarril (pequeño)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_SettlementsLarge">
     <English>Settlements (Large)</English>
+    <Spanish>Asentamientos (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_SettlementsMedium">
     <English>Settlements (Medium)</English>
+    <Spanish>Asentamientos (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_SettlementsSmall">
     <English>Settlements (Small)</English>
+    <Spanish>Asentamientos (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_SuppliesLarge">
     <English>Supplies &amp; Storage (Large)</English>
+    <Spanish>Suministros y almacenamiento (grandes)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_SuppliesMedium">
     <English>Supplies &amp; Storage (Medium)</English>
+    <Spanish>Suministros y almacenamiento (medianos)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_SuppliesSmall">
     <English>Supplies &amp; Storage (Small)</English>
+    <Spanish>Suministros y almacenamiento (pequeños)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_SupportsLarge">
     <English>Support (Large)</English>
+    <Spanish>Apoyo (grande)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_SupportsMedium">
     <English>Support (Medium)</English>
+    <Spanish>Apoyo (mediano)</Spanish>
 </Key>
 <Key ID="STR_ALIVE_COMP_VN_SupportsSmall">
     <English>Support (Small)</English>
+    <Spanish>Apoyo (pequeño)</Spanish>
 </Key>
 </Container></Package></Project>


### PR DESCRIPTION
Fills in every `stringtable.xml` key that had no `<Spanish>` element — 2780 keys across 42 files, taking Spanish from 38.7% to full coverage of all 4534 keys.

Strings only. No config, no SQF, no behaviour change.

### What was translated

- **725 interface keys** — module names and descriptions, Eden attributes, tooltips, error messages, and the MACC radio traffic in `mil_ato`.
- **2055 composition labels** — `composition_a3`, and the `composition_cup` / `composition_vn` / `composition_spe` optionals.

### Approach

Terminology follows what the existing Spanish entries already used, so a module reads the same way whichever part of it a player is looking at.

Left in English on purpose, because these are the names people identify the things by: `H-Barrier`, `HQ`, `LZ`, and the `[BLU]` / `[OPF]` / `[IND]` side tags.

Composition labels were rebuilt from a base noun phrase plus qualifiers rather than translated one string at a time, so a qualifier agrees with its base in gender and number instead of defaulting to masculine singular — "Torre de carga (marrón)", "Aeropuertos (pequeños)", "Plataforma de helicóptero (cuadrada)". Coordinated phrases of mixed gender take masculine plural, per the rule.

Radio messages keep their `%N` placeholders in the original order.

### Checks

- All 67 stringtables still parse as well-formed XML and are valid UTF-8.
- `python utils/config_validator.py` passes — 773 files, 0 errors.
- Every added `<Spanish>` carries the same set of `%N` placeholders as its `<English>` sibling.
- The diff is 2780 insertions and 0 deletions: nothing existing was touched, one `<Spanish>` added per key at the indentation of the neighbouring `<English>`.

### Worth knowing before merging

This is machine-translated and has not been reviewed by a native speaker. Happy to add an `<!-- AI-translated; native-speaker review welcome -->` comment alongside these entries, matching what some files already carry for other languages, if you would prefer that flag on them.

Also happy to split this per addon if one PR of this size is awkward to review.
